### PR TITLE
docs: cover all 32 domains in skills progression (closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **SKILLS_PROGRESSION.md now covers all 32 domains (#1)** — up from 10.
+  The domain-ladder section was regenerated from the role files themselves:
+  every one of the 216 roles appears exactly once, mapped to its metadata
+  level (Product Owner lines added throughout; the eight specialist
+  Senior-Engineer-grade governance roles sit on their domains' Senior
+  lines). New "GenAI vs classical MLOps" section documents the two AI
+  platform tracks, the Data-to-AI mobility path names which of the two
+  architect targets it leads to, and governance-specialist feeder paths
+  were added to cross-domain mobility. A new test suite pins the doc to
+  the catalog — a missing, duplicate, or phantom ladder entry now fails
+  CI. Unblocks the #15 career Sankey.
+
 ### Accessibility
 
 - **Charts respect `prefers-reduced-motion` (#17).** Users who ask the OS

--- a/docs/SKILLS_PROGRESSION.md
+++ b/docs/SKILLS_PROGRESSION.md
@@ -61,65 +61,237 @@ The **Chapter Lead** level sits above Principal Architect on the people-leadersh
 
 ## Domain-by-domain progression paths
 
+Every domain in the catalog is listed below (alphabetically), with every role file mapped to its level. Specialist roles that carry Senior Engineer grade (e.g. the service-management and data-governance specialists) appear on the Senior Engineer line of their domain.
+
+### AI Governance
+
+- Engineer: `ai_governance_engineer`, `ai_platform_engineer`, `responsible_ai_engineer`
+- Senior Engineer: `ai_governance_senior_engineer`
+- Architect: `ai_governance_architect`, `ai_platform_architect`
+- Product Owner: `ai_governance_product_owner`
+
+### App Platforms
+
+- Engineer: `api_platform_engineer`, `dotnet_engineer`, `java_engineer`
+- Senior Engineer: `api_platform_senior_engineer`, `dotnet_senior_engineer`, `java_senior_engineer`
+- Architect: `api_platform_architect`, `api_strategy_architect`, `dotnet_architect`, `java_architect`
+- Product Owner: `api_platform_product_owner`, `dotnet_product_owner`, `java_product_owner`
+
+### C-Suite
+
+- Executive: `chief_executive_officer`, `chief_financial_officer`, `chief_information_officer`, `chief_technology_officer`
+
+### Client Platform
+
+- Engineer: `client_platform_engineer`
+- Senior Engineer: `client_platform_senior_engineer`
+- Architect: `client_platform_architect`
+- Product Owner: `client_platform_product_owner`
+
 ### Cloud Platforms
 
-- Engineer: `azure_cloud_engineer`, `aws_cloud_engineer`, `gcp_cloud_engineer`
-- Senior Engineer: `azure_cloud_senior_engineer`, `aws_cloud_senior_engineer`, `gcp_cloud_senior_engineer`
-- Architect: `azure_cloud_architect`, `aws_cloud_architect`, `gcp_cloud_architect`
+- Engineer: `aws_cloud_engineer`, `azure_cloud_engineer`, `gcp_cloud_engineer`
+- Senior Engineer: `aws_cloud_senior_engineer`, `azure_cloud_senior_engineer`, `gcp_cloud_senior_engineer`
+- Architect: `aws_cloud_architect`, `azure_cloud_architect`, `gcp_cloud_architect`
 - Lead/Principal: `cloud_lead_architect`, `cloud_principal_architect`
+- Product Owner: `aws_cloud_product_owner`, `azure_cloud_product_owner`, `gcp_cloud_product_owner`
+
+### Data Engineering
+
+- Engineer: `data_engineer`, `data_platform_engineer`
+- Senior Engineer: `data_senior_engineer`, `dataops_specialist`
+- Architect: `data_mesh_architect`, `data_platform_architect`
+- Product Owner: `data_engineering_product_owner`
+
+### Data Management
+
+- Engineer: `qumulo_storage_engineer`, `storage_engineer`
+- Senior Engineer: `data_governance_lead`, `data_privacy_officer`, `qumulo_storage_senior_engineer`, `storage_senior_engineer`
+- Architect: `qumulo_storage_architect`, `storage_architect`
+- Product Owner: `qumulo_storage_product_owner`, `storage_product_owner`
+
+### Data Protection
+
+- Engineer: `backup_reliability_engineer`, `commvault_engineer`, `simplivity_backup_engineer`
+- Senior Engineer: `business_continuity_disaster_recovery_manager`, `commvault_senior_engineer`, `simplivity_backup_senior_engineer`
+- Architect: `commvault_architect`, `simplivity_backup_architect`
+- Product Owner: `commvault_product_owner`, `simplivity_backup_product_owner`
+
+### Database Management
+
+- Engineer: `database_engineer`, `database_reliability_engineer`
+- Senior Engineer: `database_senior_engineer`
+- Architect: `database_architect`
+- Product Owner: `database_product_owner`
 
 ### DevOps
 
-- Engineer: `devops_engineer`
+- Engineer: `automation_framework_engineer`, `developer_experience_engineer`, `devops_engineer`
 - Senior Engineer: `devops_senior_engineer`
+- Reliability Engineer: `platform_reliability_engineer`
 - Architect: `devops_architect`
+- Product Owner: `devops_product_owner`
 
-### Security
+### Directory Services
 
-- Engineer: `security_engineer`, `devsecops_engineer`
-- Senior Engineer: `security_senior_engineer`
-- Architect: `security_architect`, `devsecops_architect`
+- Engineer: `windows_active_directory_engineer`
+- Senior Engineer: `windows_active_directory_senior_engineer`
+- Architect: `windows_active_directory_architect`
+- Product Owner: `windows_active_directory_product_owner`
+
+### Endpoint Management
+
+- Engineer: `endpoint_management_engineer`, `sccm_engineer`
+- Senior Engineer: `endpoint_management_senior_engineer`
+- Architect: `endpoint_management_architect`
+- Product Owner: `endpoint_management_product_owner`
+
+### Enterprise Architecture
+
+- Senior Engineer: `enterprise_architecture_senior_engineer`
+- Architect: `enterprise_architect`, `solution_architect`
+
+### FinOps
+
+- Engineer: `cloud_cost_optimization_engineer`, `cloud_economics_analyst`, `finops_engineer`
+- Senior Engineer: `finops_senior_engineer`
+- Architect: `finops_architect`
+- Product Owner: `finops_product_owner`
+
+### HPE Server Hardware
+
+- Engineer: `hpe_server_hardware_engineer`
+- Senior Engineer: `hpe_server_hardware_senior_engineer`
+- Architect: `hpe_server_hardware_architect`
+- Product Owner: `hpe_server_hardware_product_owner`
+
+### Infrastructure Onboarding
+
+- Engineer: `infrastructure_onboarding_cross_platform_engineer`
+- Senior Engineer: `infrastructure_onboarding_cross_platform_senior_engineer`
+- Architect: `infrastructure_onboarding_cross_platform_architect`
+- Product Owner: `infrastructure_onboarding_cross_platform_product_owner`
+
+### Integration & Middleware
+
+- Engineer: `integration_engineer`
+- Senior Engineer: `integration_senior_engineer`
+- Architect: `integration_architect`
+- Product Owner: `integration_product_owner`
+
+### ITSM & Configuration
+
+- Engineer: `application_configuration_management_engineer`
+- Senior Engineer: `application_configuration_management_senior_engineer`
+- Architect: `application_configuration_management_architect`
+- Product Owner: `itsm_product_owner`
 
 ### Kubernetes
 
 - Engineer: `kubernetes_engineer`
 - Senior Engineer: `kubernetes_senior_engineer`
 - Architect: `kubernetes_architect`
+- Product Owner: `kubernetes_product_owner`
 
-### Data Engineering
+### Leadership
 
-- Engineer: `data_engineer`
-- Senior Engineer: `data_senior_engineer`
-- Architect: `data_platform_architect`
+- Senior Engineer: `engineering_practices_champion`, `technical_community_leader`
+- Chapter Lead: `cloud_platform_infrastructure_chapter_lead`, `data_ai_chapter_lead`, `devops_delivery_chapter_lead`, `end_user_workplace_chapter_lead`, `security_identity_chapter_lead`, `service_governance_chapter_lead`
+- Area Lead: `product_area_lead`, `technical_area_lead`
+- Executive: `chief_information_security_officer`, `svp_technology`
 
-### AI Governance
+### Linux Server OS
 
-- Engineer: `responsible_ai_engineer`
-- Senior Engineer: `ai_governance_senior_engineer`
-- Architect: `ai_governance_architect`
+- Engineer: `linux_server_engineer`
+- Senior Engineer: `linux_server_senior_engineer`
+- Architect: `linux_server_architect`
+- Product Owner: `linux_server_product_owner`
 
-### Network
+### Modern Infrastructure
 
-- Engineer: `network_engineer`
-- Senior Engineer: `network_senior_engineer`
-- Architect: `network_architect`, `network_automation_architect`
+- Engineer: `chaos_engineer`, `genai_platform_engineer`, `mlops_engineer`, `observability_engineer`, `platform_engineering_engineer`, `site_reliability_engineer`
+- Senior Engineer: `observability_senior_engineer`, `platform_engineering_senior_engineer`, `site_reliability_senior_engineer`
+- Architect: `genai_platform_architect`, `infrastructure_automation_architect`, `observability_architect`, `platform_engineering_architect`
+- Product Owner: `observability_product_owner`, `platform_engineering_product_owner`
 
 ### Modern Workplace
 
 - Engineer: `modern_workplace_engineer`
 - Senior Engineer: `modern_workplace_senior_engineer`
 - Architect: `modern_workplace_architect`
+- Product Owner: `modern_workplace_product_owner`
 
-### FinOps
+### Network
 
-- Engineer: `finops_engineer`
-- Senior Engineer: `finops_senior_engineer`
-- Architect: `finops_architect`
+- Engineer: `network_automation_engineer`, `network_engineer`
+- Senior Engineer: `network_senior_engineer`
+- Architect: `network_architect`, `network_automation_architect`
+- Product Owner: `network_product_owner`
 
-### Leadership
+### Security
 
-- Lead/Principal: `technical_area_lead`, `product_area_lead`
-- Chapter Lead: `cloud_platform_infrastructure_chapter_lead`, `devops_delivery_chapter_lead`, `data_ai_chapter_lead`, `security_identity_chapter_lead`, `end_user_workplace_chapter_lead`, `service_governance_chapter_lead`
+- Engineer: `devsecops_engineer`, `security_engineer`
+- Senior Engineer: `grc_risk_compliance_analyst`, `security_senior_engineer`
+- Architect: `devsecops_architect`, `security_architect`
+- Product Owner: `security_product_owner`
+
+### Security Cross-Platform
+
+- Engineer: `security_automation_engineer`, `security_cross_platform_engineer`
+- Senior Engineer: `cloud_security_posture_manager`, `security_cross_platform_senior_engineer`
+- Architect: `security_cross_platform_architect`
+- Product Owner: `security_cross_platform_product_owner`
+
+### Security & Identity
+
+- Engineer: `access_management_engineer`, `identity_management_engineer`, `privileged_access_management_engineer`
+- Senior Engineer: `access_management_senior_engineer`, `identity_governance_specialist`, `identity_management_senior_engineer`
+- Architect: `access_management_architect`, `identity_management_architect`, `privileged_access_management_architect`
+- Product Owner: `access_management_product_owner`, `identity_management_product_owner`
+
+### Server Hardware
+
+- Engineer: `server_hardware_engineer`
+- Senior Engineer: `server_hardware_senior_engineer`
+- Architect: `server_hardware_architect`
+- Product Owner: `server_hardware_product_owner`
+
+### Service Management
+
+- Engineer: `service_management_engineer`
+- Senior Engineer: `change_release_manager`, `major_incident_manager`, `service_management_senior_engineer`, `technical_program_manager`, `vendor_supplier_it_asset_manager`
+- Architect: `service_management_architect`
+- Product Owner: `service_management_product_owner`
+
+### Specialized Computing
+
+- Engineer: `hpc_engineer`
+- Senior Engineer: `hpc_senior_engineer`
+- Architect: `hpc_architect`
+- Product Owner: `hpc_product_owner`
+
+### Virtualization
+
+- Engineer: `hyperv_engineer`, `nutanix_engineer`, `vmware_engineer`
+- Senior Engineer: `hyperv_senior_engineer`, `nutanix_senior_engineer`, `vmware_senior_engineer`
+- Architect: `hyperv_architect`, `nutanix_architect`, `vmware_architect`
+- Product Owner: `hyperv_product_owner`, `nutanix_product_owner`, `vmware_product_owner`
+
+### Windows Server OS
+
+- Engineer: `windows_server_engineer`
+- Senior Engineer: `windows_server_senior_engineer`
+- Architect: `windows_server_architect`
+- Product Owner: `windows_server_product_owner`
+
+## GenAI vs classical MLOps: two AI platform tracks
+
+The catalog deliberately contains two distinct AI platform ladders — do not conflate them when planning a career move:
+
+- **Classical MLOps** (`ai_governance/`): `ai_platform_engineer` → `ai_platform_architect`. Focused on the ML lifecycle for predictive models — feature stores, training pipelines, model registries, drift monitoring — under the AI governance umbrella.
+- **GenAI platform** (`modern_infrastructure/`): `genai_platform_engineer` → `genai_platform_architect`. Focused on LLM-era platform capabilities — model serving and routing, prompt/RAG infrastructure, vector stores, GPU capacity, and GenAI-specific guardrails.
+
+Engineers can move between the tracks; the platform engineering fundamentals transfer, while the governance depth (classical) and inference-infrastructure depth (GenAI) are the respective specialisations to build.
 
 ## Cross-domain mobility paths
 
@@ -128,7 +300,9 @@ The moves below represent well-established lateral and forward transitions acros
 - **DevOps Engineer → Cloud Senior Engineer** — natural transition for engineers with a strong IaC and infrastructure automation focus
 - **Cloud Architect → Principal Cloud Architect** — seniority progression for architects with multi-cloud strategic delivery experience
 - **Security Engineer → DevSecOps Engineer → Security Architect** — security specialism deepening through pipeline integration toward full architectural authority
-- **Data Engineer → AI Governance Engineer → AI Platform Architect** — data-to-AI progression, increasingly common as organisations mature their ML platforms
+- **Data Engineer → AI Governance Engineer → AI Platform Architect** (`ai_governance/`) — the classical-MLOps data-to-AI progression; note this targets the *AI Platform Architect* in `ai_governance/`, not the *GenAI Platform Architect* in `modern_infrastructure/` (see the two-track note above). Engineers aiming at the GenAI track typically route via `platform_engineering_engineer` or `mlops_engineer` → `genai_platform_engineer` → `genai_platform_architect`
 - **Network Architect → Cloud Architect** — hybrid and cloud-first transition for network specialists expanding into cloud networking and landing zones
 - **Any Architect → TAL** — move onto the people-and-technical-leadership track; requires strong domain credibility plus demonstrated people development
 - **Kubernetes Engineer → Platform Engineer → DevOps or Cloud Architect** — platform engineering pathway through container orchestration into broader infrastructure or developer platform ownership
+- **Senior Engineer → governance specialist** — experienced senior engineers move into the specialist Senior-Engineer-grade governance roles: `major_incident_manager` and `change_release_manager` (from operations/SRE backgrounds), `technical_program_manager` (from delivery-heavy roles), `vendor_supplier_it_asset_manager` (from platform roles with vendor exposure), `grc_risk_compliance_analyst` (from security engineering), `business_continuity_disaster_recovery_manager` (from data-protection engineering), and `data_governance_lead` / `data_privacy_officer` (from data engineering or security)
+- **Storage/backup specialist → BC/DR Manager** — Commvault, SimpliVity, and storage senior engineers are the natural feeder pool for `business_continuity_disaster_recovery_manager`, which adds business-impact analysis and recovery governance to their technical recovery depth

--- a/test/skills-progression.test.js
+++ b/test/skills-progression.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Guards docs/SKILLS_PROGRESSION.md against drift (#1): every role file in
+// the catalog must appear exactly once in the domain-ladder section, and
+// the doc must not reference files that no longer exist. The #15 Sankey
+// will parse this document — these tests keep it parseable and complete.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+
+function ladderSection() {
+  const doc = fs.readFileSync(path.join(ROOT, 'docs', 'SKILLS_PROGRESSION.md'), 'utf8');
+  const afterHeading = doc.split('## Domain-by-domain progression paths')[1];
+  assert.ok(afterHeading, 'ladder section heading present');
+  return afterHeading.split(/\n## /)[0];
+}
+
+function catalogRoleNames() {
+  const names = new Set();
+  for (const d of fs.readdirSync(path.join(ROOT, 'Roles'), { withFileTypes: true })) {
+    if (!d.isDirectory()) continue;
+    for (const f of fs.readdirSync(path.join(ROOT, 'Roles', d.name))) {
+      if (!f.endsWith('.md') || f === 'README.md' || /_standards\.md$/.test(f)) continue;
+      names.add(f.replace('.md', ''));
+    }
+  }
+  return names;
+}
+
+test('every catalog role appears exactly once in the progression ladders', () => {
+  const section = ladderSection();
+  const seen = new Map();
+  for (const m of section.matchAll(/`([a-z0-9_]+)`/g)) {
+    seen.set(m[1], (seen.get(m[1]) || 0) + 1);
+  }
+  const real = catalogRoleNames();
+  const missing = [...real].filter(n => !seen.has(n));
+  const dupes = [...seen].filter(([, c]) => c > 1).map(([n]) => n);
+  assert.deepEqual(missing, [], `roles missing from SKILLS_PROGRESSION ladders`);
+  assert.deepEqual(dupes, [], `roles listed more than once`);
+});
+
+test('the progression ladders reference no deleted or renamed roles', () => {
+  const section = ladderSection();
+  const real = catalogRoleNames();
+  const phantom = [...new Set([...section.matchAll(/`([a-z0-9_]+)`/g)].map(m => m[1]))]
+    .filter(n => !real.has(n));
+  assert.deepEqual(phantom, [], 'ladder entries with no matching role file');
+});
+
+test('every domain has a ladder heading', () => {
+  const section = ladderSection();
+  const headings = (section.match(/^### /gm) || []).length;
+  const domainCount = fs.readdirSync(path.join(ROOT, 'Roles'), { withFileTypes: true })
+    .filter(d => d.isDirectory()).length;
+  assert.equal(headings, domainCount, 'one ladder heading per domain');
+});


### PR DESCRIPTION
## What changed

- **Ladder coverage 10 → 32 domains.** The `## Domain-by-domain progression paths` section was regenerated mechanically from the role files (levels read from each file's `Role Level` metadata), so it is accurate by construction: **all 216 roles appear exactly once**, verified by script — no missing, duplicate, or phantom entries.
- **Product Owner lines** added to every domain that has them (the old 10 ladders omitted POs entirely).
- **The 8 specialist governance roles** (per the issue) sit on their domains' Senior Engineer lines, matching their metadata grade.
- **New "GenAI vs classical MLOps" section** documents the two deliberately distinct AI platform tracks (`ai_governance` vs `modern_infrastructure`) — the issue's requested split.
- **Mobility clarification** (per the issue): the *Data Engineer → AI Governance Engineer → AI Platform Architect* path now states it targets the classical-MLOps architect and gives the GenAI-track routing; added governance-specialist feeder paths and the storage/backup → BC/DR Manager path.
- **New drift guard**: `test/skills-progression.test.js` (3 tests, suite 69 → 72) pins the doc to the catalog — adding/renaming/deleting a role without updating the ladders now fails CI. This also keeps the doc parseable for the #15 Sankey.

## Verification
- Completeness script: 216/216 roles, 32/32 headings, zero missing/dupes/phantoms.
- Rendered in the viewer: 32 ladder headings, all sections, 238 code references display correctly.
- `npm test` **72/72**; markdownlint clean; CHANGELOG included.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)