### PR TITLE
test: cover validate-roles.js with fixture-based tests (closes #19)

### DIFF
--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { listRoleFiles, validateFile, REQUIRED_SECTIONS } = require('../validate-roles');
+
+// All fixtures are generated into a temp tree at runtime — nothing under
+// Roles/ or test/ is touched, so `npm run validate` and markdownlint on the
+// repo are unaffected.
+let tmpRoot;   // <tmp>/roles-fixture — plays the part of Roles/
+let domainDir; // <tmp>/roles-fixture/testdomain
+
+test.before(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-fixture-'));
+  domainDir = path.join(tmpRoot, 'testdomain');
+  fs.mkdirSync(domainDir);
+});
+
+test.after(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// A minimal role file that satisfies every validator check. The Domain
+// value matches the folder name (no DOMAIN_LABELS entry for 'testdomain',
+// so the canonical label falls back to the folder name).
+function completeRole({ except = null, transform = null } = {}) {
+  const sections = REQUIRED_SECTIONS
+    .filter(s => s.name !== except)
+    .map(s => `## ${s.name}\n\nContent for ${s.name}.\n`)
+    .join('\n');
+  let content = `# Test Role
+
+| Field | Value |
+|---|---|
+| **Domain** | testdomain |
+| **Role Level** | Engineer |
+| **Last Reviewed** | 2026-07 |
+
+${sections}`;
+  if (transform) content = transform(content);
+  return content;
+}
+
+function writeFixture(name, content) {
+  const file = path.join(domainDir, name);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+// ── happy path ───────────────────────────────────────────
+
+test('a well-formed role file passes with 0 errors and 0 warnings', () => {
+  const file = writeFixture('complete.md', completeRole());
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  assert.deepEqual(r.warnings, []);
+  assert.equal(r.skipped, false);
+});
+
+// ── required sections ────────────────────────────────────
+
+test('each required section individually missing produces exactly that error', () => {
+  for (const section of REQUIRED_SECTIONS) {
+    const file = writeFixture('missing-section.md', completeRole({ except: section.name }));
+    const r = validateFile(file, tmpRoot);
+    assert.deepEqual(r.errors, [`Missing section: ## ${section.name}`],
+      `expected a single missing-section error for "${section.name}"`);
+  }
+});
+
+test('historical heading spellings are accepted as equivalents', () => {
+  // "Relationships & Collaboration" is an accepted alternative for
+  // "Interactions with Other Roles".
+  const file = writeFixture('alt-heading.md', completeRole({
+    transform: c => c.replace('## Interactions with Other Roles', '## Relationships & Collaboration'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+});
+
+// ── metadata errors ──────────────────────────────────────
+
+test('missing H1 title is an error', () => {
+  const file = writeFixture('no-title.md', completeRole({ transform: c => c.replace(/^# Test Role\n/, '') }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.errors.includes('Missing H1 title (# Role Title)'));
+});
+
+test('missing Domain metadata is an error', () => {
+  const file = writeFixture('no-domain.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Domain\*\*.*\n/, '') }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.errors.includes('Missing **Domain** metadata field'));
+});
+
+test('missing Role Level metadata is an error', () => {
+  const file = writeFixture('no-level.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Role Level\*\*.*\n/, '') }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.errors.includes('Missing **Role Level** metadata field'));
+});
+
+test('missing Last Reviewed metadata is an error', () => {
+  const file = writeFixture('no-reviewed.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Last Reviewed\*\*.*\n/, '') }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.errors.includes('Missing **Last Reviewed** metadata field'));
+});
+
+// ── warnings (not errors) ────────────────────────────────
+
+test('a non-canonical Role Level is a warning, not an error', () => {
+  const file = writeFixture('odd-level.md', completeRole({
+    transform: c => c.replace('| **Role Level** | Engineer |', '| **Role Level** | Grand Wizard |'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  assert.equal(r.warnings.length, 1);
+  assert.match(r.warnings[0], /Grand Wizard.*not in the canonical level vocabulary/);
+});
+
+test('a malformed Last Reviewed value is a warning, not an error', () => {
+  const file = writeFixture('odd-date.md', completeRole({
+    transform: c => c.replace('| **Last Reviewed** | 2026-07 |', '| **Last Reviewed** | July 2026 |'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  assert.ok(r.warnings.some(w => w.includes('not in YYYY-MM format')));
+});
+
+test('a Domain not matching the folder label is a warning, not an error', () => {
+  const file = writeFixture('wrong-domain.md', completeRole({
+    transform: c => c.replace('| **Domain** | testdomain |', '| **Domain** | Somewhere Else |'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  assert.ok(r.warnings.some(w => w.includes('does not match the canonical label')));
+});
+
+// ── reference docs ───────────────────────────────────────
+
+test('a _standards.md reference doc is skipped after title/domain checks', () => {
+  const file = writeFixture('cost_standards.md',
+    '# Cost Standards\n\n| Field | Value |\n|---|---|\n| **Domain** | testdomain |\n\n## Overview\n\nStandards text.\n');
+  const r = validateFile(file, tmpRoot);
+  assert.equal(r.skipped, true);
+  assert.deepEqual(r.errors, []);
+});
+
+test('a reference doc still requires title and Domain', () => {
+  const file = writeFixture('bare_standards.md', 'Just some text without title or metadata.\n');
+  const r = validateFile(file, tmpRoot);
+  assert.equal(r.skipped, true);
+  assert.ok(r.errors.includes('Missing H1 title (# Role Title)'));
+  assert.ok(r.errors.includes('Missing **Domain** metadata field'));
+});
+
+// ── listRoleFiles ────────────────────────────────────────
+
+test('listRoleFiles finds .md files in domain folders and skips READMEs', () => {
+  const listRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-list-'));
+  fs.mkdirSync(path.join(listRoot, 'dom'));
+  fs.writeFileSync(path.join(listRoot, 'dom', 'a_role.md'), '# A');
+  fs.writeFileSync(path.join(listRoot, 'dom', 'README.md'), '# readme');
+  fs.writeFileSync(path.join(listRoot, 'toplevel.md'), '# ignored'); // not in a domain folder
+  const files = listRoleFiles(listRoot).map(f => path.basename(f));
+  assert.deepEqual(files, ['a_role.md']);
+  fs.rmSync(listRoot, { recursive: true, force: true });
+});
+
+// ── CLI exit codes (spawned against a fixture tree) ─────
+
+function runCli(rolesDir, args = []) {
+  return spawnSync(process.execPath, [path.join(__dirname, '..', 'validate-roles.js'), ...args], {
+    env: { ...process.env, ROLES_DIR: rolesDir },
+    encoding: 'utf8',
+  });
+}
+
+test('CLI exits 0 on a clean tree, and warnings do not fail a normal run', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-'));
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'), completeRole());
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'warny.md'), completeRole({
+    transform: c => c.replace('| **Role Level** | Engineer |', '| **Role Level** | Grand Wizard |'),
+  }));
+  const normal = runCli(cliRoot);
+  assert.equal(normal.status, 0, normal.stdout);
+  assert.match(normal.stdout, /1 file\(s\) with warnings/);
+
+  const strict = runCli(cliRoot, ['--strict']);
+  assert.equal(strict.status, 1, '--strict must promote warnings to a failing exit code');
+
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+
+test('CLI exits 1 when a file has errors', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-err-'));
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'broken.md'),
+    completeRole({ except: 'Business Impact' }));
+  const run = runCli(cliRoot);
+  assert.equal(run.status, 1);
+  assert.match(run.stdout, /Missing section: ## Business Impact/);
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -12,7 +12,9 @@ const path = require('path');
 const { parseMeta, KNOWN_LEVELS, normalizeLevel, REFERENCE_DOC_PATTERN, DOMAIN_LABELS } = require('./roleMeta');
 
 const ROOT       = __dirname;
-const ROLES_DIR  = path.join(ROOT, 'Roles');
+// ROLES_DIR env override exists for the test suite, which points the
+// validator at a fixture tree; normal runs always use Roles/.
+const ROLES_DIR  = process.env.ROLES_DIR ? path.resolve(process.env.ROLES_DIR) : path.join(ROOT, 'Roles');
 const STRICT     = process.argv.includes('--strict');
 
 // Required section headings. Each entry accepts one or more historical
@@ -33,11 +35,11 @@ const REQUIRED_SECTIONS = [
   { name: 'Recommended Certifications & Learning Paths', patterns: [/^##\s+Recommended Certifications (&|and) Learning Paths/im] },
 ];
 
-function listRoleFiles() {
+function listRoleFiles(rolesDir = ROLES_DIR) {
   const files = [];
-  for (const entry of fs.readdirSync(ROLES_DIR, { withFileTypes: true })) {
+  for (const entry of fs.readdirSync(rolesDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    const domainPath = path.join(ROLES_DIR, entry.name);
+    const domainPath = path.join(rolesDir, entry.name);
     for (const f of fs.readdirSync(domainPath)) {
       if (f.endsWith('.md') && f !== 'README.md') {
         files.push(path.join(domainPath, f));
@@ -47,8 +49,8 @@ function listRoleFiles() {
   return files.sort();
 }
 
-function validateFile(filePath) {
-  const rel     = path.relative(ROOT, filePath).replace(/\\/g, '/');
+function validateFile(filePath, rolesDir = ROLES_DIR) {
+  const rel     = path.relative(path.dirname(rolesDir), filePath).replace(/\\/g, '/');
   const content = fs.readFileSync(filePath, 'utf8');
   const meta    = parseMeta(content);
   const errors  = [];
@@ -96,7 +98,7 @@ function validateFile(filePath) {
 
 function main() {
   const files   = listRoleFiles();
-  const results = files.map(validateFile);
+  const results = files.map(f => validateFile(f));
 
   const withErrors   = results.filter(r => r.errors.length > 0);
   const withWarnings = results.filter(r => r.warnings.length > 0);
@@ -123,4 +125,10 @@ function main() {
   }
 }
 
-main();
+// Only run the CLI when executed directly (`node validate-roles.js`).
+// The test suite requires this module and calls the exported functions.
+if (require.main === module) {
+  main();
+}
+
+module.exports = { listRoleFiles, validateFile, REQUIRED_SECTIONS };


### PR DESCRIPTION
## What changed

- **validate-roles.js refactored for testability** (behavior unchanged for normal runs):
  - `require.main` guard — CLI runs only when executed directly, matching the server.js pattern.
  - Exports `listRoleFiles`, `validateFile`, `REQUIRED_SECTIONS`; both functions take an optional `rolesDir`.
  - `ROLES_DIR` env override so the test suite can spawn the real CLI against a fixture tree.
- **test/validate-roles.test.js** (15 tests). All fixtures are generated in `os.tmpdir()` at runtime — nothing committed under `Roles/` or `test/`, so `npm run validate` and markdownlint see no new files. Coverage per the issue checklist:
  - well-formed file → 0 errors / 0 warnings
  - each required section individually missing → exactly that error (loop over `REQUIRED_SECTIONS`)
  - accepted historical heading variant (`Relationships & Collaboration`)
  - missing H1 / Domain / Role Level / Last Reviewed → errors
  - non-canonical level, malformed review date, domain-label mismatch → warnings, not errors
  - `_standards.md` reference docs skipped, but still require title + Domain
  - `listRoleFiles` skips READMEs and top-level files
  - spawned CLI: clean tree exits 0 with warnings; `--strict` exits 1 on warnings; errors exit 1

## Bug found by the tests
The new optional-parameter signature exposed a real footgun the tests caught immediately: `files.map(validateFile)` leaked the map index into `rolesDir`. Fixed to `files.map(f => validateFile(f))`.

## Verification
- `npm test`: **34/34** pass (19 existing + 15 new).
- `npm run validate` on the real tree: unchanged — 0 errors, 0 warnings, 216 role files + 1 reference doc.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)