### PR TITLE
test: extract pure view logic and cover it with node:test (closes #27)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>IT Roles Library</title>
     <script src="/vendor/marked.min.js"></script>
     <script src="/vendor/purify.min.js"></script>
+    <script src="/viewer-logic.js"></script>
     <style>
         :root {
             --bg-primary:      #f0f2f5;
@@ -983,6 +984,12 @@
 </div>
 
 <script>
+    // ── Shared pure view logic (viewer-logic.js, also under node:test) ──
+    const {
+        STALE_MONTHS, LEVEL_ORDER, LEVEL_SHORT,
+        escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
+    } = ViewerLogic;
+
     // ── State ───────────────────────────────────────────
     let allDomains  = {};
     let activeFile  = null;
@@ -995,7 +1002,6 @@
     let activeDocTitle    = null;  // title of the currently open reference doc
     let restoringView     = false; // true while goBack() is restoring a view (suppresses history push)
     const backStack       = [];    // navigation history for the Back button
-    const STALE_MONTHS = 12;   // roles not reviewed within this many months are flagged stale
     const openChapters = new Set(); // chapters explicitly expanded by user
 
     // ── Reference documents ──────────────────────────────
@@ -1101,21 +1107,6 @@
         virtualization:                          '📦',
     };
 
-    // ── HTML escaping ─────────────────────────────────────
-    // Full escape for both text nodes and attribute values. Every dynamic
-    // string interpolated into a template literal that becomes innerHTML
-    // must pass through this (role titles, levels, domain labels, search
-    // input, review dates) — markdown bodies go through renderMarkdown()
-    // instead.
-    function escapeHtml(str) {
-        return String(str)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
-
     // ── Markdown rendering ────────────────────────────────
     // marked does not sanitize its output; any HTML in a .md file passes
     // straight through. All rendered markdown is sanitized with DOMPurify
@@ -1123,26 +1114,6 @@
     // cannot execute script in the viewer.
     function renderMarkdown(md) {
         return DOMPurify.sanitize(marked.parse(md));
-    }
-
-    // ── Badge class for role level ───────────────────────
-    function badgeClass(level) {
-        if (level === 'CEO')                 return 'b-ceo';
-        if (level === 'CTO')                 return 'b-cto';
-        if (level === 'CIO')                 return 'b-cio';
-        if (level === 'CFO')                 return 'b-cfo';
-        if (level === 'SVP')                 return 'b-svp';
-        if (level === 'CISO')                return 'b-ciso';
-        if (level === 'Product Area Lead')   return 'b-pal';
-        if (level === 'Technical Area Lead') return 'b-tal';
-        if (level === 'Chapter Lead')        return 'b-cl';
-        if (level === 'Principal Architect') return 'b-prin';
-        if (level === 'Lead Architect')      return 'b-lead';
-        if (level === 'Architect')           return 'b-arch';
-        if (level === 'Senior Engineer')     return 'b-sen';
-        if (level === 'Product Owner')       return 'b-po';
-        if (level.includes('Reliability'))   return 'b-sre';
-        return 'b-eng';
     }
 
     // ── Load roles from API ──────────────────────────────
@@ -1484,21 +1455,6 @@
         document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
     }
 
-    // Resolve a Markdown link href relative to the currently open doc/role.
-    function resolveDocHref(href) {
-        href = href.replace(/^\.\//, '');
-        if (href.startsWith('Roles/') || href.startsWith('docs/')) return href;
-        const baseFile = activeDoc || activeFile || '';
-        const baseDir  = baseFile.includes('/') ? baseFile.slice(0, baseFile.lastIndexOf('/')) : '';
-        const stack    = baseDir ? baseDir.split('/') : [];
-        for (const seg of href.split('/')) {
-            if (seg === '' || seg === '.') continue;
-            if (seg === '..') stack.pop();
-            else stack.push(seg);
-        }
-        return stack.join('/');
-    }
-
     // ── Shared: build role header HTML ───────────────────
     function buildHeader(title, level, domainLabel, lastReviewed, slot) {
         const isCompare = slot === 'B';
@@ -1733,47 +1689,9 @@
     }
 
     // ── Matrix view ───────────────────────────────────────
+    // (LEVEL_ORDER / LEVEL_SHORT come from viewer-logic.js)
     let matrixOpen = false;
     let staleOpen  = false;
-
-    const LEVEL_ORDER = [
-        'CEO',
-        'CTO',
-        'CIO',
-        'CFO',
-        'SVP',
-        'CISO',
-        'Product Area Lead',
-        'Technical Area Lead',
-        'Chapter Lead',
-        'Principal Architect',
-        'Lead Architect',
-        'Architect',
-        'Senior Engineer',
-        'Engineer',
-        'Reliability Engineer',
-        'Product Owner',
-    ];
-
-    // Short column header labels
-    const LEVEL_SHORT = {
-        'CEO':                 'CEO',
-        'CTO':                 'CTO',
-        'CIO':                 'CIO',
-        'CFO':                 'CFO',
-        'SVP':                 'SVP',
-        'CISO':                'CISO',
-        'Product Area Lead':   'PAL',
-        'Technical Area Lead': 'TAL',
-        'Chapter Lead':        'Ch Lead',
-        'Principal Architect': 'Principal',
-        'Lead Architect':      'Lead Arch',
-        'Architect':           'Architect',
-        'Senior Engineer':     'Sr Engineer',
-        'Engineer':            'Engineer',
-        'Reliability Engineer':'SRE',
-        'Product Owner':       'Prod Owner',
-    };
 
     function renderMatrix(domains) {
         // Collect which levels actually exist in the data
@@ -1877,30 +1795,8 @@
         }
     }
 
-    // ── Stale-role tracking: flag roles with no review date or one
-    //    older than STALE_MONTHS ───────────────────────────
-    function monthsSinceReview(lastReviewed, now = new Date()) {
-        if (!lastReviewed) return null;
-        const m = lastReviewed.match(/^(\d{4})-(\d{2})$/);
-        if (!m) return null;
-        const reviewed = new Date(Number(m[1]), Number(m[2]) - 1, 1);
-        return (now.getFullYear() - reviewed.getFullYear()) * 12 + (now.getMonth() - reviewed.getMonth());
-    }
-
-    function computeStaleRoles(domains) {
-        const now   = new Date();
-        const stale = [];
-        for (const domain of Object.values(domains)) {
-            for (const role of domain.roles) {
-                const monthsSince = monthsSinceReview(role.lastReviewed, now);
-                if (monthsSince === null || monthsSince >= STALE_MONTHS) {
-                    stale.push({ ...role, domainLabel: domain.label, monthsSince });
-                }
-            }
-        }
-        return stale.sort((a, b) => (b.monthsSince ?? 9999) - (a.monthsSince ?? 9999));
-    }
-
+    // ── Stale-role tracking ───────────────────────────────
+    // (monthsSinceReview / computeStaleRoles come from viewer-logic.js)
     function updateStaleButton(domains) {
         const stale = computeStaleRoles(domains);
         const btn   = document.getElementById('staleBtn');
@@ -1987,7 +1883,7 @@
         e.preventDefault();
 
         // Resolve the link relative to the currently open doc/role, then route.
-        const clean = resolveDocHref(href);
+        const clean = resolveDocHref(href, activeDoc || activeFile || '');
 
         if (clean.startsWith('Roles/')) {
             // Look up role metadata from allDomains

--- a/server.js
+++ b/server.js
@@ -115,6 +115,16 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // Serve the shared pure view-logic module (also consumed by node:test)
+  if (url.pathname === '/viewer-logic.js') {
+    try {
+      send(res, 200, 'text/javascript; charset=utf-8', fs.readFileSync(path.join(ROOT, 'viewer-logic.js')));
+    } catch {
+      send(res, 404, 'text/plain', 'Asset not found');
+    }
+    return;
+  }
+
   // Serve vendored third-party assets (e.g. marked.min.js) — no CDN dependency
   if (url.pathname.startsWith('/vendor/')) {
     const rel = url.pathname.slice('/vendor/'.length);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -86,6 +86,13 @@ test('GET /api/doc rejects path traversal via ..', async () => {
   assert.equal(res.status, 400);
 });
 
+test('GET /viewer-logic.js serves the shared view-logic module', async () => {
+  const res = await request('/viewer-logic.js');
+  assert.equal(res.status, 200);
+  assert.match(res.headers['content-type'], /javascript/);
+  assert.match(res.body, /ViewerLogic/);
+});
+
 test('GET /vendor/marked.min.js serves the vendored library', async () => {
   const res = await request('/vendor/marked.min.js');
   assert.equal(res.status, 200);

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    STALE_MONTHS,
+    LEVEL_ORDER,
+    LEVEL_SHORT,
+    escapeHtml,
+    badgeClass,
+    monthsSinceReview,
+    computeStaleRoles,
+    resolveDocHref,
+} = require('../viewer-logic');
+
+const { CANONICAL_LEVELS } = require('../roleMeta');
+
+// ── escapeHtml ────────────────────────────────────────────
+
+test('escapeHtml escapes all five significant characters', () => {
+    assert.equal(
+        escapeHtml(`<img src="x" onerror='alert(1)' & more>`),
+        '&lt;img src=&quot;x&quot; onerror=&#39;alert(1)&#39; &amp; more&gt;'
+    );
+});
+
+test('escapeHtml leaves plain text unchanged and coerces non-strings', () => {
+    assert.equal(escapeHtml('Cloud Cost Optimization Engineer'), 'Cloud Cost Optimization Engineer');
+    assert.equal(escapeHtml(42), '42');
+    assert.equal(escapeHtml(null), 'null');
+});
+
+// ── badgeClass ────────────────────────────────────────────
+
+test('every canonical level maps to a badge class (only Engineer uses the default)', () => {
+    // The default 'b-eng' fallthrough shipped the #18 CFO bug: a canonical
+    // level with no explicit branch silently renders green.
+    for (const level of CANONICAL_LEVELS) {
+        const cls = badgeClass(level);
+        if (level === 'Engineer') {
+            assert.equal(cls, 'b-eng');
+        } else {
+            assert.notEqual(cls, 'b-eng', `canonical level "${level}" falls through to the Engineer badge`);
+        }
+    }
+});
+
+test('canonical levels get distinct badge classes', () => {
+    const classes = CANONICAL_LEVELS.map(badgeClass);
+    assert.equal(new Set(classes).size, classes.length);
+});
+
+// ── LEVEL_ORDER / LEVEL_SHORT parity ─────────────────────
+
+test('LEVEL_ORDER covers every canonical level (a missing one drops roles from the matrix)', () => {
+    // #46: CFO was absent from LEVEL_ORDER, so the matrix silently rendered
+    // 215 of 216 roles.
+    for (const level of CANONICAL_LEVELS) {
+        assert.ok(LEVEL_ORDER.includes(level), `canonical level "${level}" missing from LEVEL_ORDER`);
+    }
+});
+
+test('LEVEL_SHORT has a label for every LEVEL_ORDER entry', () => {
+    for (const level of LEVEL_ORDER) {
+        assert.ok(Object.hasOwn(LEVEL_SHORT, level), `LEVEL_SHORT missing "${level}"`);
+    }
+});
+
+// ── monthsSinceReview ────────────────────────────────────
+
+test('monthsSinceReview returns null for missing or malformed values', () => {
+    assert.equal(monthsSinceReview(null), null);
+    assert.equal(monthsSinceReview(undefined), null);
+    assert.equal(monthsSinceReview(''), null);
+    assert.equal(monthsSinceReview('2026'), null);
+    assert.equal(monthsSinceReview('07-2026'), null);
+    assert.equal(monthsSinceReview('2026-7'), null);
+    assert.equal(monthsSinceReview('garbage'), null);
+});
+
+test('monthsSinceReview computes whole months against a fixed now', () => {
+    const now = new Date(2026, 6, 15); // July 2026
+    assert.equal(monthsSinceReview('2026-07', now), 0);
+    assert.equal(monthsSinceReview('2026-01', now), 6);
+    assert.equal(monthsSinceReview('2025-07', now), 12); // exactly STALE_MONTHS
+    assert.equal(monthsSinceReview('2024-07', now), 24);
+});
+
+test('monthsSinceReview handles future review dates (negative months)', () => {
+    const now = new Date(2026, 6, 15);
+    assert.equal(monthsSinceReview('2026-12', now), -5);
+});
+
+// ── computeStaleRoles ────────────────────────────────────
+
+function fixtureDomains() {
+    return {
+        alpha: {
+            label: 'Alpha',
+            roles: [
+                { title: 'Fresh Role',    file: 'Roles/alpha/fresh.md',    level: 'Engineer', lastReviewed: '2026-06' },
+                { title: 'Boundary Role', file: 'Roles/alpha/boundary.md', level: 'Engineer', lastReviewed: '2025-07' },
+            ],
+        },
+        beta: {
+            label: 'Beta',
+            roles: [
+                { title: 'Never Reviewed', file: 'Roles/beta/never.md', level: 'Architect', lastReviewed: null },
+                { title: 'Ancient Role',   file: 'Roles/beta/old.md',   level: 'Architect', lastReviewed: '2020-01' },
+            ],
+        },
+    };
+}
+
+test('computeStaleRoles includes never-reviewed and >= staleMonths, excludes fresh', () => {
+    const now = new Date(2026, 6, 15);
+    const stale = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now);
+    const titles = stale.map(r => r.title);
+    assert.ok(!titles.includes('Fresh Role'));
+    assert.ok(titles.includes('Boundary Role'), 'exactly STALE_MONTHS old must count as stale');
+    assert.ok(titles.includes('Never Reviewed'));
+    assert.ok(titles.includes('Ancient Role'));
+});
+
+test('computeStaleRoles sorts never-reviewed first, then most overdue', () => {
+    const now = new Date(2026, 6, 15);
+    const stale = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now);
+    assert.deepEqual(stale.map(r => r.title), ['Never Reviewed', 'Ancient Role', 'Boundary Role']);
+});
+
+test('computeStaleRoles attaches the domain label to each entry', () => {
+    const now = new Date(2026, 6, 15);
+    const stale = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now);
+    assert.equal(stale.find(r => r.title === 'Never Reviewed').domainLabel, 'Beta');
+});
+
+test('computeStaleRoles respects a custom staleMonths threshold', () => {
+    const now = new Date(2026, 6, 15);
+    const stale = computeStaleRoles(fixtureDomains(), 1, now);
+    assert.ok(stale.some(r => r.title === 'Fresh Role'), 'one-month threshold flags last month\'s review');
+});
+
+// ── resolveDocHref ───────────────────────────────────────
+
+test('resolveDocHref passes repo-absolute hrefs through unchanged', () => {
+    assert.equal(resolveDocHref('Roles/devops/devops_engineer.md', 'docs/CHAPTERS_OVERVIEW.md'), 'Roles/devops/devops_engineer.md');
+    assert.equal(resolveDocHref('docs/SKILLS_PROGRESSION.md', 'Roles/devops/devops_engineer.md'), 'docs/SKILLS_PROGRESSION.md');
+    assert.equal(resolveDocHref('./docs/SKILLS_PROGRESSION.md', ''), 'docs/SKILLS_PROGRESSION.md');
+});
+
+test('resolveDocHref resolves siblings relative to the base file', () => {
+    assert.equal(resolveDocHref('ONBOARDING_TEMPLATE.md', 'docs/CHAPTERS_OVERVIEW.md'), 'docs/ONBOARDING_TEMPLATE.md');
+    assert.equal(resolveDocHref('./cloud_cost_optimization_standards.md', 'Roles/FinOps/finops_architect.md'), 'Roles/FinOps/cloud_cost_optimization_standards.md');
+});
+
+test('resolveDocHref resolves parent traversal from nested paths', () => {
+    assert.equal(resolveDocHref('../SKILLS_PROGRESSION.md', 'docs/chapters/data_ai.md'), 'docs/SKILLS_PROGRESSION.md');
+    assert.equal(resolveDocHref('../../docs/CHAPTERS_OVERVIEW.md', 'Roles/devops/devops_engineer.md'), 'docs/CHAPTERS_OVERVIEW.md');
+});
+
+test('resolveDocHref with no base file resolves from the repo root', () => {
+    assert.equal(resolveDocHref('README.md', ''), 'README.md');
+});

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -1,0 +1,146 @@
+// Pure view logic shared between the browser UI (index.html) and the
+// node:test suite (test/viewer-logic.test.js). UMD-ish: in the browser it
+// attaches to window.ViewerLogic; under Node it exports via module.exports.
+// Keep this file free of DOM access and application state — everything here
+// must stay callable from tests with plain data.
+(function (root, factory) {
+    'use strict';
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.ViewerLogic = factory();
+    }
+})(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    // Roles not reviewed within this many months are flagged stale.
+    const STALE_MONTHS = 12;
+
+    // Matrix column order. Must cover every canonical role level in
+    // roleMeta.js CANONICAL_LEVELS — a level missing here silently drops
+    // its roles from the matrix (see #46: CFO was absent).
+    const LEVEL_ORDER = [
+        'CEO',
+        'CTO',
+        'CIO',
+        'CFO',
+        'SVP',
+        'CISO',
+        'Product Area Lead',
+        'Technical Area Lead',
+        'Chapter Lead',
+        'Principal Architect',
+        'Lead Architect',
+        'Architect',
+        'Senior Engineer',
+        'Engineer',
+        'Reliability Engineer',
+        'Product Owner',
+    ];
+
+    // Short column header labels for the matrix.
+    const LEVEL_SHORT = {
+        'CEO':                 'CEO',
+        'CTO':                 'CTO',
+        'CIO':                 'CIO',
+        'CFO':                 'CFO',
+        'SVP':                 'SVP',
+        'CISO':                'CISO',
+        'Product Area Lead':   'PAL',
+        'Technical Area Lead': 'TAL',
+        'Chapter Lead':        'Ch Lead',
+        'Principal Architect': 'Principal',
+        'Lead Architect':      'Lead Arch',
+        'Architect':           'Architect',
+        'Senior Engineer':     'Sr Engineer',
+        'Engineer':            'Engineer',
+        'Reliability Engineer':'SRE',
+        'Product Owner':       'Prod Owner',
+    };
+
+    // Full escape for both text nodes and attribute values. Every dynamic
+    // string interpolated into a template literal that becomes innerHTML
+    // must pass through this — markdown bodies are sanitized with DOMPurify
+    // instead (renderMarkdown in index.html).
+    function escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    // Badge CSS class for a role level. Every canonical level must map to
+    // its own class — an unmapped level falls through to the Engineer
+    // green (that fallthrough shipped the #18 CFO bug).
+    function badgeClass(level) {
+        if (level === 'CEO')                 return 'b-ceo';
+        if (level === 'CTO')                 return 'b-cto';
+        if (level === 'CIO')                 return 'b-cio';
+        if (level === 'CFO')                 return 'b-cfo';
+        if (level === 'SVP')                 return 'b-svp';
+        if (level === 'CISO')                return 'b-ciso';
+        if (level === 'Product Area Lead')   return 'b-pal';
+        if (level === 'Technical Area Lead') return 'b-tal';
+        if (level === 'Chapter Lead')        return 'b-cl';
+        if (level === 'Principal Architect') return 'b-prin';
+        if (level === 'Lead Architect')      return 'b-lead';
+        if (level === 'Architect')           return 'b-arch';
+        if (level === 'Senior Engineer')     return 'b-sen';
+        if (level === 'Product Owner')       return 'b-po';
+        if (level.includes('Reliability'))   return 'b-sre';
+        return 'b-eng';
+    }
+
+    // Whole months between a YYYY-MM review stamp and now. Returns null for
+    // missing or malformed values (treated as "never reviewed" upstream).
+    function monthsSinceReview(lastReviewed, now = new Date()) {
+        if (!lastReviewed) return null;
+        const m = String(lastReviewed).match(/^(\d{4})-(\d{2})$/);
+        if (!m) return null;
+        const reviewed = new Date(Number(m[1]), Number(m[2]) - 1, 1);
+        return (now.getFullYear() - reviewed.getFullYear()) * 12 + (now.getMonth() - reviewed.getMonth());
+    }
+
+    // Roles with no review date or one at least staleMonths old, sorted
+    // most-overdue first (never-reviewed roles sort to the top).
+    function computeStaleRoles(domains, staleMonths = STALE_MONTHS, now = new Date()) {
+        const stale = [];
+        for (const domain of Object.values(domains)) {
+            for (const role of domain.roles) {
+                const monthsSince = monthsSinceReview(role.lastReviewed, now);
+                if (monthsSince === null || monthsSince >= staleMonths) {
+                    stale.push({ ...role, domainLabel: domain.label, monthsSince });
+                }
+            }
+        }
+        return stale.sort((a, b) => (b.monthsSince ?? 9999) - (a.monthsSince ?? 9999));
+    }
+
+    // Resolve a Markdown link href relative to the file it appears in.
+    // Repo-absolute hrefs (Roles/…, docs/…) pass through unchanged.
+    function resolveDocHref(href, baseFile = '') {
+        href = href.replace(/^\.\//, '');
+        if (href.startsWith('Roles/') || href.startsWith('docs/')) return href;
+        const baseDir = baseFile.includes('/') ? baseFile.slice(0, baseFile.lastIndexOf('/')) : '';
+        const stack   = baseDir ? baseDir.split('/') : [];
+        for (const seg of href.split('/')) {
+            if (seg === '' || seg === '.') continue;
+            if (seg === '..') stack.pop();
+            else stack.push(seg);
+        }
+        return stack.join('/');
+    }
+
+    return {
+        STALE_MONTHS,
+        LEVEL_ORDER,
+        LEVEL_SHORT,
+        escapeHtml,
+        badgeClass,
+        monthsSinceReview,
+        computeStaleRoles,
+        resolveDocHref,
+    };
+});


### PR DESCRIPTION
## What changed

Stacked on #49 (same index.html regions); base retargets to main when #49 merges.

Per the approach on #27 — without abandoning the single-file design:

- **`viewer-logic.js`** (new): pure functions + constants extracted from index.html — `escapeHtml`, `badgeClass`, `LEVEL_ORDER`/`LEVEL_SHORT`, `STALE_MONTHS`, `monthsSinceReview`, `computeStaleRoles`, `resolveDocHref`. UMD-ish: `window.ViewerLogic` in the browser, `module.exports` under Node. No DOM access, no app state — `resolveDocHref` takes its base file as a parameter now, `computeStaleRoles` takes threshold + clock.
- **server.js**: dedicated `/viewer-logic.js` route (same headers/CSP as everything else).
- **index.html**: loads the module and destructures it; inline definitions deleted. Still no build step — the app is now three first-party files instead of two.
- **test/viewer-logic.test.js** (17 tests): badge mapping for every `CANONICAL_LEVEL` with the Engineer-only default (**fails on #18-style bugs**), badge distinctness, `LEVEL_ORDER`/`LEVEL_SHORT` parity with roleMeta (**fails on #46-style bugs**), `monthsSinceReview` null/malformed/boundary/future, `computeStaleRoles` inclusion boundary (exactly 12 months = stale), never-reviewed-first sorting, domain-label attachment, custom threshold, `resolveDocHref` absolute/sibling/parent-traversal/rootless cases, `escapeHtml` all five chars + coercion.
- **test/server.test.js**: +1 test for the new route.

## Verification
- `npm test`: **37/37** pass (was 19).
- Browser smoke on the restarted server: ViewerLogic loads (8 exports), sidebar renders, matrix shows 216 chips, role opens, stale panel renders, Back/Home work, no console errors.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)