### PR TITLE
docs: governance-role rows in cross-domain interactions (closes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Governance-role coverage in CROSS_DOMAIN_INTERACTIONS.md (#2).** The
+  eight v1.2.0 governance roles now appear in the interaction map: seven
+  ownership-boundary rows (change enablement, major incident, BC/DR
+  standards, data governance, privacy program, risk register, vendor/asset
+  management), four cross-domain relationship entries, a "Data governance
+  scope clarification" section splitting Data Governance Lead vs Data
+  Privacy Officer vs Security, and an "Operational and governance
+  escalations" section mapping each event type to its entry-point role —
+  all aligned with the escalation paths documented in the role files
+  themselves. Unblocks the #13 relationship graph.
 - **Organisation chart view (#11).** New "🌳 Org" header toggle renders the
   live hierarchy as an ECharts tree (first UI use of the vendored ECharts):
   leadership line (CEO → C-suite/SVP → area leads → chapters) flowing into

--- a/docs/CROSS_DOMAIN_INTERACTIONS.md
+++ b/docs/CROSS_DOMAIN_INTERACTIONS.md
@@ -20,6 +20,13 @@ The table below records which domain holds primary decision-making authority ove
 | Cost governance | FinOps | All domains (consumers) |
 | Integration platform | Integration & Middleware | App Platforms, DevOps, Data Engineering |
 | Endpoint management | Endpoint Management | Modern Workplace, Security |
+| Change enablement and the production change calendar | Service Management (Change / Release Manager) | DevOps, all delivery domains |
+| Major incident and problem management | Service Management (Major Incident Manager) | All domains (responders), Security |
+| Business continuity and disaster recovery standards | Data Protection (BC/DR Manager) | Service Management, Cloud Platforms, Modern Infrastructure |
+| Data governance policy, classification scheme, and data catalogue | Data Management (Data Governance Lead) | Security, Data Engineering, AI Governance |
+| Personal data privacy program and DPIAs | Data Management (Data Privacy Officer) | Security, Data Protection, Legal (external) |
+| Enterprise risk register and compliance framework mapping | Security (GRC / Risk & Compliance Analyst) | All domains (evidence providers) |
+| Vendor contracts, IT asset and software license management | Service Management (Vendor / Supplier / IT Asset Manager) | FinOps, Endpoint Management, Procurement (external) |
 
 ## Key cross-domain relationships
 
@@ -35,6 +42,10 @@ The pairs below represent the most frequent and consequential collaboration rela
 - **AI Governance ↔ Security** — AI-specific security controls (prompt injection, model access policies), EU AI Act compliance, NIST AI RMF alignment
 - **FinOps ↔ Cloud Platforms** — cost allocation tagging standards, commitment (Reserved Instance / Savings Plan) optimisation, cloud billing governance
 - **Enterprise Architecture ↔ All** — architecture governance framework, EA repository maintenance, cross-domain Architecture Decision Records (ADRs)
+- **Service Management ↔ DevOps** — change enablement for pipeline-driven delivery: standard-change models for CI/CD deployments, pre-approved change templates, change calendar integration; the Change / Release Manager owns change risk classification, the DevOps domain owns the pipeline tooling itself
+- **Service Management ↔ Data Protection** — major-incident coordination vs recovery execution: the Major Incident Manager runs the incident bridge and communications; the BC/DR Manager owns recovery plans, BIA coverage, and DR test governance; the affected service's engineers execute the technical recovery
+- **Data Management ↔ Security** — classification vs enforcement: the Data Governance Lead defines the classification scheme and data catalogue; Security implements the enforcing controls (DLP, access policy); the Data Privacy Officer sets the privacy requirements both must satisfy for personal data
+- **Service Management ↔ FinOps** — license and contract inputs to cloud cost governance: the Vendor / Supplier / IT Asset Manager provides the contract register, license entitlements, and renewal pipeline that FinOps consumes for commitment and cost optimisation decisions
 
 ## Security domain scope clarification
 
@@ -45,6 +56,16 @@ The repository contains three distinct security-related domains. The boundaries 
 - **`security_cross_platform/`** — Security patterns that span multiple technology platforms: zero trust architecture implementation, cloud security posture management (CSPM), DevSecOps control frameworks that cut across domains, supply chain security, and security automation tooling.
 
 - **`security_identity/`** — Identity and access management architecture: Microsoft Entra ID, RBAC and ABAC design, privileged access management (PAM), identity governance and administration (IGA), federation and SSO, and passwordless authentication.
+
+## Data governance scope clarification
+
+Three roles share the data-classification and privacy space. The boundaries below prevent overlap and duplicate ownership.
+
+- **Data Governance Lead** (`data_management/`) — owns data governance policy, the classification scheme, the data catalogue, and the stewardship model. Classification work feeds the other two roles but carries no privacy or enforcement authority of its own.
+
+- **Data Privacy Officer** (`data_management/`) — owns the personal-data privacy program: DPIAs, privacy-by-design requirements, and regulator contact where legally required. Consumes the Data Governance Lead's classification; defines the privacy requirements Security's controls must meet; external Legal owns regulatory interpretation.
+
+- **Security** (`security/`, `security_identity/`) — owns the enforcing controls: DLP, access policy, encryption standards, and monitoring. Implements against the classification scheme and privacy requirements; does not define either.
 
 ## Escalation paths
 
@@ -57,3 +78,15 @@ When architectural decisions conflict between domains, use the following escalat
 5. **TAL (Technical Area Lead)** — final technical escalation; owns the technical direction for the entire IT area
 6. **PAL (Product Area Lead)** — escalation for business priority conflicts or decisions requiring budget authority
 7. **SVP of Technology / CISO** — executive escalation for strategic decisions, major risk issues, or decisions requiring board-level visibility
+
+### Operational and governance escalations
+
+The chain above covers architectural conflicts. Operational and governance events have their own entry points, aligned with each role's documented scope:
+
+- **Major incident (P1/P2)** — on-call engineers and SREs escalate to the **Major Incident Manager**, who has incident-scoped authority to direct any team onto the bridge; incidents identified as security events hand off to the **Security Architect**; executive notification goes via the Service Management Architect.
+- **Emergency or disputed change** — engineering teams appeal risk classification to the **Change / Release Manager**; unresolved CAB disputes and organisation-wide change freezes escalate to the Service Management Architect.
+- **DR invocation and recovery gaps** — service owners raise recovery capability gaps to the **BC/DR Manager**; BIA-identified risks requiring investment or risk acceptance escalate to the Security & Identity Chapter Lead, and to the **CISO** where regulatory implications exist.
+- **Privacy incident or new personal-data processing** — any domain Architect consults the **Data Privacy Officer** before launching features that collect new personal data; privacy incidents with material regulatory exposure escalate to the **CISO** and Legal/Compliance.
+- **Data classification or stewardship dispute** — domain data stewards escalate cross-domain data quality and classification conflicts to the **Data Governance Lead**; unresolved policy disputes go to the Data & AI Chapter Lead.
+- **Risk acceptance and audit findings** — control gaps route through the **GRC / Risk & Compliance Analyst**; risk acceptance for unremediated high/critical risks is a **CISO** decision.
+- **Vendor or license conflict** — technical decisions blocked by a vendor relationship or license constraint go to the **Vendor / Supplier / IT Asset Manager**; major contract risk escalates to the Service Management Architect.


### PR DESCRIPTION
## What changed

docs/CROSS_DOMAIN_INTERACTIONS.md gains full coverage of the eight governance roles added in v1.2.0:

- **7 ownership-boundary rows**: change enablement, major incident/problem management, BC/DR standards, data governance policy + catalogue, privacy program + DPIAs, enterprise risk register, vendor/asset/license management — each naming the owning domain *and* role.
- **4 cross-domain relationship entries**: Service Management ↔ DevOps (change vs pipeline ownership), Service Management ↔ Data Protection (incident bridge vs recovery execution), Data Management ↔ Security (classification vs enforcement vs privacy requirements), Service Management ↔ FinOps (license/contract inputs).
- **New "Data governance scope clarification" section** mirroring the existing security-scope pattern: Data Governance Lead vs Data Privacy Officer vs Security, per the split the issue called out.
- **New "Operational and governance escalations" subsection** under Escalation paths: entry-point role per event type (major incident, emergency change, DR invocation, privacy incident, classification dispute, risk acceptance, vendor conflict).

Every boundary and escalation target was cross-checked against the `Role Scope & Boundaries` sections of the seven role files — the doc says what the roles themselves say.

## Verification
- Rendered live in the viewer: 19 ownership rows, 14 relationship entries, both new sections present, no rendering issues.
- markdownlint clean; `npm test` 62/62 (unchanged); CHANGELOG entry included.

Unblocks #13 (relationship graph parses this doc).

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)