### PR TITLE
feat: organisation chart view (closes #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Organisation chart view (#11).** New "🌳 Org" header toggle renders the
+  live hierarchy as an ECharts tree (first UI use of the vendored ECharts):
+  leadership line (CEO → C-suite/SVP → area leads → chapters) flowing into
+  Chapters → Domains → Roles, with expand/collapse, pan/zoom, and
+  click-to-open on any role, chapter-lead, or executive node. The tree is
+  built by a pure `buildOrgTree()` in `viewer-logic.js` whose tests pin the
+  invariant that **every role appears exactly once** — unplaced leadership
+  roles group under "Cross-cutting Leadership" instead of vanishing. Ships
+  a keyboard-operable "View as list" fallback (#17), re-renders on theme
+  toggle, and is mutually exclusive with the Matrix and Stale views.
 - **Distribution charts on the welcome screen (#14).** Two horizontal bar
   charts — roles per chapter and roles per level (seniority order) — built
   on the vendored Chart.js, first UI use of the charting libraries staged

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <script src="/vendor/marked.min.js"></script>
     <script src="/vendor/purify.min.js"></script>
     <script src="/vendor/chart.umd.min.js"></script>
+    <script src="/vendor/echarts.min.js"></script>
     <script src="/viewer-logic.js"></script>
     <style>
         :root {
@@ -484,6 +485,24 @@
         }
         .chart-table td:last-child { text-align: right; color: var(--text-primary); font-weight: 600; }
         @media print { .charts-row { display: none; } }
+
+        /* ── Org chart view ─────────────────────────────────── */
+        .org-canvas {
+            width: 100%;
+            height: max(480px, calc(100vh - 320px));
+            background: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-md);
+        }
+        .org-list ul { list-style: none; padding-left: 20px; margin: 4px 0; }
+        .org-list > ul { padding-left: 0; }
+        .org-list li { padding: 2px 0; color: var(--text-secondary); font-size: 0.88em; }
+        .org-list .org-node-label { font-weight: 700; color: var(--text-primary); }
+        .org-list [data-file] {
+            cursor: pointer;
+            color: var(--accent-blue);
+        }
+        .org-list [data-file]:hover { text-decoration: underline; }
 
         @keyframes fadeInUp {
             from { opacity:0; transform: translateY(16px); }
@@ -969,6 +988,7 @@
         <button class="btn-ghost" id="backBtn" onclick="goBack()" aria-label="Go back to the previous view" style="display:none">← Back</button>
         <button class="btn-ghost" id="staleBtn" onclick="toggleStalePanel()" aria-pressed="false" aria-label="Show roles overdue for review" style="display:none"></button>
         <button class="btn-ghost" id="matrixBtn" onclick="toggleMatrix()" aria-pressed="false" aria-label="Toggle role matrix view">📊 Matrix</button>
+        <button class="btn-ghost" id="orgBtn" onclick="toggleOrg()" aria-pressed="false" aria-label="Toggle organisation chart view">🌳 Org</button>
         <button class="btn-ghost" id="themeBtn" onclick="toggleTheme()" aria-pressed="false" aria-label="Toggle dark mode">🌙 Dark</button>
     </div>
 </header>
@@ -1048,6 +1068,23 @@
         <!-- Stale-roles view (roles overdue for review) -->
         <div class="matrix-view" id="staleView"></div>
 
+        <!-- Organisation chart view -->
+        <div class="matrix-view" id="orgView">
+            <div class="matrix-header">
+                <div>
+                    <h2>🌳 Organisation Chart</h2>
+                    <p>Leadership line and Chapters → Domains → Roles. Click a node to expand or collapse it,
+                       click a role to open it; drag to pan, scroll to zoom.</p>
+                </div>
+            </div>
+            <div id="orgChartCanvas" class="org-canvas" role="img"
+                 aria-label="Organisation chart. A text version is available below under 'View as list'."></div>
+            <details class="chart-table">
+                <summary>View as list</summary>
+                <div id="orgListFallback" class="org-list"></div>
+            </details>
+        </div>
+
         <!-- Doc view (reference documents) -->
         <div class="doc-view" id="docView">
             <div class="role-card doc-card" id="docHeader"></div>
@@ -1065,7 +1102,7 @@
     const {
         STALE_MONTHS, LEVEL_ORDER, LEVEL_SHORT,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
-        rolesPerChapter, rolesPerLevel,
+        rolesPerChapter, rolesPerLevel, buildOrgTree,
     } = ViewerLogic;
 
     // ── State ───────────────────────────────────────────
@@ -1338,6 +1375,142 @@
         renderBarChart('levelChart', 'levelChartTable', rolesPerLevel(domains), 'level');
     }
 
+    // ── Org chart view (ECharts tree) ─────────────────────
+    let orgOpen  = false;
+    let orgChart = null; // ECharts instance, disposed on re-render
+
+    // Decorate the pure buildOrgTree() output with per-kind display hints
+    // and per-node labels for ECharts.
+    function orgDisplayNode(node) {
+        const kindColor = {
+            exec:    '#764ba2',
+            lead:    '#005a9e',
+            chapter: '#0078D4',
+            domain:  '#17a2b8',
+            group:   '#8e8ea0',
+            role:    '#0078D4',
+        };
+        const out = {
+            name: node.name,
+            kind: node.kind,
+            file: node.file || null,
+            value: node.count || undefined,
+            itemStyle: { color: kindColor[node.kind] || kindColor.role },
+            children: (node.children || []).map(orgDisplayNode),
+        };
+        if (node.kind === 'chapter' && node.count) out.name = `${node.name} (${node.count})`;
+        if (node.kind === 'domain'  && node.count) out.name = `${node.name} (${node.count})`;
+        return out;
+    }
+
+    function renderOrgChart() {
+        if (typeof echarts === 'undefined') return;
+        const theme = chartTheme();
+        const tree  = buildOrgTree(allDomains, CHAPTERS);
+
+        orgChart?.dispose();
+        orgChart = echarts.init(document.getElementById('orgChartCanvas'));
+        orgChart.setOption({
+            tooltip: {
+                trigger: 'item',
+                formatter: p => {
+                    const d = p.data;
+                    if (d.kind === 'chapter') return `${escapeHtml(p.name)}<br>Chapter — click to open its lead role`;
+                    if (d.kind === 'domain')  return `${escapeHtml(p.name)}<br>Domain — click to expand`;
+                    if (d.file)               return `${escapeHtml(p.name)}<br>Click to open this role`;
+                    return escapeHtml(p.name);
+                },
+            },
+            series: [{
+                type: 'tree',
+                data: [orgDisplayNode(tree)],
+                orient: 'LR',
+                roam: true,
+                initialTreeDepth: 2,
+                expandAndCollapse: true,
+                symbol: 'circle',
+                symbolSize: 9,
+                lineStyle: { color: theme.grid, width: 1.5, curveness: 0.5 },
+                label: {
+                    color: theme.text,
+                    fontSize: 12,
+                    position: 'left',
+                    verticalAlign: 'middle',
+                    align: 'right',
+                    distance: 6,
+                },
+                leaves: { label: { position: 'right', align: 'left' } },
+                emphasis: { focus: 'descendant' },
+                animationDuration: 300,
+                animationDurationUpdate: 400,
+            }],
+        });
+
+        // Role and chapter-lead nodes open the role view; branch nodes
+        // expand/collapse natively.
+        orgChart.on('click', params => {
+            const d = params.data;
+            if (!d || !d.file) return;
+            if (d.kind === 'role' || d.kind === 'exec' || d.kind === 'lead' || d.kind === 'chapter') {
+                const m = findRoleMeta(d.file);
+                openRole(d.file, m.title, m.level, m.domainLabel);
+            }
+        });
+
+        // Accessible fallback: the same tree as a nested list.
+        document.getElementById('orgListFallback').innerHTML = orgListHtml(tree);
+    }
+
+    function orgListHtml(node) {
+        const label = node.file
+            ? `<span data-file="${escapeHtml(node.file)}" role="button" tabindex="0">${escapeHtml(node.name)}</span>`
+            : `<span class="org-node-label">${escapeHtml(node.name)}</span>`;
+        const meta = node.leadTitle && !node.file ? '' :
+            node.leadTitle ? ` — lead: ${escapeHtml(node.leadTitle)}` : '';
+        const kids = (node.children || []).map(c => orgListHtml(c)).join('');
+        return `<ul><li>${label}${meta}${kids ? kids : ''}</li></ul>`;
+    }
+
+    function toggleOrg() {
+        orgOpen = !orgOpen;
+        const ov  = document.getElementById('orgView');
+        const btn = document.getElementById('orgBtn');
+        btn.setAttribute('aria-pressed', String(orgOpen));
+
+        if (orgOpen) {
+            document.getElementById('welcomeState').style.display = 'none';
+            document.getElementById('chapterView').style.display  = 'none';
+            document.getElementById('rolesGrid').style.display    = 'none';
+            document.getElementById('docView').style.display      = 'none';
+            activeDoc = null;
+            ov.classList.add('show');
+            btn.style.background = 'rgba(255,255,255,0.3)';
+            btn.style.borderColor = 'rgba(255,255,255,0.6)';
+            renderOrgChart();
+
+            // Org, matrix, and stale views are mutually exclusive
+            if (matrixOpen) {
+                matrixOpen = false;
+                document.getElementById('matrixView').classList.remove('show');
+                const mb = document.getElementById('matrixBtn');
+                mb.style.background = ''; mb.style.borderColor = ''; mb.setAttribute('aria-pressed', 'false');
+            }
+            if (staleOpen) {
+                staleOpen = false;
+                document.getElementById('staleView').classList.remove('show');
+                document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
+            }
+        } else {
+            ov.classList.remove('show');
+            btn.style.background = '';
+            btn.style.borderColor = '';
+            if (!activeFile) document.getElementById('welcomeState').style.display = '';
+        }
+    }
+
+    // Keep the ECharts canvas sized to its container.
+    window.addEventListener('resize', () => orgChart?.resize());
+
     // ── Render sidebar ───────────────────────────────────
     function renderSidebar(domains, filter = '') {
         const q   = filter.toLowerCase();
@@ -1474,6 +1647,7 @@
         document.getElementById('rolesGrid').style.display    = 'none';
         document.getElementById('matrixView').classList.remove('show');
         document.getElementById('staleView').classList.remove('show');
+        document.getElementById('orgView').classList.remove('show');
         document.getElementById('docView').style.display      = 'none';
         document.getElementById('welcomeState').style.display = 'none';
 
@@ -1605,15 +1779,19 @@
         updateBackBtn();
     }
 
-    // Close the matrix and stale panels (used when opening a role/doc/chapter).
+    // Close the matrix, stale, and org panels (used when opening a role/doc/chapter).
     function closePanels() {
         matrixOpen = false;
         staleOpen  = false;
+        orgOpen    = false;
         document.getElementById('matrixView').classList.remove('show');
         document.getElementById('staleView').classList.remove('show');
+        document.getElementById('orgView').classList.remove('show');
         const mb = document.getElementById('matrixBtn');
         mb.style.background = ''; mb.style.borderColor = ''; mb.setAttribute('aria-pressed', 'false');
         document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
+        const ob = document.getElementById('orgBtn');
+        ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
     }
 
     // ── Shared: build role header HTML ───────────────────
@@ -1753,6 +1931,12 @@
         staleOpen = false;
         document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
 
+        document.getElementById('orgView').classList.remove('show');
+        orgOpen = false;
+        document.getElementById('orgBtn').style.background  = '';
+        document.getElementById('orgBtn').style.borderColor = '';
+        document.getElementById('orgBtn').setAttribute('aria-pressed', 'false');
+
         renderSidebar(allDomains, document.getElementById('searchInput').value);
 
         const docView = document.getElementById('docView');
@@ -1850,6 +2034,7 @@
         // Charts read their colors from CSS variables at render time, so a
         // theme flip means a re-render against the new surface.
         if (Object.keys(allDomains).length) renderDistributionCharts(allDomains);
+        if (orgOpen) renderOrgChart();
     }
 
     // ── Matrix view ───────────────────────────────────────
@@ -1946,8 +2131,14 @@
             renderMatrix(allDomains);
             renderSidebar(allDomains, document.getElementById('searchInput').value);
 
-            // Matrix and stale panel are mutually exclusive
+            // Matrix, stale, and org panels are mutually exclusive
             if (staleOpen) { staleOpen = false; document.getElementById('staleView').classList.remove('show'); document.getElementById('staleBtn').setAttribute('aria-pressed', 'false'); }
+            if (orgOpen) {
+                orgOpen = false;
+                document.getElementById('orgView').classList.remove('show');
+                const ob = document.getElementById('orgBtn');
+                ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
+            }
         } else {
             // Restore normal content
             document.getElementById('rolesGrid').style.display = '';
@@ -1986,13 +2177,19 @@
             sv.classList.add('show');
             renderStalePanel(allDomains);
 
-            // Matrix and stale panel are mutually exclusive
+            // Matrix, stale, and org panels are mutually exclusive
             if (matrixOpen) {
                 matrixOpen = false;
                 document.getElementById('matrixView').classList.remove('show');
                 document.getElementById('matrixBtn').setAttribute('aria-pressed', 'false');
                 document.getElementById('matrixBtn').style.background  = '';
                 document.getElementById('matrixBtn').style.borderColor = '';
+            }
+            if (orgOpen) {
+                orgOpen = false;
+                document.getElementById('orgView').classList.remove('show');
+                const ob = document.getElementById('orgBtn');
+                ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
             }
         } else {
             sv.classList.remove('show');
@@ -2111,6 +2308,14 @@
         const chip = e.target.closest('.matrix-chip');
         if (!chip) return;
         openRole(chip.dataset.file, chip.dataset.title, chip.dataset.level, chip.dataset.domain);
+    });
+
+    // ── Org list-fallback clicks (single delegated listener) ─
+    document.getElementById('orgListFallback').addEventListener('click', e => {
+        const item = e.target.closest('[data-file]');
+        if (!item) return;
+        const m = findRoleMeta(item.dataset.file);
+        openRole(item.dataset.file, m.title, m.level, m.domainLabel);
     });
 
     // ── Keyboard activation for role="button" elements ───

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -13,6 +13,7 @@ const {
     computeStaleRoles,
     rolesPerLevel,
     rolesPerChapter,
+    buildOrgTree,
     resolveDocHref,
 } = require('../viewer-logic');
 
