### PR TITLE
feat: make standards docs reachable in the viewer (closes #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Reference/standards docs are reachable in the viewer again (#29).**
+  `/api/roles` now lists `*_standards.md` files in a per-domain
+  `references` array (never counted as roles, levelled, or stale-tracked),
+  and the sidebar renders them inside their domain group with a 📐
+  Standards badge, opening in the doc view. Markdown links to standards
+  docs route to the doc view instead of the role view, and the FinOps
+  Architect/Engineer files gained "See also" cross-links to the Cloud
+  Cost Optimization Standards. Fixes the side effect of #23 that left the
+  FinOps standards doc orphaned; the pattern works for any future
+  standards file in any domain.
 - **Domain relationship graph (#13).** New "🔗 Graph" header toggle renders
   an ECharts force-directed graph built live from
   docs/CROSS_DOMAIN_INTERACTIONS.md: nodes are domains (sized by how

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -13,6 +13,8 @@
 
 The FinOps Architect designs and implements cloud financial management strategies, governance frameworks, and cost optimization architectures across the organization. This role bridges financial management practices with cloud technology to ensure optimal resource utilization and cost efficiency.
 
+See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.md) — the tagging, budgeting, and chargeback standards this role works within.
+
 ## Business Impact
 
 - **Business Objective:** Designs cloud financial management frameworks and cost optimisation architectures ensuring cloud investments align with business strategy and deliver maximum value through governance, visibility, and accountability

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -13,6 +13,8 @@
 
 The FinOps Engineer implements and maintains cloud cost monitoring, reporting, and optimization solutions. This role applies technical expertise to operationalize FinOps practices, ensuring effective day-to-day management of cloud costs and supporting the organization's cloud financial management goals.
 
+See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.md) — the tagging, budgeting, and chargeback standards this role works within.
+
 ## Business Impact
 
 - **Business Objective:** Implements and maintains cloud cost monitoring, tagging, and reporting solutions ensuring day-to-day cloud cost visibility and optimisation enabling business units to manage their cloud consumption effectively

--- a/index.html
+++ b/index.html
@@ -367,6 +367,7 @@
         .b-sen   { background: rgba(0,120,212,0.14);  color: #0078D4; }
         .b-eng   { background: rgba(40,167,69,0.14);  color: #28a745; }
         .b-po    { background: rgba(255,152,0,0.14);  color: #e08000; }
+        .b-standards { background: rgba(23,162,184,0.12); color: var(--accent-cyan); }
         .b-sre   { background: rgba(23,162,184,0.14); color: #17a2b8; }
         .b-pal   { background: rgba(30,58,95,0.14);   color: #1e3a5f; }
         .b-tal   { background: rgba(0,120,212,0.22);  color: #005a9e; font-weight: 700; }
@@ -384,6 +385,7 @@
         [data-theme="dark"] .b-sen  { background: rgba(0,120,212,0.28);  color: #60b4ff; }
         [data-theme="dark"] .b-eng  { background: rgba(40,167,69,0.28);  color: #6bcf7f; }
         [data-theme="dark"] .b-po   { background: rgba(255,152,0,0.28);  color: #ffb84d; }
+        [data-theme="dark"] .b-standards { background: rgba(23,162,184,0.25); color: #5fd3e8; }
         [data-theme="dark"] .b-sre  { background: rgba(23,162,184,0.28); color: #5bc8d9; }
         [data-theme="dark"] .b-pal  { background: rgba(100,160,255,0.2); color: #a0c8ff; font-weight: 700; }
         [data-theme="dark"] .b-tal  { background: rgba(0,120,212,0.35);  color: #90d0ff; font-weight: 700; }
@@ -1119,7 +1121,7 @@
 <script>
     // ── Shared pure view logic (viewer-logic.js, also under node:test) ──
     const {
-        STALE_MONTHS, LEVEL_ORDER, LEVEL_SHORT,
+        STALE_MONTHS, REFERENCE_DOC_PATTERN, LEVEL_ORDER, LEVEL_SHORT,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
     } = ViewerLogic;
@@ -1728,7 +1730,16 @@
                         chapter.label.toLowerCase().includes(q))
                     : domain.roles;
 
-                if (roles.length === 0) continue;
+                // Reference/standards docs live under the domain too (#29);
+                // they match the same search fields but are never roles.
+                const refs = q
+                    ? (domain.references || []).filter(r =>
+                        r.title.toLowerCase().includes(q) ||
+                        domain.label.toLowerCase().includes(q) ||
+                        chapter.label.toLowerCase().includes(q))
+                    : (domain.references || []);
+
+                if (roles.length === 0 && refs.length === 0) continue;
                 chHasContent = true;
 
                 const domainOpen = (q || (activeFile && activeFile.includes(`/${domainKey}/`))) ? 'open' : '';
@@ -1755,6 +1766,14 @@
                              data-domain="${escapeHtml(domain.label)}">
                             <span class="role-item-name">${escapeHtml(r.title)}</span>
                             <span class="badge ${badgeClass(r.level)}">${escapeHtml(r.level)}</span>
+                        </div>`).join('')}
+                        ${refs.map(r => `
+                        <div class="role-item standards-item ${activeDoc === r.file ? 'active' : ''}"
+                             role="button" tabindex="0"
+                             data-doc="${escapeHtml(r.file)}"
+                             data-doc-title="${escapeHtml(r.title)}">
+                            <span class="role-item-name">📐 ${escapeHtml(r.title)}</span>
+                            <span class="badge b-standards">Standards</span>
                         </div>`).join('')}
                     </div>
                 </div>`;
@@ -2163,7 +2182,10 @@
             '<div class="loading"><div class="spinner"></div> Loading…</div>';
 
         try {
-            const res      = await fetch(`/api/doc?file=${encodeURIComponent(file)}`);
+            // Reference docs live under docs/ (served by /api/doc) or as
+            // *_standards.md files under Roles/ (served by /api/role).
+            const endpoint = file.startsWith('Roles/') ? '/api/role' : '/api/doc';
+            const res      = await fetch(`${endpoint}?file=${encodeURIComponent(file)}`);
             const markdown = await res.text();
             document.getElementById('docBody').innerHTML = renderMarkdown(markdown);
             document.getElementById('mainArea').scrollTop = 0;
@@ -2466,6 +2488,14 @@
         const clean = resolveDocHref(href, activeDoc || activeFile || '');
 
         if (clean.startsWith('Roles/')) {
+            // Reference/standards docs open in the doc view, not as a role (#29)
+            if (REFERENCE_DOC_PATTERN.test(clean)) {
+                const ref = Object.values(allDomains)
+                    .flatMap(d => d.references || [])
+                    .find(r => r.file === clean);
+                openDoc(clean, ref ? ref.title : clean.split('/').pop().replace(/_/g, ' ').replace('.md', ''));
+                return;
+            }
             // Look up role metadata from allDomains
             const allRoles = Object.values(allDomains).flatMap(d =>
                 d.roles.map(r => ({ ...r, domainLabel: d.label }))
@@ -2495,6 +2525,14 @@
         const resItem = e.target.closest('.resource-item');
         if (resItem) {
             openDoc(resItem.dataset.doc, resItem.dataset.docTitle);
+            return;
+        }
+
+        // Standards/reference docs inside a domain group (#29) — must be
+        // checked before .role-item because they share its styling class.
+        const stdItem = e.target.closest('.standards-item');
+        if (stdItem) {
+            openDoc(stdItem.dataset.doc, stdItem.dataset.docTitle);
             return;
         }
 

--- a/server.js
+++ b/server.js
@@ -45,11 +45,13 @@ function getRoles() {
 
   for (const entry of entries) {
     const domainPath = path.join(ROLES_DIR, entry.name);
-    const files = fs.readdirSync(domainPath)
-      .filter(f => f.endsWith('.md') && f !== 'README.md' && !REFERENCE_DOC_PATTERN.test(f))
+    const allMd = fs.readdirSync(domainPath)
+      .filter(f => f.endsWith('.md') && f !== 'README.md')
       .sort();
+    const files    = allMd.filter(f => !REFERENCE_DOC_PATTERN.test(f));
+    const refFiles = allMd.filter(f => REFERENCE_DOC_PATTERN.test(f));
 
-    if (files.length === 0) continue;
+    if (files.length === 0 && refFiles.length === 0) continue;
 
     const roles = files.map(file => {
       const content = fs.readFileSync(path.join(domainPath, file), 'utf8');
@@ -65,9 +67,23 @@ function getRoles() {
       };
     });
 
+    // Reference/standards documents (e.g. *_standards.md) are listed
+    // separately: they are reachable in the viewer but never counted as
+    // roles, never levelled, and never stale-tracked (#23, #29).
+    const references = refFiles.map(file => {
+      const content = fs.readFileSync(path.join(domainPath, file), 'utf8');
+      const meta = parseMeta(content);
+      return {
+        name:  file.replace('.md', ''),
+        file:  `Roles/${entry.name}/${file}`,
+        title: meta.title || file.replace(/_/g, ' ').replace('.md', ''),
+      };
+    });
+
     domains[entry.name] = {
       label: DOMAIN_LABELS[entry.name] || entry.name.replace(/_/g, ' '),
       roles,
+      references,
     };
   }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -49,6 +49,18 @@ test('GET /api/roles returns JSON grouped by domain', async () => {
   assert.ok('lastReviewed' in domains.kubernetes.roles[0]);
 });
 
+test('GET /api/roles lists reference docs separately from roles (#29)', async () => {
+  const res = await request('/api/roles');
+  const domains = JSON.parse(res.body);
+  const finops = domains.FinOps;
+  assert.ok(Array.isArray(finops.references), 'FinOps carries a references array');
+  const std = finops.references.find(r => r.file.endsWith('cloud_cost_optimization_standards.md'));
+  assert.ok(std, 'the standards doc is listed as a reference');
+  assert.equal(std.title, 'Cloud Cost Optimization Standards');
+  assert.ok(!('level' in std) && !('lastReviewed' in std), 'references carry no role metadata');
+  assert.ok(!finops.roles.some(r => r.file.endsWith('_standards.md')), 'standards docs never appear as roles');
+});
+
 test('GET /api/role returns a real role file', async () => {
   const res = await request('/api/role?file=Roles/kubernetes/kubernetes_architect.md');
   assert.equal(res.status, 200);

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -19,7 +19,15 @@ const {
     resolveDocHref,
 } = require('../viewer-logic');
 
-const { CANONICAL_LEVELS } = require('../roleMeta');
+const { CANONICAL_LEVELS, REFERENCE_DOC_PATTERN: ROLEMETA_REF_PATTERN } = require('../roleMeta');
+const { REFERENCE_DOC_PATTERN } = require('../viewer-logic');
+
+test('viewer-logic REFERENCE_DOC_PATTERN mirrors roleMeta exactly', () => {
+    // The browser cannot require roleMeta.js, so viewer-logic carries a
+    // copy; this test keeps the two from drifting apart.
+    assert.equal(REFERENCE_DOC_PATTERN.source, ROLEMETA_REF_PATTERN.source);
+    assert.equal(REFERENCE_DOC_PATTERN.flags, ROLEMETA_REF_PATTERN.flags);
+});
 
 // ── escapeHtml ────────────────────────────────────────────
 

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -16,6 +16,11 @@
     // Roles not reviewed within this many months are flagged stale.
     const STALE_MONTHS = 12;
 
+    // Files that document standards/policy rather than a single role.
+    // Mirror of roleMeta.js REFERENCE_DOC_PATTERN (which can't be required
+    // from the browser); a test asserts the two stay identical.
+    const REFERENCE_DOC_PATTERN = /_standards\.md$/;
+
     // Matrix column order. Must cover every canonical role level in
     // roleMeta.js CANONICAL_LEVELS — a level missing here silently drops
     // its roles from the matrix (see #46: CFO was absent).
@@ -331,6 +336,7 @@
 
     return {
         STALE_MONTHS,
+        REFERENCE_DOC_PATTERN,
         LEVEL_ORDER,
         LEVEL_SHORT,
         escapeHtml,


### PR DESCRIPTION
## What changed

The #23 fix correctly stopped counting `cloud_cost_optimization_standards.md` as a role but left it unreachable. Now:

- **server.js**: `/api/roles` lists `*_standards.md` files in a per-domain `references` array — `{name, file, title}` only, no role metadata. Domains with only reference docs still render.
- **Sidebar**: standards docs appear inside their domain group with a 📐 icon and a cyan `Standards` badge, keyboard-operable like every other item (#24 pattern), search-filterable.
- **Doc view**: `openDoc()` picks its endpoint by path prefix (`Roles/…` → `/api/role`, `docs/…` → `/api/doc`) — no server route changes needed.
- **Markdown links**: `*_standards.md` hrefs inside rendered content route to the doc view instead of opening as a pseudo-role.
- **Cross-links**: FinOps Architect + Engineer gained a "See also" line pointing at the standards doc (per the issue's suggestion).
- **Pattern parity**: viewer-logic carries a browser-side mirror of roleMeta's `REFERENCE_DOC_PATTERN` with a test asserting the two regexes stay identical.

## Verification (live + tests)
- Standards item renders under FinOps, is tabbable, opens the doc view (title + 10 sections rendered).
- "See also" link from FinOps Architect opens the doc view, not the role view.
- Role count still 216, matrix still 216 chips, stale panel unaffected — acceptance criteria from the issue all hold.
- New tests: `/api/roles` references payload shape + never-a-role assertion; regex parity. `npm test` **69/69**; validate 0/0 (See-also lines don't disturb section checks); markdownlint clean.
- Works generically for any future `*_standards.md` in any domain.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)