### PR TITLE
fix: polish authored content from issue #7 batch (closes #44)

### DIFF
--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -100,7 +100,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 - Budgeting and forecasting platforms
 - Commitment management tooling (Reserved Instances, Savings Plans, Committed Use Discounts)
 - BI and reporting platforms (Power BI, Tableau) for unit-economics dashboards
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Cloud provider pricing, TCO, and what-if modelling tools
 - Collaboration and stakeholder reporting tools
 
 ## Typical Day-to-Day Activities

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -101,7 +101,7 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 - Enterprise backup integration for file data protection
 - Storage automation and orchestration frameworks
 - ITSM and self-service request portals (ServiceNow)
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Data replication and migration tooling for file estates (Qumulo continuous replication)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -101,7 +101,7 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 - Backup compliance, retention, and reporting dashboards
 - License usage tracking and optimization tooling
 - ITSM integration for backup/restore request workflows (ServiceNow)
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Commvault REST API and workflow automation for service integration
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -93,7 +93,7 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 - RPO/RTO monitoring, reporting, and compliance dashboards
 - Recovery testing and application recovery orchestration tooling
 - ITSM integration for backup/restore request workflows (ServiceNow)
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- HPE InfoSight predictive analytics for SimpliVity estates
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -99,7 +99,7 @@ The Database Product Owner manages the portfolio of database platforms and data 
 - Database-as-a-service and self-service provisioning frameworks
 - Database security, auditing, and compliance tooling
 - License and cost management tooling for database estates
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Schema migration and database release tooling (Flyway, Liquibase)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -82,14 +82,23 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - HPE ATP - Server Solutions V5
 - HPE Product Certified - Server Solutions
-- HPE Product Certified - OneView
 - CompTIA Server+
-- ITIL Foundation
+
+**Complementary Certifications:**
+
+- HPE Product Certified - OneView
+- ITIL 4 Foundation
 - Microsoft Certified: Windows Server
 - VMware Certified Technical Associate (VCTA)
 - Data Center certification basics
+
+**Learning Resources and Communities:**
+
+- HPE education portal (education.hpe.com), HPE TechLibrary technical documentation (techlibrary.hpe.com), CompTIA Server+ study resources, HPE Smart Update Manager documentation, and HPE InfoSight for Servers learning content
 
 ## Interactions with Other Roles
 
@@ -130,14 +139,6 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 - Standard build implementation quality
 - User satisfaction with hardware support
 - Knowledge sharing and collaboration
-
-**Complementary Certifications:**
-
-- HPE Product Certified - OneView, CompTIA Server+, and ITIL 4 Foundation
-
-**Learning Resources and Communities:**
-
-- HPE education portal (education.hpe.com), HPE TechLibrary technical documentation (techlibrary.hpe.com), CompTIA Server+ study resources, HPE Smart Update Manager documentation, and HPE InfoSight for Servers learning content
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -101,7 +101,7 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 - Cloud Linux services and hybrid image pipelines
 - Monitoring and observability platforms for Linux estates
 - Open source governance and license compliance tooling
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Golden-image build pipelines (Packer, cloud image factories)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -101,7 +101,7 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 - Failover Clustering and high-availability technologies
 - Monitoring and capacity management platforms
 - Windows Server licensing and cost management tooling
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Backup and DR integration for Windows Server estates (Azure Site Recovery, enterprise backup)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -106,7 +106,7 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 - Cloud HPC services (Azure CycleCloud, AWS ParallelCluster)
 - Utilization, chargeback, and value reporting for HPC investments
 - Scientific application stacks and environment module systems
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- HPC user portals and self-service gateways (Open OnDemand)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -120,7 +120,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 - PowerShell automation and self-service provisioning frameworks
 - Monitoring and capacity management platforms (System Center Operations Manager)
 - Windows Server and virtualization licensing management tooling
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Azure Automation and System Center Orchestrator for VM lifecycle workflows
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -91,7 +91,7 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 - REST API and automation frameworks for the Nutanix stack
 - Migration tooling (Nutanix Move)
 - Licensing and cost management for hyperconverged estates
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- Nutanix Sizer and capacity forecasting tools
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -109,7 +109,7 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 - PowerCLI and API-driven automation frameworks
 - Virtualization security, compliance, and hardening tooling
 - VMware licensing and cost optimization tooling
-- Product backlog and roadmap management tools (Azure DevOps, Jira)
+- VMware Skyline proactive support and estate health analytics
 
 ## Typical Day-to-Day Activities
 


### PR DESCRIPTION
## What changed

Two quality fixes for content authored in PR #42 (see #44):

1. **hpe_server_hardware_engineer.md** — the `## Recommended Certifications & Learning Paths` section is now in the house Core/Complementary/Learning Resources format. The `**Complementary Certifications:**` and `**Learning Resources and Communities:**` blocks stranded inside the Key Performance Indicators section were absorbed into it (duplicated certs deduped) and removed from the KPI section.
2. **11 product-owner files** — the identical `Product backlog and roadmap management tools (Azure DevOps, Jira)` bullet is replaced with one platform-specific technology per file (e.g. Nutanix Sizer, VMware Skyline, Open OnDemand, Flyway/Liquibase, Packer image pipelines), matching the domain-technical convention of passing PO files.

## Verification
- `grep -rl 'Product backlog and roadmap management tools' Roles`: 0 files
- `npm run validate`: 0 errors / 0 warnings
- `markdownlint-cli2 'Roles/**/*.md'`: 0 errors (220 files)
- `npm test`: 19/19 pass
- hpe file: no orphaned bold blocks outside their section (heading scan clean)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)