@@ -235,4 +236,94 @@ test('rolesPerChapter counts a chapter with no present domains as 0', () => {
     const chapters = { empty: { label: 'Empty', domains: ['nope'] } };
     assert.deepEqual(rolesPerChapter(distributionFixture(), chapters),
         [{ key: 'empty', label: 'Empty', count: 0 }]);
+});
+
+// ── buildOrgTree ─────────────────────────────────────────
+
+function orgFixture() {
+    const domains = {
+        c_suite: {
+            label: 'C-Suite',
+            roles: [
+                { title: 'Chief Executive Officer', file: 'Roles/c_suite/ceo.md', level: 'CEO' },
+                { title: 'Chief Technology Officer', file: 'Roles/c_suite/cto.md', level: 'CTO' },
+            ],
+        },
+        leadership: {
+            label: 'Leadership',
+            roles: [
+                { title: 'SVP of Technology', file: 'Roles/leadership/svp.md', level: 'SVP' },
+                { title: 'Product Area Lead', file: 'Roles/leadership/pal.md', level: 'Product Area Lead' },
+                { title: 'Alpha Chapter Lead', file: 'Roles/leadership/alpha_lead.md', level: 'Chapter Lead' },
+                { title: 'Community Leader', file: 'Roles/leadership/community.md', level: 'Senior Engineer' },
+            ],
+        },
+        devops: {
+            label: 'DevOps',
+            roles: [
+                { title: 'DevOps Engineer', file: 'Roles/devops/eng.md', level: 'Engineer' },
+                { title: 'DevOps Architect', file: 'Roles/devops/arch.md', level: 'Architect' },
+            ],
+        },
+    };
+    const chapters = {
+        alpha: { label: 'Alpha Chapter', domains: ['devops'], leadFile: 'Roles/leadership/alpha_lead.md' },
+        leadership_chapter: { label: 'Leadership', domains: ['c_suite', 'leadership'], leadFile: null },
+    };
+    return { domains, chapters };
+}
+
+function collectFiles(node, out = []) {
+    if (node.file) out.push(node.file);
+    for (const c of node.children || []) collectFiles(c, out);
+    return out;
+}
+
+test('buildOrgTree roots at the CEO with C-suite and SVP children', () => {
+    const { domains, chapters } = orgFixture();
+    const tree = buildOrgTree(domains, chapters);
+    assert.equal(tree.name, 'Chief Executive Officer');
+    assert.equal(tree.kind, 'exec');
+    const childNames = tree.children.map(c => c.name);
+    assert.ok(childNames.includes('Chief Technology Officer'));
+    assert.ok(childNames.includes('SVP of Technology'));
+});
+
+test('buildOrgTree hangs area leads, cross-cutting roles, and chapters under the SVP', () => {
+    const { domains, chapters } = orgFixture();
+    const tree = buildOrgTree(domains, chapters);
+    const svp = tree.children.find(c => c.name === 'SVP of Technology');
+    const names = svp.children.map(c => c.name);
+    assert.ok(names.includes('Product Area Lead'));
+    assert.ok(names.includes('Cross-cutting Leadership'), 'unplaced leadership roles are grouped');
+    assert.ok(names.includes('Alpha Chapter'));
+});
+
+test('buildOrgTree attaches the chapter lead and counts roles per chapter', () => {
+    const { domains, chapters } = orgFixture();
+    const tree = buildOrgTree(domains, chapters);
+    const chapter = tree.children.find(c => c.name === 'SVP of Technology')
+        .children.find(c => c.name === 'Alpha Chapter');
+    assert.equal(chapter.leadTitle, 'Alpha Chapter Lead');
+    assert.equal(chapter.count, 2);
+    assert.equal(chapter.children[0].name, 'DevOps');
+    assert.equal(chapter.children[0].children.length, 2);
+});
+
+test('buildOrgTree places every role exactly once', () => {
+    const { domains, chapters } = orgFixture();
+    const tree = buildOrgTree(domains, chapters);
+    const files = collectFiles(tree);
+    const allFiles = Object.values(domains).flatMap(d => d.roles.map(r => r.file)).sort();
+    assert.deepEqual([...files].sort(), allFiles);
+    assert.equal(new Set(files).size, files.length, 'no role may appear twice');
+});
+
+test('buildOrgTree falls back to a generic root when no CEO exists', () => {
+    const { domains, chapters } = orgFixture();
+    domains.c_suite.roles = domains.c_suite.roles.filter(r => r.level !== 'CEO');
+    const tree = buildOrgTree(domains, chapters);
+    assert.equal(tree.name, 'IT Organisation');
+    assert.equal(tree.kind, 'group');
+    assert.equal(collectFiles(tree).length, 7, 'all remaining roles still placed');
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -145,6 +145,92 @@
         }));
     }
 
