### PR TITLE
feat: charts respect prefers-reduced-motion (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Accessibility
+
+- **Charts respect `prefers-reduced-motion` (#17).** Users who ask the OS
+  for reduced motion get all four visuals (distribution charts, org chart,
+  relationship graph) without entrance/update animations; the force graph
+  lays out statically. This closes the chart-accessibility issue — the
+  fallback/labeling requirements it tracked were built into each chart as
+  it shipped: aria-label summaries and table/list fallbacks on every
+  visual, identity via labels and shape cues (solid vs dashed edges)
+  rather than color alone, and validated palettes on both themes.
+
 ### Added
 
 - **Reference/standards docs are reachable in the viewer again (#29).**

--- a/index.html
+++ b/index.html
@@ -1322,6 +1322,13 @@
     // and a real <details> table fallback (WCAG, #17).
     const chartInstances = {};
 
+    // WCAG 2.2 motion: users who ask the OS for reduced motion get charts
+    // without entrance/update animations (#17). Evaluated per render so a
+    // live OS-setting change is picked up on the next redraw.
+    function reducedMotion() {
+        return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
     function chartTheme() {
         const css = getComputedStyle(document.documentElement);
         return {
@@ -1354,6 +1361,7 @@
                 indexAxis: 'y',
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: reducedMotion() ? false : undefined,
                 plugins: {
                     legend: { display: false }, // single series — the title names it
                     tooltip: {
@@ -1462,6 +1470,7 @@
                 },
                 leaves: { label: { position: 'right', align: 'left' } },
                 emphasis: { focus: 'descendant' },
+                animation: !reducedMotion(),
                 animationDuration: 300,
                 animationDurationUpdate: 400,
             }],
@@ -1629,7 +1638,11 @@
                 roam: true,
                 draggable: true,
                 label: { color: theme.text, fontSize: 11, position: 'right' },
-                force: { repulsion: 320, edgeLength: [70, 150], gravity: 0.12 },
+                force: {
+                    repulsion: 320, edgeLength: [70, 150], gravity: 0.12,
+                    layoutAnimation: !reducedMotion(),
+                },
+                animation: !reducedMotion(),
                 emphasis: { focus: 'adjacency', lineStyle: { width: 3 } },
             }],
         });


### PR DESCRIPTION
## What changed
One real gap remained for #17: charts animated unconditionally. Now a `reducedMotion()` check (evaluated per render) disables Chart.js animations, ECharts tree/graph animations, and the force graph's `layoutAnimation` when the OS requests reduced motion.

## Audit — the rest of #17 was already met by construction (verified live this session)

| Criterion | Distribution charts (#14) | Org chart (#11) | Relationship graph (#13) |
|---|---|---|---|
| Not color-alone | single hue; identity = axis labels | identity = node labels/structure | always-on node labels + legend + **solid vs dashed edge shape cue** |
| Text/table fallback | 2 `<details>` tables | 216-entry keyboard-operable list | 22-domain relationship list |
| Canvas semantics | `aria-label` data summary ×2 | `role=img` + pointer to fallback | `role=img` + pointer to fallback |
| Palette validated (both themes) | ✔ (#14 PR) | per-kind colors, labels carry identity | ✔ 7-slot CVD/contrast validated (#13 PR) |
| Reduced motion | **this PR** | **this PR** | **this PR** (static force layout verified painting: 6.9%) |

## Verification
- Emulated `prefers-reduced-motion: reduce`: all animation flags off; org chart and force graph still lay out and paint (pixel-verified 4.5% / 6.9%).
- No console errors; `npm test` 69/69; markdownlint clean; CHANGELOG under a new **Accessibility** heading.

Note for #15 (Sankey): this bar applies to it too — reduced motion, aria summary, table fallback, validated colors.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)