### PR TITLE
fix: resolve all 43 role files failing validation (closes #7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '18'
-      # Non-blocking: 43 pre-existing role files fail validation (tracked in
-      # issue #7). Flip continue-on-error to false once that backfill lands.
       - run: npm run validate
-        continue-on-error: true
       - run: npm run check-counts
 
   markdownlint:

--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -70,7 +70,7 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 - AWS Certified Cloud Practitioner, AZ-900, or Google Cloud Digital Leader preferred
 - Demonstrated hands-on experience with at least one major cloud cost management or FinOps platform
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/FinOps/cloud_cost_optimization_standards.md
+++ b/Roles/FinOps/cloud_cost_optimization_standards.md
@@ -1,5 +1,9 @@
 # Cloud Cost Optimization Standards
 
+| Field | Value |
+|---|---|
+| **Domain** | FinOps |
+
 ## Overview
 
 This document outlines the standards and best practices for cloud cost optimization across our organization. These standards provide a framework for consistent, efficient management of cloud resources to maximize value while controlling costs.

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -71,7 +71,7 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 - Google Data Analytics Certificate or equivalent data analytics qualification advantageous
 - Demonstrated experience delivering financial or cost reporting outputs to senior business stakeholders
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -71,7 +71,7 @@ The FinOps Architect designs and implements cloud financial management strategie
 - Experience with cloud cost management tools (e.g., CloudHealth, Cloudability, AWS Cost Explorer)
 - Prior experience in architecture or senior technical leadership roles
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -71,7 +71,7 @@ The FinOps Engineer implements and maintains cloud cost monitoring, reporting, a
 - Knowledge of FinOps principles and practices
 - Cloud platform certifications preferred
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -70,7 +70,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 - Knowledge of cloud cost management tools and platforms
 - Background in financial analysis or IT financial management
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|
@@ -90,6 +90,18 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 - Self-service financial tools for engineering teams
 - Financial governance and policies
 - Stakeholder engagement and education
+
+## Key Technologies
+
+- Cloud-native cost management consoles (AWS Cost Explorer, Azure Cost Management, GCP Billing)
+- FinOps platforms (Apptio Cloudability, VMware Aria Cost / CloudHealth)
+- Chargeback, showback, and cost-allocation tooling
+- Tagging governance and policy enforcement tools
+- Budgeting and forecasting platforms
+- Commitment management tooling (Reserved Instances, Savings Plans, Committed Use Discounts)
+- BI and reporting platforms (Power BI, Tableau) for unit-economics dashboards
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Collaboration and stakeholder reporting tools
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -71,7 +71,7 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 - Experience leading technical projects and initiatives
 - Demonstrated expertise in cloud cost optimization
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/c_suite/chief_executive_officer.md
+++ b/Roles/c_suite/chief_executive_officer.md
@@ -104,7 +104,7 @@ Degree in Business, Economics, Law, Engineering, or a related field. An MBA or o
 
 20+ years of progressive leadership experience across multiple business functions, with at least 5–10 years in C-suite or Group-level roles. Proven track record of P&L ownership, Board-level accountability, and executive leadership across complex, multi-domain organisations.
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -117,7 +117,7 @@ Degree in Business, Economics, Law, Engineering, or a related field. An MBA or o
 | Total Shareholder Return (TSR) | Meets or exceeds sector peer group benchmark | Annual |
 | Major incident response (technology, security, operational) | Board-appropriate escalation and communication within agreed protocols | Per incident |
 
-## Career Progression
+## Career Development Path
 
 **Previous Roles:**
 
@@ -147,6 +147,54 @@ Degree in Business, Economics, Law, Engineering, or a related field. An MBA or o
 | Board of Directors | Primary governance accountability; strategy, performance, risk, executive appointments, and regulatory posture |
 | Investors / Shareholders | External accountability relationship; investor relations, capital markets, and shareholder communications |
 | Regulators | External engagement; regulatory posture, formal notifications, government relations, and sector compliance |
+
+## Key Technologies
+
+- Board governance and reporting platforms (Diligent, BoardVantage, or equivalent)
+- Enterprise ERP and financial management platforms (SAP, Oracle Financials) at governance level
+- Executive business intelligence dashboards (Power BI, Tableau) for enterprise performance visibility
+- Enterprise risk and GRC platforms (ServiceNow GRC, Archer) for risk appetite governance
+- OKR and executive performance management frameworks
+- Investor relations and shareholder communication platforms
+- Virtual data rooms and M&A due-diligence tooling
+- Collaboration and executive communication tools (Microsoft Teams, SharePoint)
+
+## Typical Day-to-Day Activities
+
+- Preparing for and chairing Board meetings, Board committee sessions, and executive leadership team meetings
+- Reviewing enterprise performance against the annual operating plan with the CFO and function heads
+- Holding strategic 1:1s with C-suite direct reports, including the technology reporting line (CTO/CIO/SVP)
+- Engaging investors, analysts, and shareholders through briefings, roadshows, and results communications
+- Reviewing enterprise risk posture, including technology and cyber risk briefings from the CISO reporting chain
+- Progressing M&A pipeline activity: target reviews, due-diligence checkpoints, and integration steering
+- Representing the organisation externally with regulators, government bodies, industry forums, and media
+- Driving executive talent, succession, and organisational design decisions with the CPO
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid; substantial on-site presence required for Board meetings, executive leadership sessions, investor engagements, and organisational leadership visibility
+- **Collaboration Tools:** Microsoft Teams, SharePoint, board governance platforms, and executive dashboards for performance, risk, and strategy reporting
+- **On-Site Requirements:** Regular presence at headquarters for Board and executive team cycles; frequent travel for investor relations, regulator engagement, M&A activity, and site leadership visits
+- **Time Zone Flexibility:** Extended availability across regions for global investor, Board, and partner engagements
+- **On-Call / Operational Demands:** Ultimate escalation point for enterprise crises — major technology or security incidents, regulatory events, and reputational issues — with availability governed by crisis-management protocols
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Certificate in Company Direction (IoD) or NACD Directorship Certification — Board governance and director accountability
+- Chartered Director (CDir) — senior governance and strategic leadership
+- Executive leadership programmes (Harvard Business School, INSEAD, London Business School)
+
+**Complementary Certifications:**
+
+- Board-level cyber risk governance programmes (e.g., NACD Cyber-Risk Oversight, Carnegie Mellon/SEI executive cyber programmes)
+- AI governance and strategy programmes for executives (e.g., MIT Sloan Artificial Intelligence for Business Strategy)
+- Corporate finance and M&A executive education for non-CFO executives
+
+**Learning Resources and Communities:**
+
+- World Economic Forum and Gartner executive research, CEO peer networks (YPO, Business Roundtable, Chief Executive Network), Board and governance publications (Harvard Business Review, Directors & Boards), and investor-relations and regulatory briefing services
 
 ## Common Challenges
 

--- a/Roles/c_suite/chief_financial_officer.md
+++ b/Roles/c_suite/chief_financial_officer.md
@@ -106,7 +106,7 @@ Degree in Finance, Accounting, Economics, or a related field. A postgraduate qua
 
 15+ years of progressive finance leadership experience, with at least 5 years in a senior finance executive role (CFO, VP of Finance, Group Financial Controller, or equivalent). Proven track record of owning enterprise financial reporting, managing external audit and regulatory relationships, governing capital allocation at scale, and partnering with CEOs and Boards through complex financial cycles including growth phases, restructuring, or M&A activity.
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -119,7 +119,7 @@ Degree in Finance, Accounting, Economics, or a related field. A postgraduate qua
 | Budget cycle completion | Annual budget approved by Board within agreed governance timeline | Annual |
 | Regulatory financial compliance | Zero material compliance breaches; all regulatory returns filed on time | Annual |
 
-## Career Progression
+## Career Development Path
 
 **Previous Roles:**
 
@@ -150,6 +150,54 @@ Degree in Finance, Accounting, Economics, or a related field. A postgraduate qua
 | CISO | Financial risk dimensions of cyber and data incidents; regulatory financial penalties; cyber insurance governance |
 | Business unit and functional leaders | Budget ownership, financial performance management, investment business cases, and financial reporting obligations |
 | External auditors and regulators | Primary executive contact for statutory audit, regulatory financial submissions, and financial compliance assurance |
+
+## Key Technologies
+
+- Enterprise ERP and financial management platforms (SAP S/4HANA, Oracle Financials, Workday Financials)
+- Enterprise planning and forecasting platforms (Anaplan, Oracle EPM, Workday Adaptive Planning)
+- Financial consolidation, close, and reporting tooling
+- Treasury management systems and banking platforms
+- Business intelligence and executive dashboards (Power BI, Tableau) for financial performance visibility
+- GRC, audit management, and internal-controls platforms
+- Cloud cost governance and FinOps reporting consoles for technology investment oversight
+- Investor relations and results communication platforms
+
+## Typical Day-to-Day Activities
+
+- Reviewing financial performance, cash position, and forecast variance with FP&A and treasury teams
+- Chairing capital allocation and investment governance forums, including technology business-case reviews
+- Preparing Board, audit committee, and investor reporting: results, guidance, and financial risk posture
+- Working with the CEO on enterprise strategy, operating plan trade-offs, and M&A financial modelling
+- Engaging auditors, banks, rating agencies, and institutional investors
+- Reviewing enterprise cost programmes, including cloud and technology spend governance with the CTO/CIO
+- Overseeing financial controls, compliance, and tax posture with controllers and internal audit
+- Holding 1:1s with finance leadership and driving finance function transformation and automation
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid; significant on-site presence required for Board and audit committee cycles, results announcements, executive leadership sessions, and investor engagements
+- **Collaboration Tools:** Microsoft Teams, SharePoint, ERP and planning platforms, and executive dashboards for financial reporting and governance
+- **On-Site Requirements:** Regular presence at headquarters for Board, audit committee, and executive team meetings; travel for investor roadshows, banking relationships, and M&A activity
+- **Time Zone Flexibility:** Standard business hours with extended availability during close, results, audit, and M&A periods
+- **On-Call / Operational Demands:** Escalation point for material financial events, liquidity issues, and financially significant incidents, including cyber events with financial-disclosure implications
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Chartered or certified accountancy qualification (ACA, ACCA, CIMA, CPA) — professional finance foundation
+- CFA Charter — investment and capital-markets depth (common in capital-markets-facing CFO roles)
+- Board governance programmes (IoD Certificate in Company Direction, NACD Directorship Certification)
+
+**Complementary Certifications:**
+
+- FinOps Certified Practitioner — cloud financial governance literacy for technology investment oversight
+- Enterprise risk management programmes (COSO ERM, IRM qualifications)
+- Executive leadership programmes (Wharton, INSEAD, London Business School CFO programmes)
+
+**Learning Resources and Communities:**
+
+- Financial Executives International (FEI), Gartner CFO research, CFO peer networks and roundtables, Big Four technical accounting and regulatory update services, and investor-relations society resources
 
 ## Common Challenges
 

--- a/Roles/c_suite/chief_information_officer.md
+++ b/Roles/c_suite/chief_information_officer.md
@@ -105,7 +105,7 @@ Degree in Information Technology, Computer Science, Business Information Systems
 
 15+ years of progressive IT leadership experience, with at least 5 years in a senior IT executive role (CIO, VP of IT, Head of IT, or equivalent). Proven track record of owning enterprise IT operations, managing large IT vendor and system integrator relationships, and delivering IT service improvement and enterprise system transformation programmes in complex, multi-site organisations.
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -118,7 +118,7 @@ Degree in Information Technology, Computer Science, Business Information Systems
 | IT vendor performance | ≥90% of key vendors meeting contracted SLA targets | Quarterly |
 | Business continuity / DR test results | All critical systems recovered within agreed RTO/RPO in annual DR test | Annual |
 
-## Career Progression
+## Career Development Path
 
 **Previous Roles:**
 
@@ -148,6 +148,55 @@ Degree in Information Technology, Computer Science, Business Information Systems
 | CISO | IT security posture, IT compliance obligations, and security requirements for enterprise systems and IT infrastructure; CISO may report to CIO in some governance models |
 | Business operations leaders | IT as an enabler of operational performance; SLA management, service improvement prioritisation, and operational IT requirements |
 | Enterprise system vendors and system integrators | Executive vendor relationships for ERP, HRIS, ITSM, and collaboration platforms; performance management and contract governance |
+
+## Key Technologies
+
+- IT portfolio and strategic planning platforms (ServiceNow Strategic Portfolio Management, LeanIX, Planview)
+- ITSM and enterprise service management platforms (ServiceNow)
+- Enterprise ERP and corporate application estates at governance level
+- Cloud platform governance consoles (Azure Management Groups, AWS Organizations, GCP Resource Manager)
+- Enterprise risk, security, and compliance dashboards (with the CISO organisation)
+- Data, analytics, and AI platform strategy tooling at portfolio level
+- Digital workplace and collaboration platforms (Microsoft 365, Teams)
+- Business intelligence and executive dashboards (Power BI, Tableau) for IT performance reporting
+
+## Typical Day-to-Day Activities
+
+- Chairing IT leadership, portfolio, and governance forums across delivery, operations, and risk
+- Reviewing IT investment portfolio performance: delivery progress, budget adherence, and benefit realisation
+- Engaging business unit executives to align technology services and roadmaps with business priorities
+- Reviewing operational health: major incident posture, service levels, resilience, and continuity readiness
+- Holding strategic 1:1s with IT leadership team and the CISO on security and risk posture
+- Preparing Board and executive reporting on technology strategy, risk, and transformation progress
+- Conducting executive vendor and partner engagements, including strategic agreements and escalations
+- Sponsoring digital transformation, data, and AI adoption programmes across the enterprise
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid; significant on-site presence required for executive leadership sessions, Board reporting, business unit engagement, and major vendor negotiations
+- **Collaboration Tools:** Microsoft Teams, SharePoint, ServiceNow, and executive dashboards for portfolio, risk, and service reporting
+- **On-Site Requirements:** Regular presence at headquarters for executive and governance cycles; travel to major sites, vendor executive briefings, and industry forums
+- **Time Zone Flexibility:** Standard business hours with availability for global vendor engagements and cross-regional leadership forums
+- **On-Call / Operational Demands:** Executive escalation authority for major technology incidents with enterprise, regulatory, or Board implications; participates in crisis-management protocols
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- CGEIT (Certified in the Governance of Enterprise IT) — enterprise IT governance
+- ITIL 4 Strategic Leader — service management and operating-model leadership
+- Board-level technology governance programmes (IoD, NACD, or equivalent)
+
+**Complementary Certifications:**
+
+- CISM or CISSP — security and risk governance credibility
+- TOGAF Foundation — enterprise architecture literacy
+- FinOps Certified Practitioner — cloud financial governance
+- Executive programmes (MIT Sloan CIO Executive Programme, Gartner CIO academies)
+
+**Learning Resources and Communities:**
+
+- Gartner Executive Programmes (EXP), MIT CISR research, SIM (Society for Information Management), CIO Executive Council, and peer CIO networks and industry forums
 
 ## Common Challenges
 

--- a/Roles/c_suite/chief_technology_officer.md
+++ b/Roles/c_suite/chief_technology_officer.md
@@ -104,7 +104,7 @@ Degree in Computer Science, Software Engineering, Mathematics, or a related tech
 
 15+ years of progressive technology and engineering leadership experience, with at least 5 years in a senior technology executive role (VP of Engineering, CTO, or equivalent). Proven track record of owning enterprise technology strategy, leading large engineering organisations, and delivering technology-led business outcomes at scale.
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -117,7 +117,7 @@ Degree in Computer Science, Software Engineering, Mathematics, or a related tech
 | R&D investment return | Defined ROI or capability outcomes from R&D budget within agreed timeframes | Annual |
 | Time to production for major platform releases | Meets agreed release cadence targets | Per release |
 
-## Career Progression
+## Career Development Path
 
 **Previous Roles:**
 
@@ -147,6 +147,54 @@ Degree in Computer Science, Software Engineering, Mathematics, or a related tech
 | Technical Area Lead (TAL) | Close partnership on enterprise architecture, engineering standards, principal engineering community, and technology governance |
 | Strategic technology vendors / cloud providers | Executive relationship management for platform strategy, roadmap alignment, and strategic commercial agreements |
 | Board / Investors | Technical credibility, innovation narrative, and technology risk assurance for investor and Board engagement |
+
+## Key Technologies
+
+- Cloud platform strategy and governance consoles (Azure, AWS, GCP) at portfolio level
+- Enterprise architecture management platforms (LeanIX or equivalent)
+- Engineering delivery and DevOps toolchains (GitHub, Azure DevOps) at governance level
+- Data, analytics, and AI/ML platform strategy tooling
+- Technology portfolio, innovation, and R&D management platforms
+- Product analytics and engineering performance dashboards (DORA-style delivery metrics)
+- Enterprise risk and security dashboards (with the CISO organisation)
+- Business intelligence and executive reporting tools (Power BI, Tableau)
+
+## Typical Day-to-Day Activities
+
+- Setting and communicating technology strategy, architecture direction, and platform investment priorities
+- Chairing architecture, engineering, and innovation governance forums
+- Holding strategic 1:1s with senior technology leaders: Product Area Leads, architects, and engineering leadership
+- Reviewing engineering delivery health, platform reliability, and technology KPI trends
+- Evaluating emerging technologies — AI, cloud services, and platform capabilities — and setting adoption positions
+- Engaging product and business leadership to align technology capability with commercial strategy
+- Conducting executive engagements with strategic technology vendors and partners
+- Preparing Board and executive updates on technology strategy, innovation, and technology risk
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid; significant on-site presence required for executive leadership sessions, engineering leadership engagement, Board reporting, and strategic partner meetings
+- **Collaboration Tools:** Microsoft Teams, SharePoint, engineering and portfolio dashboards, and executive reporting platforms
+- **On-Site Requirements:** Regular presence at headquarters for executive and governance cycles; travel for vendor executive briefings, industry conferences, and engineering site engagement
+- **Time Zone Flexibility:** Standard business hours with availability for global partner engagements and cross-regional technology forums
+- **On-Call / Operational Demands:** Executive escalation authority for major platform or technology incidents with enterprise impact; participates in crisis-management protocols alongside the CIO and CISO
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Executive technology leadership programmes (MIT Sloan CTO Programme or equivalent)
+- TOGAF Foundation or Practitioner — enterprise architecture governance
+- Board-level technology governance programmes (IoD, NACD, or equivalent)
+
+**Complementary Certifications:**
+
+- Cloud architecture certifications (Azure Solutions Architect Expert, AWS Certified Solutions Architect) — for platform credibility, at awareness-to-proficient depth
+- AI strategy and governance programmes (e.g., MIT Sloan AI for Business Strategy)
+- CISM or CISSP — security governance credibility
+
+**Learning Resources and Communities:**
+
+- Gartner and Forrester technology strategy research, Thoughtworks Technology Radar, DORA/Accelerate research on engineering performance, CTO peer forums and communities, and major cloud provider executive briefing programmes
 
 ## Common Challenges
 

--- a/Roles/client_platform/client_platform_architect.md
+++ b/Roles/client_platform/client_platform_architect.md
@@ -40,6 +40,19 @@ This role operates at the intersection of engineering rigour and business strate
 - Mentor Senior Engineers and provide architectural governance over engineering delivery.
 - Represent the Client Platform domain in architecture review boards and cross-functional governance forums.
 
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Client OS reference architecture and engineering standards across Windows, macOS, and Linux desktop | UEM policy and MDM configuration detail (owned by Endpoint Management) |
+| OS image build, provisioning pipeline, and application packaging standards | Application portfolio decisions and business application selection |
+| OS hardening baseline definitions (CIS Benchmarks, DISA STIGs) for the client estate | Enterprise security policy and Zero Trust strategy (owned by Security Architecture) |
+| Client hardware lifecycle standards, device specifications, and OEM selection criteria | Procurement commercial negotiations and contract terms |
+| Client platform tooling selection and proof-of-concept outcomes (e.g., Jamf Pro, Fleet.dm) | Enterprise-wide tooling consolidation decisions (architecture review board) |
+| Domain boundary definitions between Client Platform, Endpoint Management, and Modern Workplace | Service desk support model and staffing (owned by Service Desk Lead) |
+
 ## Required Skills
 
 **Technical Skills:**
@@ -88,7 +101,7 @@ This role operates at the intersection of engineering rigour and business strate
 
 **Experience:** Minimum 8 years in endpoint or client platform engineering, with at least 3 years in an architecture or technical lead role. Demonstrated hands-on experience across Windows, macOS, and Linux desktop environments at enterprise scale (2,000+ devices).
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -101,7 +114,7 @@ This role operates at the intersection of engineering rigour and business strate
 | Architecture standards adoption rate (new builds) | 100% | Quarterly |
 | Application packaging lead time (standard apps) | ≤ 5 business days | Monthly |
 
-## Career Progression
+## Career Development Path
 
 **From (typical previous roles):**
 
@@ -131,7 +144,7 @@ This role operates at the intersection of engineering rigour and business strate
 | Client Platform Senior Engineers | Provide architectural direction, review engineering designs, mentor on platform decisions |
 | Infrastructure / Server OS Architects | Coordinate on shared automation tooling, scripting standards, and cross-platform configuration management patterns |
 
-## Tools and Technologies
+## Key Technologies
 
 **OS Engineering & Deployment:**
 
@@ -184,6 +197,44 @@ This role operates at the intersection of engineering rigour and business strate
 - Bash / Zsh (macOS and Linux)
 - Python 3.x (cross-platform automation)
 - Git (version control for build scripts and standards)
+
+## Typical Day-to-Day Activities
+
+- Reviewing and evolving OS reference architectures, build standards, and hardening baselines
+- Leading design sessions for provisioning, packaging, and patching pipeline changes across the three client platforms
+- Reviewing engineering designs and providing architectural direction to Senior Engineers
+- Meeting with Endpoint Management, Security, and Modern Workplace counterparts to align roadmaps and domain boundaries
+- Evaluating tooling and platform options through structured proof-of-concept work
+- Progressing hardware lifecycle governance: device specification reviews, driver pack strategy, and refresh planning with Procurement
+- Presenting client platform direction at architecture review boards and governance forums
+- Reviewing estate telemetry (compliance, patch currency, provisioning success) and directing corrective engineering work
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid or remote-first; architecture and governance work is largely location-independent, with periodic on-site presence for workshops and hardware evaluation
+- **Collaboration Tools:** Microsoft Teams, SharePoint, Git-based documentation repositories, and architecture diagramming tools
+- **On-Site Requirements:** Occasional presence for architecture workshops, physical hardware/driver validation, OEM engagements, and major migration cutovers
+- **Time Zone Flexibility:** Standard business hours with occasional flexibility for global stakeholder alignment and vendor briefings
+- **On-Call / Operational Demands:** Not part of a standing on-call rota; consulted as escalation authority during major client-estate incidents (e.g., a failed patch ring or provisioning outage)
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Microsoft Certified: Endpoint Administrator Associate (MD-102)
+- Jamf Certified Expert (JCE) or Jamf 400-level
+- TOGAF Foundation — architecture method grounding
+
+**Complementary Certifications:**
+
+- Microsoft Certified: Azure Administrator Associate (AZ-104)
+- CIS Controls Implementation Group Practitioner
+- ITIL 4 Foundation
+- Linux Foundation Certified System Administrator (LFCS) — Linux desktop credibility
+
+**Learning Resources and Communities:**
+
+- Microsoft Intune and Windows deployment documentation and release notes, Jamf Nation community, MacAdmins Slack and conference, Fleet.dm and osquery communities, Lenovo commercial deployment resources, and CIS Benchmark working groups
 
 ## Common Challenges
 

--- a/Roles/client_platform/client_platform_engineer.md
+++ b/Roles/client_platform/client_platform_engineer.md
@@ -37,6 +37,17 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 - Participate in sprint ceremonies, daily stand-ups, and retrospectives as part of the Client Platform team.
 - Escalate complex technical issues to the Senior Engineer with clear diagnostic information and reproduction steps.
 
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Execution of OS build, provisioning, packaging, and patching tasks to the defined standards | Engineering pipeline design (owned by Senior Engineers and the Architect) |
+| Quality and documentation of individual packages, scripts, and build artefacts | Packaging and hardening standards (provides implementation feedback) |
+| First-line resolution of escalated client platform tickets within the engineering tier | Patch ring strategy and scheduling (Senior Engineer/Architect-owned) |
+| Accuracy of estate telemetry data hygiene for assigned platforms | Tooling selection and platform strategy |
+
 ## Required Skills
 
 **Technical Skills:**
@@ -83,7 +94,7 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 
 **Experience:** 1–3 years in desktop support, IT field services, or a junior endpoint/client platform engineering role. Demonstrable hands-on experience with Windows device management; exposure to macOS or Linux desktop is advantageous.
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -94,7 +105,7 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 | Patch compliance rate on assigned device cohorts | ≥ 97% | Monthly |
 | Runbook and documentation accuracy (verified by Senior Engineer) | No critical gaps identified in quarterly review | Quarterly |
 
-## Career Progression
+## Career Development Path
 
 **From (typical previous roles):**
 
@@ -120,7 +131,7 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 | HR / People Operations | Align device setup timing with new employee start dates and onboarding cohort schedules |
 | Procurement / Asset Management | Receive new hardware for imaging; return retired devices for secure wipe and disposal |
 
-## Tools and Technologies
+## Key Technologies
 
 **OS Image Maintenance:**
 
@@ -166,6 +177,43 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 - ServiceNow or Jira (ticket handling and sprint tracking)
 - Microsoft Teams, SharePoint (team communication)
 - Confluence or SharePoint (runbook and documentation maintenance)
+
+## Typical Day-to-Day Activities
+
+- Building, testing, and releasing application packages for Windows (MSIX/Win32), macOS (.pkg), and Linux (.deb/.rpm)
+- Executing OS image build and provisioning tasks, including driver pack updates and validation on reference hardware
+- Running patch deployment activities and verifying update compliance across assigned rings
+- Resolving escalated tickets from the Service Desk that require OS engineering investigation
+- Writing and maintaining automation scripts (PowerShell, Bash) for routine client-platform tasks
+- Updating engineering documentation, runbooks, and package records
+- Validating hardening baseline settings on test devices and reporting deviations
+- Participating in team stand-ups, peer reviews, and knowledge-sharing sessions
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid; a substantial share of packaging, scripting, and pipeline work is remote-compatible, with regular lab presence for device work
+- **Collaboration Tools:** Microsoft Teams, Git repositories, Intune/Jamf consoles, and ticketing/ITSM tooling
+- **On-Site Requirements:** Regular presence for physical device provisioning, hardware troubleshooting, and deployment support events
+- **Time Zone Flexibility:** Standard business hours; occasional out-of-hours participation in deployment windows
+- **On-Call / Operational Demands:** May participate in a follow-the-sun or rota-based escalation model for client estate incidents
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Microsoft Certified: Endpoint Administrator Associate (MD-102)
+- Jamf Certified Associate / Jamf 200-level (JCA)
+- CompTIA A+ or equivalent client platform foundation
+
+**Complementary Certifications:**
+
+- Linux Foundation Certified IT Associate (LFCA) or LFCS
+- ITIL 4 Foundation
+- PowerShell and scripting fundamentals courses (Microsoft Learn paths)
+
+**Learning Resources and Communities:**
+
+- Microsoft Learn (Windows deployment, Intune), Jamf training catalogue and Jamf Nation, MacAdmins community, packaging communities (PSAppDeployToolkit, Homebrew), and internal engineering runbooks and standards
 
 ## Common Challenges
 

--- a/Roles/client_platform/client_platform_product_owner.md
+++ b/Roles/client_platform/client_platform_product_owner.md
@@ -24,6 +24,13 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 - **Key Stakeholders:** CIO/CTO, CISO, IT Operations leadership, HR/People Operations, Procurement, Finance, Service Desk, Security Architecture, Endpoint Management Product Owner.
 - **Processes Supported:** New employee device provisioning, hardware refresh planning and budgeting, OS lifecycle management, application onboarding backlog, client estate compliance reporting, vendor and OEM relationship management.
 
+## Business Impact
+
+- **Business Objective:** Ensure the client platform service delivers maximum workforce value — a secure, reliable, and modern device experience — by prioritising the engineering backlog around business outcomes, stakeholder needs, and platform health.
+- **Value Metrics:** Stakeholder satisfaction with the client platform service, backlog lead time for prioritised platform features, provisioning and packaging service-level performance, adoption rate of new platform capabilities (e.g., zero-touch provisioning), platform compliance and patch currency trends.
+- **Key Stakeholders:** End User & Workplace Chapter Lead, Client Platform Architect and engineering team, Endpoint Management Product Owner, Service Desk Lead, HR (onboarding experience), Procurement, Security, and business unit representatives.
+- **Processes Supported:** Client platform backlog and roadmap management, demand intake and prioritisation, new capability rollout planning, stakeholder communication, and service performance review.
+
 ## Key Responsibilities
 
 - Own and maintain the Client Platform product backlog, ensuring stories are well-defined, estimated, and prioritised in alignment with business value and technical risk.
@@ -37,6 +44,18 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 - Coordinate with the Endpoint Management Product Owner to ensure aligned priorities where Client Platform engineering intersects with UEM platform capabilities.
 - Ensure hardware asset lifecycle data for the Lenovo and Apple fleet is accurately maintained in the ITAM system (ServiceNow ITAM or equivalent), aligned with Lenovo Premier Support warranty records and enabling accurate refresh cycle forecasting.
 - Remove blockers for the engineering team through stakeholder escalation, procurement facilitation, and dependency resolution.
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Client platform backlog content, ordering, and sprint/iteration priorities | Engineering solution design and implementation approach (owned by Architect and engineers) |
+| Acceptance criteria and definition of done for platform features and improvements | OS hardening and security baseline requirements (Security/Architect-owned) |
+| Platform roadmap communication and stakeholder expectation management | Hardware lifecycle standards and OEM selection (Architect/Procurement-owned) |
+| Trade-off decisions between feature work, technical debt, and operational stability within the backlog | Budget envelope and headcount (Chapter Lead-owned) |
+| Rollout sequencing and communication plans for user-facing platform changes | UEM policy detail and endpoint security tooling (Endpoint Management/Security-owned) |
 
 ## Required Skills
 
@@ -82,7 +101,7 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 
 **Experience:** Minimum 4 years in IT product ownership, IT programme management, or a senior IT operations role with backlog and stakeholder management responsibilities. Experience in end-user computing, endpoint management, or workplace technology domains is strongly preferred.
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -94,7 +113,7 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 | Backlog refinement coverage (stories refined and estimated) | ≥ 80% of next sprint's stories refined 1 sprint ahead | Per sprint |
 | Stakeholder satisfaction with Client Platform delivery | ≥ 4.0 / 5.0 (survey-based) | Quarterly |
 
-## Career Progression
+## Career Development Path
 
 **From (typical previous roles):**
 
@@ -124,7 +143,7 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 | Finance | Manage hardware refresh budget planning, CapEx submissions, and lifecycle cost reporting |
 | Microsoft, Apple, OEM Vendors | Manage roadmap briefings, software assurance reviews, escalations, and commercial relationships |
 
-## Tools and Technologies
+## Key Technologies
 
 **Backlog & Delivery Management:**
 
@@ -160,6 +179,42 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 - Microsoft Partner Centre / TAM engagement
 - Apple Business Manager and Apple authorised reseller engagement
 - OEM SLA tracking and escalation management portals
+
+## Typical Day-to-Day Activities
+
+- Refining and reprioritising the client platform backlog with the Architect and engineering team
+- Running backlog refinement, sprint planning, and review ceremonies for the platform team
+- Gathering and clarifying demand from HR, Service Desk, Security, and business stakeholders
+- Writing user stories and acceptance criteria for provisioning, packaging, and platform improvements
+- Reviewing platform service metrics (provisioning success, packaging lead time, patch currency) and feeding findings into priorities
+- Communicating roadmap progress and upcoming changes to stakeholders and user representatives
+- Coordinating rollout plans for user-visible changes (OS upgrades, new provisioning experiences) with change management
+- Aligning with the Endpoint Management Product Owner on cross-domain sequencing and dependencies
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid or remote-first; product ownership work is largely location-independent
+- **Collaboration Tools:** Microsoft Teams, Azure DevOps or Jira for backlog management, SharePoint, and service dashboards
+- **On-Site Requirements:** Periodic presence for stakeholder workshops, planning events, and major rollout support
+- **Time Zone Flexibility:** Standard business hours with flexibility for cross-regional stakeholder sessions
+- **On-Call / Operational Demands:** Not on-call; engaged during major user-impacting platform incidents for communication and prioritisation decisions
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Professional Scrum Product Owner (PSPO I) or Certified Scrum Product Owner (CSPO)
+- ITIL 4 Foundation — service management context
+
+**Complementary Certifications:**
+
+- Microsoft Certified: Endpoint Administrator Associate (MD-102) — platform domain literacy
+- SAFe Product Owner/Product Manager (POPM) where scaled agile is in use
+- Change management foundations (e.g., Prosci) for user-facing rollouts
+
+**Learning Resources and Communities:**
+
+- Scrum.org and product-management learning paths, Microsoft Intune/Windows deployment release notes for roadmap awareness, MacAdmins and Jamf Nation community trends, and internal chapter and product community forums
 
 ## Common Challenges
 

--- a/Roles/client_platform/client_platform_senior_engineer.md
+++ b/Roles/client_platform/client_platform_senior_engineer.md
@@ -38,6 +38,18 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 - Mentor Client Platform Engineers through peer reviews of packaging submissions, pairing on build tasks, and structured knowledge-sharing.
 - Maintain technical documentation including build procedures, packaging standards, runbooks, and known-issues logs.
 
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Detailed engineering design of OS build, provisioning, and packaging pipelines within the reference architecture | Client platform reference architecture and standards (owned by the Architect) |
+| Complex application packaging solutions and cross-platform automation implementations | OS hardening baseline selection (advises the Architect with implementation feedback) |
+| Patch ring execution design and remediation engineering for the client estate | UEM policy configuration (owned by Endpoint Management) |
+| Technical quality of engineering deliverables and peer review outcomes | Hardware specification and OEM selection (Architect/Procurement-owned) |
+| Escalated engineering investigations and root-cause analysis for client platform issues | Service desk knowledge base structure and support processes |
+
 ## Required Skills
 
 **Technical Skills:**
@@ -83,7 +95,7 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 
 **Experience:** Minimum 5 years in client platform or endpoint engineering, with demonstrated multi-platform experience across Windows and at least one of macOS or Linux desktop. Experience packaging applications and building/maintaining OS images at enterprise scale (1,000+ devices).
 
-## KPIs and Success Metrics
+## Key Performance Indicators
 
 | Metric | Target | Frequency |
 |---|---|---|
@@ -95,7 +107,7 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 | Documentation coverage for active build pipelines and runbooks | 100% of active pipelines documented | Quarterly |
 | Peer review participation rate for packaging submissions | 100% reviewed before promotion | Monthly |
 
-## Career Progression
+## Career Development Path
 
 **From (typical previous roles):**
 
@@ -123,7 +135,7 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 | HR / People Operations | Support device provisioning workflows for new employee onboarding cohorts |
 | Procurement | Advise on hardware compatibility for new device models entering the standard |
 
-## Tools and Technologies
+## Key Technologies
 
 **OS Image Build:**
 
@@ -169,6 +181,44 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 - Apple Software Update / softwareupdate CLI (macOS firmware and security updates)
 - fwupd / Linux Vendor Firmware Service (LVFS) for Lenovo hardware on Ubuntu LTS
 - OEM INF/SYS driver packages (Intel, AMD — supplementary chipset and peripheral components)
+
+## Typical Day-to-Day Activities
+
+- Designing and building OS image, provisioning, and packaging pipeline improvements across Windows, macOS, and Linux
+- Implementing and testing hardening baseline changes and validating compliance impact before rollout
+- Handling escalated engineering issues from Engineers and the Service Desk, leading root-cause analysis
+- Reviewing peers’ engineering work: scripts, packages, pipeline changes, and documentation
+- Automating repetitive client-platform tasks with PowerShell, Bash, and Python
+- Monitoring patch ring health and provisioning telemetry, driving remediation where success rates degrade
+- Mentoring Engineers on platform internals, packaging techniques, and automation practices
+- Contributing implementation feedback to the Architect on standards and tooling decisions
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid or remote-first; engineering work is largely remote-compatible with occasional lab/hardware presence
+- **Collaboration Tools:** Microsoft Teams, Git repositories for build scripts and pipelines, Intune/Jamf/Fleet.dm consoles, and shared engineering documentation
+- **On-Site Requirements:** Occasional presence for physical device validation, driver/firmware testing on reference hardware, and major deployment events
+- **Time Zone Flexibility:** Standard business hours; occasional out-of-hours windows for patch ring cutovers and migration activities
+- **On-Call / Operational Demands:** Participates in escalation support for client-estate incidents affecting provisioning, patching, or OS stability
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Microsoft Certified: Endpoint Administrator Associate (MD-102)
+- Jamf Certified Tech / Jamf 300-level (JCT)
+- Linux Foundation Certified System Administrator (LFCS)
+
+**Complementary Certifications:**
+
+- Microsoft Certified: Azure Administrator Associate (AZ-104)
+- CIS Controls Implementation Group Practitioner
+- ITIL 4 Foundation
+- HashiCorp or Red Hat automation credentials (e.g., RHCE/Ansible) for cross-platform automation depth
+
+**Learning Resources and Communities:**
+
+- Microsoft Learn deployment and Intune content, Jamf Nation and MacAdmins community, PatchMyPC and packaging community resources, osquery/Fleet.dm documentation, and PowerShell and Python automation communities
 
 ## Common Challenges
 

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -91,6 +91,18 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 - Compliance and data governance
 - Storage-as-a-service delivery model
 
+## Key Technologies
+
+- Qumulo Core distributed file system and Qumulo analytics
+- Qumulo REST API for automation and self-service integration
+- File protocols and access control (SMB, NFS, Active Directory integration)
+- Hybrid and cloud file services (Qumulo on Azure / AWS)
+- Capacity monitoring, trending, and reporting platforms
+- Enterprise backup integration for file data protection
+- Storage automation and orchestration frameworks
+- ITSM and self-service request portals (ServiceNow)
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the Qumulo storage platform backlog

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -91,6 +91,18 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 - Disaster recovery planning and testing
 - Backup reporting and analytics
 
+## Key Technologies
+
+- Commvault Complete Data Protection and Command Center
+- Commvault HyperScale X scale-out infrastructure
+- Cloud backup and DR targets (Azure Blob, Amazon S3)
+- Deduplication storage pools and backup storage tiering
+- Automated recovery testing and DR orchestration tooling
+- Backup compliance, retention, and reporting dashboards
+- License usage tracking and optimization tooling
+- ITSM integration for backup/restore request workflows (ServiceNow)
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the Commvault platform backlog

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -83,6 +83,18 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 - Backup reporting and compliance
 - Recovery testing program
 
+## Key Technologies
+
+- HPE SimpliVity hyperconverged platform and OmniStack data virtualization
+- SimpliVity native backup policies and RapidDR orchestration
+- VMware vCenter integration for backup and recovery workflows
+- Enterprise backup solution integration (e.g. HPE StoreOnce, Commvault)
+- Backup policy automation and scheduling frameworks
+- RPO/RTO monitoring, reporting, and compliance dashboards
+- Recovery testing and application recovery orchestration tooling
+- ITSM integration for backup/restore request workflows (ServiceNow)
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the SimpliVity backup platform backlog

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -89,6 +89,18 @@ The Database Product Owner manages the portfolio of database platforms and data 
 - Database lifecycle management
 - Data migration and modernization planning
 
+## Key Technologies
+
+- Relational database platforms (Microsoft SQL Server, Oracle, PostgreSQL, MySQL)
+- Cloud database services (Azure SQL, Amazon RDS, managed PostgreSQL)
+- High availability and DR technologies (Always On, Data Guard, replication)
+- Database performance monitoring platforms
+- Database backup and recovery tooling
+- Database-as-a-service and self-service provisioning frameworks
+- Database security, auditing, and compliance tooling
+- License and cost management tooling for database estates
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the database platform backlog

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -80,7 +80,7 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 - **Experience:** 3–5 years in DevOps, software engineering, or QA automation engineering, with at least 2 years focused on framework or library development rather than point-in-time automation delivery.
 - **Certifications:** HashiCorp Certified: Terraform Associate, GitHub Actions certification, AWS Certified DevOps Engineer – Professional or Microsoft Certified: DevOps Engineer Expert (AZ-400), ISTQB Advanced Level – Test Automation Engineer (desirable).
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -78,6 +78,28 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 | CI/CD teams | Deployment pipeline integration |
 | Kubernetes Senior Engineers and Architect | Day-to-day guidance and direction |
 
+## Key Technologies
+
+- Kubernetes distributions and managed services (kubeadm-based clusters, AKS/EKS)
+- kubectl, Helm, and Kustomize for cluster and workload management
+- Container runtimes and image tooling (containerd, Docker, image registries such as Harbor/ACR)
+- Ingress controllers and cluster networking (NGINX Ingress, CNI plugins, network policies)
+- GitOps and deployment tooling (Argo CD, Flux)
+- Monitoring and logging stacks (Prometheus, Grafana, Loki/Fluent Bit)
+- Kubernetes security basics (RBAC, namespaces, secrets management, image scanning with Trivy)
+- Infrastructure as Code fundamentals (Terraform) for cluster-adjacent resources
+
+## Typical Day-to-Day Activities
+
+- Performing daily cluster health checks and responding to platform monitoring alerts
+- Executing cluster patching and upgrade tasks following the defined upgrade runbooks
+- Resolving standard Kubernetes incidents and tickets: failing pods, resource pressure, configuration issues
+- Provisioning namespaces, RBAC bindings, and quotas for application team onboarding
+- Reviewing and applying workload manifests and Helm chart changes through the GitOps pipeline
+- Maintaining platform documentation, runbooks, and onboarding guides
+- Participating in stand-ups, change advisory reviews for standard changes, and knowledge sharing with Senior Engineers
+- Escalating complex platform issues to the Kubernetes Senior Engineer with diagnostic context
+
 ## Key Performance Indicators
 
 - Kubernetes cluster uptime and reliability

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -78,7 +78,7 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 - Track record of owning technical strategy and architecture governance for large infrastructure estates
 - Experience in organisations operating both on-premises datacentres and major public cloud platforms (Azure, AWS, and/or GCP)
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -78,7 +78,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 - Track record of owning enterprise data strategy and governance at scale, including data quality programmes and platform consolidation
 - Experience leading AI governance or ML risk management programmes in a regulated or enterprise context
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -77,7 +77,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 - Track record of owning delivery toolchain strategy and platform engineering governance at enterprise scale
 - Experience establishing or maturing a FinOps practice, including cloud cost governance and optimisation programmes
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -79,7 +79,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 - Track record of owning Microsoft 365 governance, device management strategy, or digital workplace transformation programmes at enterprise scale
 - Experience collaborating with security teams to govern endpoint security posture, conditional access, and zero trust device compliance
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -85,7 +85,7 @@ The Engineering Practices Champion is a senior individual contributor and intern
 - **Experience:** Typically 7+ years in software engineering, DevOps, or platform engineering roles, with a strong focus on quality practices and engineering excellence; at least 2–3 years of coaching, mentoring, or team enablement experience at Senior Engineer level or above
 - **Certifications:** No mandatory certifications required; recommended certifications listed in the Certifications section below
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -78,7 +78,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 - Track record of owning security architecture governance, zero trust programme delivery, or identity platform strategy at enterprise scale
 - Deep familiarity with security compliance and regulatory frameworks applicable to the organisation's industry context
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -78,7 +78,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 - Track record of owning ITSM process maturity improvement, CMDB governance, or enterprise architecture governance at enterprise scale
 - Experience engaging with Risk, Audit, and Compliance stakeholders on IT compliance reporting and service accountability
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -69,7 +69,7 @@ The Technical Community Leader is a senior individual contributor responsible fo
 - **Experience:** Typically 7+ years in software or platform engineering roles, with at least 2–3 years of demonstrated leadership, mentoring, or community-building activity; experience at Senior Engineer or Architect level in at least one domain
 - **Certifications:** No mandatory certifications required for this role; recommended certifications listed in the Certifications section below
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -77,6 +77,17 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 | service desk with monitoring data | Troubleshooting |
 | Senior Observability Engineers and Architect | Day-to-day guidance and direction |
 
+## Key Technologies
+
+- Metrics platforms (Prometheus, Grafana, Azure Monitor)
+- Log management stacks (Elastic Stack, Grafana Loki, Splunk)
+- Distributed tracing and telemetry standards (OpenTelemetry, Jaeger)
+- Application performance monitoring platforms (Dynatrace, Datadog, Azure Application Insights)
+- Telemetry collection pipelines (OpenTelemetry Collector, Fluent Bit, Logstash)
+- Alert routing and incident integration (Alertmanager, PagerDuty/Opsgenie, ITSM webhooks)
+- Dashboards-as-code and monitoring configuration management (Grafana provisioning, Terraform)
+- Scripting for automation and integration (Python, PowerShell, Bash)
+
 ## Key Performance Indicators
 
 - Reliability and performance of observability platforms

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -79,7 +79,7 @@ The Security Automation Engineer builds and maintains the automated security too
 - **Experience:** 3–5 years of experience in DevOps engineering, security engineering, or software engineering with a strong security focus; at least 2 years of hands-on experience building and operating automated security tooling within CI/CD pipelines.
 - **Certifications:** CompTIA Security+, Certified Ethical Hacker (CEH), Offensive Security Certified Professional (OSCP), AWS Certified Security – Specialty, Microsoft Certified: Security Operations Analyst Associate (SC-200).
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -79,7 +79,7 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 - **Experience:** 5–7 years of experience in identity and access management, IAM engineering, or information security; at least 3 years with direct hands-on IGA platform operations (SailPoint, Saviynt, Omada, or Microsoft Entra ID Governance) in an enterprise environment.
 - **Certifications:** Microsoft Certified: Identity and Access Administrator Associate (SC-300), SailPoint IdentityNow Certified Engineer, ISACA Certified Information Systems Auditor (CISA), ISC2 Certified Cloud Security Professional (CCSP), CyberArk Trustee.
 
-## Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -138,3 +138,26 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 **Learning Resources and Communities:**
 
 - HPE education portal (education.hpe.com), HPE TechLibrary technical documentation (techlibrary.hpe.com), CompTIA Server+ study resources, HPE Smart Update Manager documentation, and HPE InfoSight for Servers learning content
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid with a significant on-site component; physical server installation, cabling, and break-fix work requires data centre presence, while firmware, configuration, and documentation work can be done remotely via HPE iLO and OneView
+- **Collaboration Tools:** Microsoft Teams, ITSM ticketing, HPE OneView and iLO remote management consoles, and shared runbook repositories
+- **On-Site Requirements:** Regular data centre presence for hardware installs, component replacement, maintenance windows, and smart-hands activities
+- **Time Zone Flexibility:** Standard business hours with scheduled out-of-hours maintenance windows
+- **On-Call / Operational Demands:** Participates in the hardware support on-call rota for critical server hardware incidents
+
+## Career Development Path
+
+**From (typical previous roles):**
+
+- Data Centre Technician or Smart Hands Engineer
+- IT Support / Field Service Engineer with server hardware exposure
+- Junior Systems Engineer
+
+**To (typical next roles):**
+
+- HPE Server Hardware Senior Engineer
+- Server Hardware Architect
+- Platform engineering roles in adjacent domains (Virtualization, Linux/Windows Server OS)
+- Data Centre Operations Lead

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -39,6 +39,42 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 - Reduce total cost of ownership
 - Drive server technology innovation and adoption
 
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| HPE server hardware backlog content, ordering, and sprint priorities | Server hardware architecture standards and reference configurations (Architect-owned) |
+| Acceptance criteria and definition of done for hardware platform deliverables | Procurement contract terms and commercial negotiation (Procurement-owned) |
+| Hardware refresh roadmap sequencing and stakeholder communication | Data centre facilities capacity and power/cooling planning |
+| Trade-off decisions between refresh, capacity, and operational-stability work within the backlog | Budget envelope and investment approval (IT leadership/FinOps) |
+| Prioritisation of HPE vendor engagement topics and escalations | Cross-platform infrastructure strategy (platform product owners and architects) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Solid working knowledge of the HPE server portfolio (ProLiant, Synergy) and lifecycle management tooling (HPE OneView, iLO, InfoSight)
+- Understanding of server lifecycle, capacity, and refresh planning at enterprise scale
+- Familiarity with data centre operations, provisioning workflows, and dependent platforms (virtualisation, Windows/Linux server OS)
+- Financial literacy for total-cost-of-ownership analysis, refresh business cases, and vendor cost models
+- Proficiency with backlog and roadmap tooling (Azure DevOps, Jira) and agile delivery practices
+
+**Soft Skills:**
+
+- Stakeholder management across platform teams, FinOps, procurement, and data centre facilities
+- Clear prioritisation and trade-off communication under competing demands
+- Vendor relationship management with HPE account and support teams
+- Data-driven decision making from capacity, utilisation, and cost metrics
+
+**Qualifications:**
+
+- Degree in Information Technology, Business, or equivalent professional experience
+- Professional Scrum Product Owner (PSPO I) or Certified Scrum Product Owner (CSPO)
+- ITIL 4 Foundation; HPE sales/technical fundamentals (e.g., HPE ATP) beneficial
+- 5+ years in infrastructure roles with 2+ years in product ownership or service ownership
+
 ## Key Technologies
 
 - HPE ProLiant servers (DL, ML series)

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -91,6 +91,18 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 - Cloud and on-premises Linux strategy
 - Open source governance and risk management
 
+## Key Technologies
+
+- Enterprise Linux distributions (RHEL, SUSE, Ubuntu LTS)
+- Lifecycle and patch management (Red Hat Satellite, SUSE Manager)
+- Configuration management and automation (Ansible, Infrastructure as Code)
+- Security hardening and compliance scanning (OpenSCAP, CIS benchmarks)
+- Container runtimes and virtualization support on Linux
+- Cloud Linux services and hybrid image pipelines
+- Monitoring and observability platforms for Linux estates
+- Open source governance and license compliance tooling
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the Linux platform service backlog

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -91,6 +91,18 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 - Performance optimization and capacity planning
 - Windows Server version adoption and migration
 
+## Key Technologies
+
+- Windows Server platform (current and N-1 versions, Server Core)
+- Hybrid management (Azure Arc, Windows Admin Center)
+- Endpoint and server configuration management (Microsoft Configuration Manager, Group Policy)
+- Patching and update orchestration (WSUS, Azure Update Manager)
+- PowerShell automation and Desired State Configuration
+- Failover Clustering and high-availability technologies
+- Monitoring and capacity management platforms
+- Windows Server licensing and cost management tooling
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the Windows Server platform backlog

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -96,6 +96,18 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 - Innovation and continuous improvement in HPC capabilities
 - User support models and knowledge transfer for research teams
 
+## Key Technologies
+
+- HPC cluster platforms and job schedulers (Slurm, PBS Pro)
+- Parallel file systems (Lustre, IBM Storage Scale/GPFS)
+- GPU and accelerator ecosystems (NVIDIA CUDA, multi-instance GPU)
+- MPI and parallel programming frameworks
+- HPC containerization (Apptainer/Singularity)
+- Cloud HPC services (Azure CycleCloud, AWS ParallelCluster)
+- Utilization, chargeback, and value reporting for HPC investments
+- Scientific application stacks and environment module systems
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the HPC platform backlog

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -72,7 +72,7 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 - **Working Knowledge required:** Azure Arc integration and hybrid cloud connectivity for Hyper-V workloads, Shielded VMs and Virtualization-Based Security (VBS) for platform security design, Azure migration tooling for Hyper-V workload cloud integration
 - **Awareness level expected:** Azure Stack HCI next-generation capabilities and evolving licensing, Emerging containerisation and Kubernetes integration on Windows Server
 
-## Key Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -74,7 +74,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 - **Working Knowledge required:** Hyper-V Replica and Azure Site Recovery for DR planning and SLA governance, Software-Defined Networking product capabilities in Windows Server, PowerShell automation and self-service provisioning pattern design
 - **Awareness level expected:** Azure Arc and Azure Stack HCI platform convergence roadmap, VMware and Nutanix competitive positioning for infrastructure strategy context
 
-## Key Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|
@@ -109,6 +109,18 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 - Backup and business continuity services
 - Licensing optimization for Windows environments
 - Virtualization automation and efficiency
+
+## Key Technologies
+
+- Microsoft Hyper-V and Failover Clustering
+- System Center Virtual Machine Manager (SCVMM)
+- Azure Stack HCI and hybrid Azure services
+- Windows Admin Center for platform management
+- Azure Site Recovery for DR and business continuity
+- PowerShell automation and self-service provisioning frameworks
+- Monitoring and capacity management platforms (System Center Operations Manager)
+- Windows Server and virtualization licensing management tooling
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -77,7 +77,7 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 - **Working Knowledge required:** Windows Admin Center extensions and performance monitoring integration, Azure Arc and Azure Stack HCI hybrid connectivity for management, Microsoft Endpoint Configuration Manager integration for VM guest OS management
 - **Awareness level expected:** Azure Stack HCI next-generation capabilities and ARC-enabled services, Windows Server container integration and Kubernetes on Hyper-V emerging patterns
 
-## Key Interactions
+## Interactions with Other Roles
 
 | Role | Nature of Interaction |
 |---|---|

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -81,6 +81,18 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 - Data protection strategies
 - Licensing optimization and cost management
 
+## Key Technologies
+
+- Nutanix AOS and AHV hypervisor
+- Nutanix Prism Element and Prism Central management
+- Nutanix data protection and DR (Leap, protection domains)
+- Nutanix Flow for microsegmentation and security policy
+- Capacity planning and runway analytics in Prism
+- REST API and automation frameworks for the Nutanix stack
+- Migration tooling (Nutanix Move)
+- Licensing and cost management for hyperconverged estates
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Managing the Nutanix infrastructure backlog

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -88,3 +88,64 @@ The VMware Architect designs and oversees the organization's virtualization infr
 - VMware Horizon VDI
 - VMware Site Recovery Manager
 - vSphere Replication and High Availability
+
+## Typical Day-to-Day Activities
+
+- Leading design sessions and reviews for vSphere, vSAN, and NSX platform changes
+- Developing and maintaining virtualization standards, reference architectures, and design records
+- Planning platform upgrades and migrations, including VMware Cloud Foundation adoption and Broadcom licensing impact assessment
+- Reviewing platform capacity, performance, and availability trends and directing optimisation work
+- Aligning with storage, network, security, and cloud architects on integrated infrastructure designs
+- Advising engineers on complex implementation questions and reviewing engineering designs
+- Evaluating VMware roadmap developments and alternatives, and briefing IT leadership on platform strategy
+- Participating in architecture review boards and DR/HA design and test planning
+
+## Key Performance Indicators
+
+- Virtualization platform availability against agreed service levels
+- VM consolidation ratio and infrastructure cost-efficiency trend
+- Adoption rate of approved design standards in new deployments
+- Disaster recovery test success rate for VMware-hosted workloads
+- Platform version currency (vSphere/vSAN/NSX at N or N-1)
+- NSX microsegmentation coverage of eligible workloads
+- Workload migration success rate for platform transformation programmes
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Hybrid or remote-first; architecture and design work is largely location-independent
+- **Collaboration Tools:** Microsoft Teams, SharePoint, architecture diagramming tools, and Git-based design documentation repositories
+- **On-Site Requirements:** Occasional presence for design workshops, data centre reviews, major migration cutovers, and vendor engagements
+- **Time Zone Flexibility:** Standard business hours with occasional flexibility for global stakeholder and vendor sessions
+- **On-Call / Operational Demands:** Not part of a standing on-call rota; engaged as design authority during major virtualization platform incidents
+
+## Career Development Path
+
+**From (typical previous roles):**
+
+- VMware Senior Engineer
+- Infrastructure or Virtualization Engineer with design responsibility
+- Storage or Network Architect broadening into SDDC scope
+
+**To (typical next roles):**
+
+- Cloud Lead Architect or Cloud Principal Architect
+- Enterprise Architect
+- Technical Area Lead or Chapter Lead (Cloud, Platform & Infrastructure)
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- VMware Certified Advanced Professional — Data Center Virtualization Design (VCAP-DCV Design)
+- VMware Certified Design Expert (VCDX) — aspirational, for senior design authority credibility
+- VMware Certified Professional — Data Center Virtualization (VCP-DCV) as the maintained baseline
+
+**Complementary Certifications:**
+
+- VCAP — Network Virtualization (NSX) for software-defined networking depth
+- Microsoft Certified: Azure Administrator Associate (AZ-104) and Azure VMware Solution learning paths for hybrid strategy
+- TOGAF Foundation for architecture method grounding
+
+**Learning Resources and Communities:**
+
+- Broadcom/VMware technical documentation and release notes, VMware Hands-on Labs, VMUG community and VMware Explore conference content, and virtualization design blogs and reference architectures

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -99,6 +99,18 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 - Security and compliance integration
 - VMware license optimization
 
+## Key Technologies
+
+- VMware vSphere, ESXi, and vCenter Server
+- VMware vSAN and software-defined storage
+- VMware NSX network virtualization
+- VMware Aria Operations (vRealize) for capacity and performance management
+- Site Recovery Manager for DR orchestration
+- PowerCLI and API-driven automation frameworks
+- Virtualization security, compliance, and hardening tooling
+- VMware licensing and cost optimization tooling
+- Product backlog and roadmap management tools (Azure DevOps, Jira)
+
 ## Typical Day-to-Day Activities
 
 - Conducting backlog refinement sessions with technical teams
@@ -147,7 +159,7 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 - IT Portfolio Manager
 - Enterprise Platform Product Owner
 
-## Recommended Background
+## Recommended Certifications & Learning Paths
 
 - ITIL or other service management framework certification
 - Professional Scrum Product Owner (PSPO) or similar


### PR DESCRIPTION
## What changed

All 43 files failing `npm run validate` now pass — **0 errors, 0 warnings** across the full catalog. Three fix categories:

**1. Heading normalization (content was present, heading was a variant):**
- `## Interactions` / `## Key Interactions` → `## Interactions with Other Roles` (20 files: FinOps, leadership, devops, security, virtualization)
- `## KPIs and Success Metrics` → `## Key Performance Indicators`, `## Career Progression` → `## Career Development Path`, `## Tools and Technologies` → `## Key Technologies` (c_suite + client_platform, 8 files)
- `## Recommended Background` → `## Recommended Certifications & Learning Paths` (vmware_product_owner — content was cert recommendations)

**2. Authored missing sections:**
- `## Key Technologies` for 11 product-owner files (they only had `Key Focus Areas`, which lists focus domains, not technologies — kept both)
- 4 exec-level sections (Key Technologies, Typical Day-to-Day, Remote Work, Recommended Certifications) × 4 c_suite roles, styled after the passing `svp_technology.md`
- Key Decisions & Accountabilities + 3 sections × 4 client_platform roles (+ Business Impact for the PO)
- Remaining gaps in `kubernetes_engineer`, `observability_engineer`, both HPE server hardware roles, and `vmware_architect`

**3. Metadata:** added the `Domain` field to `cloud_cost_optimization_standards.md` (reference doc, CRLF-preserving edit).

**CI:** removed `continue-on-error: true` from the validate job — role content validation is now a blocking check, per the note left in ci.yml.

## Verification
- `npm run validate`: **0 files with errors, 0 with warnings** (was 43/0)
- `npm test`: 19/19 pass
- `npm run check-counts`: README counts still match (216 roles, 32 domains, 7 chapters)
- `markdownlint-cli2 'Roles/**/*.md'`: 0 errors across 220 files
- Viewer verified in browser: CEO role renders all 15 sections incl. the 4 new ones; `/api/roles` returns 216 roles / 32 domains; no console errors

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)