+    // Build the org-chart tree: leadership line (CEO → C-suite/SVP →
+    // PAL/TAL → chapters) on top of the Chapters → Domains → Roles
+    // hierarchy. Pure data in, nested { name, kind, file?, count?,
+    // children? } out — the renderer decides how to draw it.
+    //
+    // Invariant: every role in `domains` appears exactly once — either as a
+    // node on the leadership line, a chapter-lead attachment, or a leaf
+    // under its domain. Roles must never be silently dropped (#46 lesson).
+    function buildOrgTree(domains, chapters) {
+        const allRoles = Object.entries(domains).flatMap(([key, d]) =>
+            d.roles.map(r => ({ ...r, domainKey: key, domainLabel: d.label })));
+        const used = new Set();
+        const take = pred => {
+            const hit = allRoles.find(r => !used.has(r.file) && pred(r));
+            if (hit) used.add(hit.file);
+            return hit || null;
+        };
+        const roleNode = (r, kind = 'role') =>
+            ({ name: r.title, kind, file: r.file, roleLevel: r.level });
+
+        // Leadership line
+        const ceo  = take(r => r.level === 'CEO');
+        const svp  = take(r => r.level === 'SVP');
+        const suite = ['CTO', 'CIO', 'CFO', 'CISO']
+            .map(lvl => take(r => r.level === lvl)).filter(Boolean);
+        const areaLeads = [];
+        for (;;) {
+            const lead = take(r => r.level === 'Product Area Lead' || r.level === 'Technical Area Lead');
+            if (!lead) break;
+            areaLeads.push(lead);
+        }
+
+        // Chapter nodes (the Leadership chapter IS the line above — skip any
+        // chapter whose domains are all consumed by leadership placement).
+        const chapterNodes = Object.entries(chapters)
+            .filter(([, ch]) => ch.domains.some(d => domains[d] && !['c_suite', 'leadership'].includes(d)))
+            .map(([key, ch]) => {
+                const lead = ch.leadFile
+                    ? take(r => r.file === ch.leadFile || r.file.replace(/\\/g, '/') === ch.leadFile)
+                    : null;
+                const domainNodes = ch.domains
+                    .filter(d => domains[d] && !['c_suite', 'leadership'].includes(d))
+                    .map(d => ({
+                        name: domains[d].label,
+                        kind: 'domain',
+                        count: domains[d].roles.length,
+                        children: domains[d].roles.map(r => {
+                            used.add(r.file);
+                            return roleNode(r);
+                        }),
+                    }));
+                return {
+                    name: ch.label,
+                    kind: 'chapter',
+                    file: lead ? lead.file : null,
+                    leadTitle: lead ? lead.title : null,
+                    count: domainNodes.reduce((n, d) => n + d.count, 0),
+                    children: domainNodes,
+                };
+            });
+
+        // Anything not yet placed (e.g. cross-cutting leadership roles)
+        const leftovers = allRoles.filter(r => !used.has(r.file));
+        const crossCutting = leftovers.length
+            ? [{
+                name: 'Cross-cutting Leadership',
+                kind: 'group',
+                count: leftovers.length,
+                children: leftovers.map(r => roleNode(r)),
+            }]
+            : [];
+
+        const svpNode = svp
+            ? { ...roleNode(svp, 'exec'), children: [...areaLeads.map(r => roleNode(r, 'lead')), ...crossCutting, ...chapterNodes] }
+            : null;
+
+        const rootChildren = [
+            ...suite.map(r => roleNode(r, 'exec')),
+            ...(svpNode ? [svpNode] : [...areaLeads.map(r => roleNode(r, 'lead')), ...crossCutting, ...chapterNodes]),
+        ];
+
+        return ceo
+            ? { ...roleNode(ceo, 'exec'), children: rootChildren }
+            : { name: 'IT Organisation', kind: 'group', children: rootChildren };
+    }
+
     // Resolve a Markdown link href relative to the file it appears in.
     // Repo-absolute hrefs (Roles/…, docs/…) pass through unchanged.
     function resolveDocHref(href, baseFile = '') {
@@ -170,6 +256,7 @@
         computeStaleRoles,
         rolesPerLevel,
         rolesPerChapter,
+        buildOrgTree,
         resolveDocHref,
     };
 });


