### PR TITLE
docs: sync changelog and fix stale count comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `SECURITY.md`: security policy with private reporting instructions, scope,
+  and response expectations.
+- `.github/dependabot.yml`: weekly grouped update PRs for GitHub Actions and
+  npm dependencies, labeled and assigned automatically.
+
+### Changed
+
+- CI workflow now declares a least-privilege `permissions: contents: read`
+  block.
+- Repository setting `delete_branch_on_merge` enabled — merged PR branches
+  are deleted automatically.
+
+### Fixed
+
+- Stale "217 role files" comment in `server.js` (catalog is 216 since the
+  v1.3.0 duplicate-role removal); comment is now count-free so it cannot
+  drift again (#40).
+
 ## [1.3.0] - 2026-07-06
 
 ### Added

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const VENDOR_DIR = path.join(ROOT, 'vendor');
 // Cache getRoles() results, invalidated whenever any directory or file under
 // Roles/ has a newer mtime than what was last seen (covers edits, adds, and
 // removes -- a deletion changes its parent directory's mtime). Avoids a full
-// readdir+readFile+parse pass of all 217 role files on every /api/roles hit.
+// readdir+readFile+parse pass of every role file on every /api/roles hit.
 let rolesCache = { signature: -1, domains: null };
 
 function rolesTreeSignature() {


### PR DESCRIPTION
## What changed
- `CHANGELOG.md`: backfilled the empty `[Unreleased]` section with the three post-v1.3.0 hardening commits (SECURITY.md, Dependabot config, least-privilege CI permissions) plus the newly enabled `delete_branch_on_merge` repo setting.
- `server.js`: cache comment said "all 217 role files" (catalog is 216); now count-free so it cannot drift again.

## Verification
- `npm test`: 19/19 pass.
- `git grep -nE '21[78]'` on code files: no remaining count references outside historical CHANGELOG entries.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)