### PR TITLE
feat: distribution charts for chapters and levels (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Distribution charts on the welcome screen (#14).** Two horizontal bar
+  charts — roles per chapter and roles per level (seniority order) — built
+  on the vendored Chart.js, first UI use of the charting libraries staged
+  in v1.2.0. Data shaping (`rolesPerChapter`, `rolesPerLevel`) lives in
+  `viewer-logic.js` with tests, including a guard that unknown levels are
+  appended rather than silently dropped (the #46 failure mode). Single
+  accent-blue hue validated for contrast and color-vision safety on both
+  themes; charts re-render on theme toggle, and each ships an
+  `aria-label` summary plus a "View as table" fallback (#17).
 - `SECURITY.md`: security policy with private reporting instructions, scope,
   and response expectations.
 - `.github/dependabot.yml`: weekly grouped update PRs for GitHub Actions and

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>IT Roles Library</title>
     <script src="/vendor/marked.min.js"></script>
     <script src="/vendor/purify.min.js"></script>
+    <script src="/vendor/chart.umd.min.js"></script>
     <script src="/viewer-logic.js"></script>
     <style>
         :root {
@@ -431,6 +432,58 @@
         [data-theme="dark"] .stat-card .val.accent-arch { color: #c09ee0; }
         [data-theme="dark"] .stat-card .val.accent-lead { color: #90d0ff; }
         [data-theme="dark"] .stat-card .val.accent-eng  { color: #6bcf7f; }
+
+        /* ── Distribution charts (welcome screen) ─────────── */
+        .charts-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 18px;
+            margin-top: 28px;
+            justify-content: center;
+            text-align: left;
+        }
+        .chart-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-lg);
+            padding: 18px 20px 12px;
+            box-shadow: var(--shadow-sm);
+            margin: 0;
+            flex: 1 1 380px;
+            max-width: 560px;
+            min-width: 320px;
+        }
+        .chart-title {
+            font-size: 0.9em;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 10px;
+        }
+        .chart-canvas-wrap { position: relative; width: 100%; }
+        .chart-canvas-chapters { height: 240px; }
+        .chart-canvas-levels   { height: 420px; }
+        .chart-table summary {
+            cursor: pointer;
+            font-size: 0.78em;
+            color: var(--text-muted);
+            margin-top: 8px;
+            padding: 4px 0;
+        }
+        .chart-table summary:hover { color: var(--accent-blue); }
+        .chart-table table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.82em;
+            margin-top: 6px;
+        }
+        .chart-table th, .chart-table td {
+            text-align: left;
+            padding: 4px 8px;
+            border-bottom: 1px solid var(--border-color);
+            color: var(--text-secondary);
+        }
+        .chart-table td:last-child { text-align: right; color: var(--text-primary); font-weight: 600; }
+        @media print { .charts-row { display: none; } }
 
         @keyframes fadeInUp {
             from { opacity:0; transform: translateY(16px); }
@@ -946,6 +999,30 @@
             <h2>Select a role to view</h2>
             <p>Choose a domain and role from the sidebar to read the full role definition.</p>
             <div class="stats-cards" id="statsCards"></div>
+
+            <!-- Distribution charts (rendered once role data is loaded) -->
+            <div class="charts-row" id="chartsRow" hidden>
+                <figure class="chart-card">
+                    <figcaption class="chart-title">Roles per chapter</figcaption>
+                    <div class="chart-canvas-wrap chart-canvas-chapters">
+                        <canvas id="chapterChart"></canvas>
+                    </div>
+                    <details class="chart-table">
+                        <summary>View as table</summary>
+                        <div id="chapterChartTable"></div>
+                    </details>
+                </figure>
+                <figure class="chart-card">
+                    <figcaption class="chart-title">Roles per level</figcaption>
+                    <div class="chart-canvas-wrap chart-canvas-levels">
+                        <canvas id="levelChart"></canvas>
+                    </div>
+                    <details class="chart-table">
+                        <summary>View as table</summary>
+                        <div id="levelChartTable"></div>
+                    </details>
+                </figure>
+            </div>
         </div>
 
         <!-- Role(s) grid — single column normally, two columns when comparing -->
@@ -988,6 +1065,7 @@
     const {
         STALE_MONTHS, LEVEL_ORDER, LEVEL_SHORT,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
+        rolesPerChapter, rolesPerLevel,
     } = ViewerLogic;
 
     // ── State ───────────────────────────────────────────
@@ -1123,6 +1201,7 @@
             allDomains = await res.json();
             renderSidebar(allDomains);
             renderWelcomeStats(allDomains);
+            renderDistributionCharts(allDomains);
             updateStaleButton(allDomains);
         } catch {
             document.getElementById('sidebarNav').innerHTML =
@@ -1175,6 +1254,88 @@
                 <div class="lbl">${lbl}</div>
             </div>
         `).join('');
+    }
+
+    // ── Distribution charts (welcome screen) ─────────────
+    // Two horizontal bar charts fed by viewer-logic's rolesPerChapter /
+    // rolesPerLevel. Single sequential hue (--accent-blue, validated for
+    // contrast + CVD on both surfaces); identity comes from the axis
+    // labels, never from color. Each chart carries an aria-label summary
+    // and a real <details> table fallback (WCAG, #17).
+    const chartInstances = {};
+
+    function chartTheme() {
+        const css = getComputedStyle(document.documentElement);
+        return {
+            bar:   css.getPropertyValue('--accent-blue').trim() || '#0078D4',
+            grid:  css.getPropertyValue('--border-color').trim() || 'rgba(0,0,0,0.08)',
+            text:  css.getPropertyValue('--text-secondary').trim() || '#555770',
+        };
+    }
+
+    function renderBarChart(canvasId, tableId, rows, labelKey) {
+        const theme = chartTheme();
+        const labels = rows.map(r => r[labelKey]);
+        const counts = rows.map(r => r.count);
+
+        chartInstances[canvasId]?.destroy();
+        chartInstances[canvasId] = new Chart(document.getElementById(canvasId), {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    data: counts,
+                    backgroundColor: theme.bar,
+                    borderRadius: { topRight: 4, bottomRight: 4 },
+                    borderSkipped: 'start',
+                    maxBarThickness: 14,
+                    categoryPercentage: 0.82,
+                }],
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { display: false }, // single series — the title names it
+                    tooltip: {
+                        displayColors: false,
+                        callbacks: { label: ctx => `${ctx.parsed.x} role${ctx.parsed.x !== 1 ? 's' : ''}` },
+                    },
+                },
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        grid:   { color: theme.grid },
+                        border: { display: false },
+                        ticks:  { color: theme.text, precision: 0 },
+                    },
+                    y: {
+                        grid:   { display: false },
+                        border: { display: false },
+                        ticks:  { color: theme.text, autoSkip: false },
+                    },
+                },
+            },
+        });
+
+        // Screen-reader summary on the canvas + a real table fallback.
+        const canvas = document.getElementById(canvasId);
+        canvas.setAttribute('role', 'img');
+        canvas.setAttribute('aria-label',
+            `Bar chart. ${rows.map(r => `${r[labelKey]}: ${r.count}`).join(', ')}.`);
+        document.getElementById(tableId).innerHTML = `
+            <table>
+                <thead><tr><th>${labelKey === 'label' ? 'Chapter' : 'Level'}</th><th>Roles</th></tr></thead>
+                <tbody>${rows.map(r => `<tr><td>${escapeHtml(r[labelKey])}</td><td>${r.count}</td></tr>`).join('')}</tbody>
+            </table>`;
+    }
+
+    function renderDistributionCharts(domains) {
+        if (typeof Chart === 'undefined') return; // chart lib failed to load — stat cards still work
+        document.getElementById('chartsRow').hidden = false;
+        renderBarChart('chapterChart', 'chapterChartTable', rolesPerChapter(domains, CHAPTERS), 'label');
+        renderBarChart('levelChart', 'levelChartTable', rolesPerLevel(domains), 'level');
     }
 
     // ── Render sidebar ───────────────────────────────────
@@ -1686,6 +1847,9 @@
         const btn = document.getElementById('themeBtn');
         btn.textContent = isDark ? '🌙 Dark' : '☀️ Light';
         btn.setAttribute('aria-pressed', String(!isDark));
+        // Charts read their colors from CSS variables at render time, so a
+        // theme flip means a re-render against the new surface.
+        if (Object.keys(allDomains).length) renderDistributionCharts(allDomains);
     }
 
     // ── Matrix view ───────────────────────────────────────

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -11,6 +11,8 @@ const {
     badgeClass,
     monthsSinceReview,
     computeStaleRoles,
+    rolesPerLevel,
+    rolesPerChapter,
     resolveDocHref,
 } = require('../viewer-logic');
 
@@ -161,4 +163,76 @@ test('resolveDocHref resolves parent traversal from nested paths', () => {
 
 test('resolveDocHref with no base file resolves from the repo root', () => {
     assert.equal(resolveDocHref('README.md', ''), 'README.md');
+});
+
+// ── rolesPerLevel ────────────────────────────────────────
+
+function distributionFixture() {
+    return {
+        alpha: {
+            label: 'Alpha',
+            roles: [
+                { title: 'A1', file: 'Roles/alpha/a1.md', level: 'Engineer' },
+                { title: 'A2', file: 'Roles/alpha/a2.md', level: 'Architect' },
+                { title: 'A3', file: 'Roles/alpha/a3.md', level: 'Engineer' },
+            ],
+        },
+        beta: {
+            label: 'Beta',
+            roles: [
+                { title: 'B1', file: 'Roles/beta/b1.md', level: 'CEO' },
+                { title: 'B2', file: 'Roles/beta/b2.md', level: 'Engineer' },
+            ],
+        },
+    };
+}
+
+test('rolesPerLevel counts roles across domains in seniority order', () => {
+    const dist = rolesPerLevel(distributionFixture());
+    assert.deepEqual(dist, [
+        { level: 'CEO',       count: 1 },
+        { level: 'Architect', count: 1 },
+        { level: 'Engineer',  count: 3 },
+    ]);
+});
+
+test('rolesPerLevel appends unknown levels instead of dropping them', () => {
+    // #46 lesson: a level absent from the order list must never silently
+    // remove its roles from a visualization.
+    const domains = {
+        x: { label: 'X', roles: [
+            { title: 'X1', file: 'Roles/x/x1.md', level: 'Engineer' },
+            { title: 'X2', file: 'Roles/x/x2.md', level: 'Grand Wizard' },
+        ] },
+    };
+    const dist = rolesPerLevel(domains);
+    assert.deepEqual(dist, [
+        { level: 'Engineer',     count: 1 },
+        { level: 'Grand Wizard', count: 1 },
+    ]);
+});
+
+test('rolesPerLevel total matches the role count', () => {
+    const dist = rolesPerLevel(distributionFixture());
+    assert.equal(dist.reduce((n, d) => n + d.count, 0), 5);
+});
+
+// ── rolesPerChapter ──────────────────────────────────────
+
+test('rolesPerChapter sums domain counts per chapter in chapter order', () => {
+    const chapters = {
+        first:  { label: 'First Chapter',  domains: ['alpha'] },
+        second: { label: 'Second Chapter', domains: ['beta', 'missing_domain'] },
+    };
+    const dist = rolesPerChapter(distributionFixture(), chapters);
+    assert.deepEqual(dist, [
+        { key: 'first',  label: 'First Chapter',  count: 3 },
+        { key: 'second', label: 'Second Chapter', count: 2 },
+    ]);
+});
+
+test('rolesPerChapter counts a chapter with no present domains as 0', () => {
+    const chapters = { empty: { label: 'Empty', domains: ['nope'] } };
+    assert.deepEqual(rolesPerChapter(distributionFixture(), chapters),
+        [{ key: 'empty', label: 'Empty', count: 0 }]);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -118,6 +118,33 @@
         return stale.sort((a, b) => (b.monthsSince ?? 9999) - (a.monthsSince ?? 9999));
     }
 
+    // Role counts per canonical level, in seniority order (LEVEL_ORDER).
+    // Levels present in the data but missing from the order are appended at
+    // the end rather than dropped — a chart must never silently lose roles
+    // the way the matrix once lost the CFO (#46).
+    function rolesPerLevel(domains, levelOrder = LEVEL_ORDER) {
+        const counts = new Map();
+        for (const domain of Object.values(domains)) {
+            for (const role of domain.roles) {
+                counts.set(role.level, (counts.get(role.level) || 0) + 1);
+            }
+        }
+        const ordered = levelOrder.filter(l => counts.has(l));
+        const extras  = [...counts.keys()].filter(l => !levelOrder.includes(l)).sort();
+        return [...ordered, ...extras].map(level => ({ level, count: counts.get(level) }));
+    }
+
+    // Role counts per chapter, in the chapters object's own order.
+    // `chapters` is the CHAPTERS mapping from index.html: key → { label,
+    // domains: [domainKey, …] }. Domains absent from the data count as 0.
+    function rolesPerChapter(domains, chapters) {
+        return Object.entries(chapters).map(([key, chapter]) => ({
+            key,
+            label: chapter.label,
+            count: chapter.domains.reduce((n, d) => n + (domains[d]?.roles.length || 0), 0),
+        }));
+    }
+
     // Resolve a Markdown link href relative to the file it appears in.
     // Repo-absolute hrefs (Roles/…, docs/…) pass through unchanged.
     function resolveDocHref(href, baseFile = '') {
@@ -141,6 +168,8 @@
         badgeClass,
         monthsSinceReview,
         computeStaleRoles,
+        rolesPerLevel,
+        rolesPerChapter,
         resolveDocHref,
     };
 });


### PR DESCRIPTION
## What changed

- **Welcome screen gains two charts** below the stat cards: *Roles per chapter* (7 bars) and *Roles per level* (16 bars, seniority order) — horizontal bars, the honest form for magnitude comparison across many long-named categories (a 7-slice donut and 16 categorical hues both fail readability; issue text allowed either form).
- **Data shaping in `viewer-logic.js`**: `rolesPerChapter(domains, chapters)` and `rolesPerLevel(domains, levelOrder)`, +5 tests (57 total). `rolesPerLevel` appends unknown levels instead of dropping them — a chart can never silently lose roles the way the matrix lost the CFO (#46); a test pins this.
- **Chart.js finally earns its vendor slot** (staged since #12): `/vendor/chart.umd.min.js` script tag, no CDN, same CSP.
- **Design**: single sequential hue (`--accent-blue` #0078D4) — **validated** with the dataviz palette checker: PASS on lightness band, chroma floor, and ≥3:1 contrast against both surfaces (#ffffff light, #161b22 dark). Thin 14px bars with 4px rounded data-ends, recessive grid from `--border-color`, no legend (single series — the title names it), tooltips on hover.
- **Accessibility (#17 applied)**: each canvas gets `role=img` with a full data summary `aria-label`; each chart has a keyboard-operable `<details>` "View as table" with a real table. Identity comes from axis labels, never color.
- **Theme-aware**: colors read from CSS variables at render; theme toggle re-renders both charts.

## Verification (live)
- Both charts render; chapter bars sum to 216 and level bars sum to 216 (no lost roles).
- Level order CEO → Product Owner; CFO row present in chart and table.
- Dark mode screenshot verified — ticks/grid/bars legible on the dark card.
- Table fallback opens, 16 rows, summary natively focusable.
- No console errors; `npm test` **57/57**; validate 0/0; markdownlint clean.
- CHANGELOG entry included (no post-merge drift PR this time).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)