### PR DESCRIPTION
## What changed

- **New "🌳 Org" header toggle** rendering the live hierarchy as an ECharts tree series (per the issue's recommendation — Chart.js cannot draw trees; ECharts 5.6.0 was vendored in v1.2.0 and gets its first UI use). Orientation left-to-right, `initialTreeDepth: 2`, expand/collapse on branch click, pan/zoom roam, per-kind node colors, tooltips.
- **Leadership line + hierarchy**: CEO root → C-suite (CTO/CIO/CFO/CISO) + SVP → PAL/TAL + 6 chapters → domains → 216 role leaves. Chapter nodes carry their Chapter Lead (click opens the lead role); leadership roles not on the line group under "Cross-cutting Leadership".
- **`buildOrgTree()` in viewer-logic.js** — pure, renderer-agnostic, 5 new tests (62 total). The load-bearing test pins the invariant **every role appears exactly once** in the tree; a missing-CEO fixture proves graceful fallback to a generic root.
- **Accessibility (#17)**: canvas has `role=img` + pointer to the fallback; "View as list" renders the same tree as a nested list where every role is a keyboard-operable `role=button` (reuses the #24 global Enter/Space handler) that opens the role.
- **View discipline**: Org, Matrix, and Stale are mutually exclusive; org closes correctly from `openRole`/`openDoc`/`openChapter`/Home; theme toggle re-renders against the new surface; window resize resizes the canvas.

## Verification (live)
- Tree root = Chief Executive Officer; children = CTO, CIO, CFO, CISO, SVP of Technology.
- **216 file-bearing nodes in the tree and 216 clickable entries in the list fallback** — invariant holds on real data.
- List-fallback click opens the role (verified: DevOps Architect) and closes the org view cleanly.
- Mutual exclusion verified both directions (org↔matrix) with button aria-pressed states.
- Canvas paint verified at pixel level in light **and** dark mode (~4.4% painted pixels; the Browser-pane screenshot tool was timing out because the backgrounded pane suspends rAF — forced `refreshImmediately()` proved the render; in a foreground browser it paints normally).
- No console errors; `npm test` **62/62**; validate 0/0; markdownlint clean; CHANGELOG entry included.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)