### PR TITLE
feat: career path flow view (closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Career path flow view (#15).** New "📈 Careers" header toggle renders
+  an ECharts sankey built live from SKILLS_PROGRESSION.md: career rungs as
+  columns (Engineer → Senior → Architect → Lead/Principal → Chapter Lead →
+  Area Lead → Executive), band width = role count at each rung, with
+  Product Owner and Reliability Engineer branching off the IC line. Node
+  colors are an ordinal blue ramp (darker = more senior); hover shows the
+  contributing domains per band. Ladder and mobility parsers
+  (`parseProgressionLadders`, `buildCareerSankey`, `parseMobilityPaths`)
+  live in `viewer-logic.js` with fixture tests plus an integration test
+  against the real document (32 ladders, all 216 roles). Ships the full
+  chart-accessibility bar: reduced-motion support, aria summary, and a
+  "View as table" fallback that also lists the cross-domain mobility
+  paths. Completes the In-App Data Visualization milestone's original
+  chart set.
 - **SKILLS_PROGRESSION.md now covers all 32 domains (#1)** — up from 10.
   The domain-ladder section was regenerated from the role files themselves:
   every one of the 216 roles appears exactly once, mapped to its metadata

--- a/index.html
+++ b/index.html
@@ -992,6 +992,7 @@
         <button class="btn-ghost" id="matrixBtn" onclick="toggleMatrix()" aria-pressed="false" aria-label="Toggle role matrix view">📊 Matrix</button>
         <button class="btn-ghost" id="orgBtn" onclick="toggleOrg()" aria-pressed="false" aria-label="Toggle organisation chart view">🌳 Org</button>
         <button class="btn-ghost" id="graphBtn" onclick="toggleGraph()" aria-pressed="false" aria-label="Toggle domain relationship graph">🔗 Graph</button>
+        <button class="btn-ghost" id="careersBtn" onclick="toggleCareers()" aria-pressed="false" aria-label="Toggle career path flow view">📈 Careers</button>
         <button class="btn-ghost" id="themeBtn" onclick="toggleTheme()" aria-pressed="false" aria-label="Toggle dark mode">🌙 Dark</button>
     </div>
 </header>
@@ -1106,6 +1107,25 @@
             </details>
         </div>
 
+        <!-- Career path flow view -->
+        <div class="matrix-view" id="careersView">
+            <div class="matrix-header">
+                <div>
+                    <h2>📈 Career Path Flow</h2>
+                    <p>How the catalog's roles ladder upward — built live from the Skills Progression
+                       reference. Band width shows how many roles each rung offers; Product Owner and
+                       Reliability Engineer branch off the individual-contributor line. Hover any band
+                       for the contributing domains.</p>
+                </div>
+            </div>
+            <div id="careersChartCanvas" class="org-canvas" role="img"
+                 aria-label="Career path flow diagram. A text version is available below under 'View as table'."></div>
+            <details class="chart-table">
+                <summary>View as table</summary>
+                <div id="careersListFallback" class="org-list"></div>
+            </details>
+        </div>
+
         <!-- Doc view (reference documents) -->
         <div class="doc-view" id="docView">
             <div class="role-card doc-card" id="docHeader"></div>
@@ -1124,6 +1144,7 @@
         STALE_MONTHS, REFERENCE_DOC_PATTERN, LEVEL_ORDER, LEVEL_SHORT,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
+        parseProgressionLadders, buildCareerSankey, parseMobilityPaths,
     } = ViewerLogic;
 
     // ── State ───────────────────────────────────────────
@@ -1536,6 +1557,12 @@
                 const gb = document.getElementById('graphBtn');
                 gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
             }
+            if (careersOpen) {
+                careersOpen = false;
+                document.getElementById('careersView').classList.remove('show');
+                const cb = document.getElementById('careersBtn');
+                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
+            }
         } else {
             ov.classList.remove('show');
             btn.style.background = '';
@@ -1710,6 +1737,12 @@
                 const ob = document.getElementById('orgBtn');
                 ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
             }
+            if (careersOpen) {
+                careersOpen = false;
+                document.getElementById('careersView').classList.remove('show');
+                const cb = document.getElementById('careersBtn');
+                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
+            }
         } else {
             gv.classList.remove('show');
             btn.style.background = '';
@@ -1718,8 +1751,128 @@
         }
     }
 
+    // ── Career path flow (ECharts sankey) ─────────────────
+    let careersOpen  = false;
+    let careersChart = null;
+
+    // Ordinal blue ramp (light→dark with seniority) for the main IC line,
+    // aqua for the two branch rungs. Sequential/ordinal encoding — one hue,
+    // monotonic lightness — per the dataviz method for ordered levels.
+    const SANKEY_NODE_COLORS = {
+        light: {
+            'Engineer': '#86b6ef', 'Senior Engineer': '#5598e7', 'Architect': '#2a78d6',
+            'Lead/Principal': '#1c5cab', 'Chapter Lead': '#184f95', 'Area Lead': '#104281',
+            'Executive': '#0d366b',
+            'Reliability Engineer': '#1baf7a', 'Product Owner': '#1baf7a',
+        },
+        dark: {
+            'Engineer': '#9ec5f4', 'Senior Engineer': '#6da7ec', 'Architect': '#3987e5',
+            'Lead/Principal': '#2a78d6', 'Chapter Lead': '#256abf', 'Area Lead': '#1c5cab',
+            'Executive': '#184f95',
+            'Reliability Engineer': '#199e70', 'Product Owner': '#199e70',
+        },
+    };
+
+    async function renderCareerSankey() {
+        if (typeof echarts === 'undefined') return;
+        const theme  = chartTheme();
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        const colors = SANKEY_NODE_COLORS[isDark ? 'dark' : 'light'];
+
+        let md;
+        try {
+            const res = await fetch(`/api/doc?file=${encodeURIComponent('docs/SKILLS_PROGRESSION.md')}`);
+            md = await res.text();
+        } catch {
+            document.getElementById('careersListFallback').innerHTML =
+                '<p>⚠️ Could not load the Skills Progression document.</p>';
+            return;
+        }
+        const ladders  = parseProgressionLadders(md);
+        const sankey   = buildCareerSankey(ladders);
+        const mobility = parseMobilityPaths(md);
+
+        careersChart?.dispose();
+        careersChart = echarts.init(document.getElementById('careersChartCanvas'));
+        careersChart.setOption({
+            tooltip: {
+                trigger: 'item',
+                formatter: p => {
+                    if (p.dataType === 'edge') {
+                        const doms = (p.data.domains || []).map(escapeHtml).join('<br>• ');
+                        return `<b>${escapeHtml(p.data.source)} → ${escapeHtml(p.data.target)}</b>: ${p.data.value} role${p.data.value !== 1 ? 's' : ''}${doms ? '<br>• ' + doms : ''}`;
+                    }
+                    return `<b>${escapeHtml(p.name)}</b>`;
+                },
+            },
+            series: [{
+                type: 'sankey',
+                data: sankey.nodes.map(n => ({ ...n, itemStyle: { color: colors[n.name] || theme.bar } })),
+                links: sankey.links,
+                orient: 'horizontal',
+                nodeAlign: 'left',
+                nodeGap: 14,
+                label: { color: theme.text, fontSize: 12 },
+                lineStyle: { color: 'gradient', curveness: 0.5, opacity: isDark ? 0.35 : 0.25 },
+                emphasis: { focus: 'adjacency' },
+                animation: !reducedMotion(),
+            }],
+        });
+
+        // Fallback: flows as a table plus the mobility paths as text.
+        const rows = sankey.links.map(l => `
+            <tr><td>${escapeHtml(l.source)}</td><td>${escapeHtml(l.target)}</td>
+                <td>${l.value}</td><td>${escapeHtml(l.domains.join('; '))}</td></tr>`).join('');
+        const mobilityHtml = mobility.map(m =>
+            `<li><b>${escapeHtml(m.path)}</b> — ${escapeHtml(m.description)}</li>`).join('');
+        document.getElementById('careersListFallback').innerHTML = `
+            <table>
+                <thead><tr><th>From</th><th>To</th><th>Roles</th><th>Contributing domains</th></tr></thead>
+                <tbody>${rows}</tbody>
+            </table>
+            <p><b>Cross-domain mobility paths</b></p>
+            <ul>${mobilityHtml}</ul>`;
+    }
+
+    function toggleCareers() {
+        careersOpen = !careersOpen;
+        const cv  = document.getElementById('careersView');
+        const btn = document.getElementById('careersBtn');
+        btn.setAttribute('aria-pressed', String(careersOpen));
+
+        if (careersOpen) {
+            document.getElementById('welcomeState').style.display = 'none';
+            document.getElementById('chapterView').style.display  = 'none';
+            document.getElementById('rolesGrid').style.display    = 'none';
+            document.getElementById('docView').style.display      = 'none';
+            activeDoc = null;
+            cv.classList.add('show');
+            btn.style.background = 'rgba(255,255,255,0.3)';
+            btn.style.borderColor = 'rgba(255,255,255,0.6)';
+            renderCareerSankey();
+
+            // All five side panels are mutually exclusive
+            for (const [flagOff, viewId, btnId] of [
+                [() => { matrixOpen = false; }, 'matrixView', 'matrixBtn'],
+                [() => { staleOpen  = false; }, 'staleView',  'staleBtn'],
+                [() => { orgOpen    = false; }, 'orgView',    'orgBtn'],
+                [() => { graphOpen  = false; }, 'graphView',  'graphBtn'],
+            ]) {
+                flagOff();
+                document.getElementById(viewId).classList.remove('show');
+                const b = document.getElementById(btnId);
+                b.style.background = ''; b.style.borderColor = ''; b.setAttribute('aria-pressed', 'false');
+            }
+        } else {
+            cv.classList.remove('show');
+            btn.style.background = '';
+            btn.style.borderColor = '';
+            if (!activeFile) document.getElementById('welcomeState').style.display = '';
+        }
+    }
+
     // Keep the ECharts canvases sized to their containers.
-    window.addEventListener('resize', () => { orgChart?.resize(); graphChart?.resize(); });
+    window.addEventListener('resize', () => { orgChart?.resize(); graphChart?.resize(); careersChart?.resize(); });
 
     // ── Render sidebar ───────────────────────────────────
     function renderSidebar(domains, filter = '') {
@@ -1876,6 +2029,7 @@
         document.getElementById('staleView').classList.remove('show');
         document.getElementById('orgView').classList.remove('show');
         document.getElementById('graphView').classList.remove('show');
+        document.getElementById('careersView').classList.remove('show');
         document.getElementById('docView').style.display      = 'none';
         document.getElementById('welcomeState').style.display = 'none';
 
@@ -2024,6 +2178,10 @@
         ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
         const gb = document.getElementById('graphBtn');
         gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
+        careersOpen = false;
+        document.getElementById('careersView').classList.remove('show');
+        const cb = document.getElementById('careersBtn');
+        cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
     }
 
     // ── Shared: build role header HTML ───────────────────
@@ -2175,6 +2333,12 @@
         document.getElementById('graphBtn').style.borderColor = '';
         document.getElementById('graphBtn').setAttribute('aria-pressed', 'false');
 
+        document.getElementById('careersView').classList.remove('show');
+        careersOpen = false;
+        document.getElementById('careersBtn').style.background  = '';
+        document.getElementById('careersBtn').style.borderColor = '';
+        document.getElementById('careersBtn').setAttribute('aria-pressed', 'false');
+
         renderSidebar(allDomains, document.getElementById('searchInput').value);
 
         const docView = document.getElementById('docView');
@@ -2277,6 +2441,7 @@
         if (Object.keys(allDomains).length) renderDistributionCharts(allDomains);
         if (orgOpen) renderOrgChart();
         if (graphOpen) renderDomainGraph();
+        if (careersOpen) renderCareerSankey();
     }
 
     // ── Matrix view ───────────────────────────────────────
@@ -2387,6 +2552,12 @@
                 const gb = document.getElementById('graphBtn');
                 gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
             }
+            if (careersOpen) {
+                careersOpen = false;
+                document.getElementById('careersView').classList.remove('show');
+                const cb = document.getElementById('careersBtn');
+                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
+            }
         } else {
             // Restore normal content
             document.getElementById('rolesGrid').style.display = '';
@@ -2444,6 +2615,12 @@
                 document.getElementById('graphView').classList.remove('show');
                 const gb = document.getElementById('graphBtn');
                 gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
+            }
+            if (careersOpen) {
+                careersOpen = false;
+                document.getElementById('careersView').classList.remove('show');
+                const cb = document.getElementById('careersBtn');
+                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
             }
         } else {
             sv.classList.remove('show');

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -16,6 +16,9 @@ const {
     buildOrgTree,
     parseInteractions,
     labelToChapter,
+    parseProgressionLadders,
+    buildCareerSankey,
+    parseMobilityPaths,
     resolveDocHref,
 } = require('../viewer-logic');
 
@@ -412,4 +415,75 @@ test('labelToChapter maps domain labels to chapter labels', () => {
         b: { label: 'Chapter B', domains: ['network', 'missing'] },
     };
     assert.deepEqual(labelToChapter(domains, chapters), { 'DevOps': 'Chapter A', 'Network': 'Chapter B' });
+});
+
+// ── parseProgressionLadders / buildCareerSankey ──────────
+
+const LADDER_FIXTURE = `# Skills progression framework
+
+## Domain-by-domain progression paths
+
+Intro line.
+
+### Alpha Domain
+
+- Engineer: \`alpha_engineer\`, \`alpha_tool_engineer\`
+- Senior Engineer: \`alpha_senior_engineer\`
+- Architect: \`alpha_architect\`
+- Product Owner: \`alpha_product_owner\`
+
+### Leadershipish
+
+- Senior Engineer: \`champion\`
+- Chapter Lead: \`alpha_chapter_lead\`
+- Executive: \`svp_thing\`
+
+### Execs Only
+
+- Executive: \`ceo_thing\`
+
+## Cross-domain mobility paths
+
+- **Alpha Engineer → Beta Senior Engineer** — a well-trodden move
+- **Any Architect → TAL** — leadership track
+`;
+
+test('parseProgressionLadders extracts domains, buckets, and role names', () => {
+    const ladders = parseProgressionLadders(LADDER_FIXTURE);
+    assert.equal(ladders.length, 3);
+    assert.deepEqual(ladders[0].levels['Engineer'], ['alpha_engineer', 'alpha_tool_engineer']);
+    assert.deepEqual(ladders[1].levels['Chapter Lead'], ['alpha_chapter_lead']);
+});
+
+test('buildCareerSankey links adjacent present rungs weighted by target count', () => {
+    const s = buildCareerSankey(parseProgressionLadders(LADDER_FIXTURE));
+    const link = (a, b) => s.links.find(l => l.source === a && l.target === b);
+    assert.equal(link('Engineer', 'Senior Engineer').value, 1);
+    assert.equal(link('Senior Engineer', 'Architect').value, 1);
+    assert.equal(link('Senior Engineer', 'Product Owner').value, 1, 'PO branches off Senior');
+    assert.equal(link('Senior Engineer', 'Chapter Lead').value, 1, 'absent rungs are skipped, not broken');
+    assert.equal(link('Chapter Lead', 'Executive').value, 1);
+});
+
+test('buildCareerSankey keeps entry-only rungs as nodes (nothing vanishes)', () => {
+    const s = buildCareerSankey(parseProgressionLadders(LADDER_FIXTURE));
+    assert.ok(s.nodes.some(n => n.name === 'Executive'), 'exec-only domain still contributes its node');
+    assert.ok(s.links.every(l => l.value > 0));
+});
+
+test('career sankey handles the real SKILLS_PROGRESSION.md', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const md = fs.readFileSync(path.join(__dirname, '..', 'docs', 'SKILLS_PROGRESSION.md'), 'utf8');
+    const ladders = parseProgressionLadders(md);
+    assert.equal(ladders.length, 32, 'all 32 domain ladders parse');
+    const totalRoles = ladders.reduce((n, l) => n + Object.values(l.levels).flat().length, 0);
+    assert.equal(totalRoles, 216, 'parser sees every role the drift guard guarantees');
+    const s = buildCareerSankey(ladders);
+    assert.ok(s.nodes.length >= 8, 'all level rungs present');
+    const engSr = s.links.find(l => l.source === 'Engineer' && l.target === 'Senior Engineer');
+    assert.ok(engSr.value >= 40, `main-line flow has real volume (got ${engSr.value})`);
+    const mobility = parseMobilityPaths(md);
+    assert.ok(mobility.length >= 7, 'mobility bullets parse');
+    assert.ok(mobility.some(m => m.path.includes('TAL')));
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -221,6 +221,98 @@
         };
     }
 
+    // Parse the domain-ladder section of docs/SKILLS_PROGRESSION.md into
+    // [{ domain, levels: { bucket: [roleName, …] } }]. Pure markdown in;
+    // the drift-guard tests in test/skills-progression.test.js keep the
+    // document complete, so this parser can trust its shape.
+    function parseProgressionLadders(markdown) {
+        const section = String(markdown)
+            .split('## Domain-by-domain progression paths')[1];
+        if (!section) return [];
+        const body = section.split(/\r?\n## /)[0];
+        const ladders = [];
+        let current = null;
+        for (const line of body.split(/\r?\n/)) {
+            const h = line.match(/^###\s+(.+)/);
+            if (h) {
+                current = { domain: h[1].trim(), levels: {} };
+                ladders.push(current);
+                continue;
+            }
+            const l = current && line.match(/^-\s+([^:]+):\s+(.+)$/);
+            if (l) {
+                const bucket = l[1].trim();
+                const roles = [...l[2].matchAll(/`([a-z0-9_]+)`/g)].map(m => m[1]);
+                if (roles.length) current.levels[bucket] = roles;
+            }
+        }
+        return ladders;
+    }
+
+    // Build a level-flow sankey from parsed ladders. Nodes are career
+    // levels; a link Engineer → Senior Engineer with value 3 means a domain
+    // contributes 3 Senior roles reachable from its Engineer rung. Link
+    // weight = role count at the TARGET level, so node throughput mirrors
+    // how many roles exist at each rung. Product Owner branches off Senior
+    // Engineer; Reliability Engineer branches off Engineer; every ladder
+    // role is represented in exactly one link value (or as a source-only
+    // entry node), so nothing silently disappears (#46 lesson).
+    const SANKEY_MAIN_LINE = [
+        'Engineer', 'Senior Engineer', 'Architect', 'Lead/Principal',
+        'Chapter Lead', 'Area Lead', 'Executive',
+    ];
+    const SANKEY_BRANCHES = {
+        'Reliability Engineer': 'Engineer',
+        'Product Owner':        'Senior Engineer',
+    };
+
+    function buildCareerSankey(ladders) {
+        const linkMap = new Map(); // "src|tgt" → { value, domains: [] }
+        const nodeSet = new Set();
+
+        function addLink(source, target, value, domain) {
+            const key = `${source}|${target}`;
+            if (!linkMap.has(key)) linkMap.set(key, { source, target, value: 0, domains: [] });
+            const l = linkMap.get(key);
+            l.value += value;
+            l.domains.push(`${domain} (${value})`);
+            nodeSet.add(source);
+            nodeSet.add(target);
+        }
+
+        for (const { domain, levels } of ladders) {
+            const present = SANKEY_MAIN_LINE.filter(b => levels[b]);
+            for (let i = 1; i < present.length; i++) {
+                addLink(present[i - 1], present[i], levels[present[i]].length, domain);
+            }
+            if (present.length === 1) nodeSet.add(present[0]); // entry-only rung (e.g. C-Suite Executive)
+            for (const [branch, from] of Object.entries(SANKEY_BRANCHES)) {
+                if (levels[branch] && levels[from]) {
+                    addLink(from, branch, levels[branch].length, domain);
+                }
+            }
+        }
+
+        const order = [...SANKEY_MAIN_LINE, ...Object.keys(SANKEY_BRANCHES)];
+        return {
+            nodes: order.filter(n => nodeSet.has(n)).map(name => ({ name })),
+            links: [...linkMap.values()],
+        };
+    }
+
+    // Parse the cross-domain mobility bullet list from SKILLS_PROGRESSION.md
+    // into [{ path, description }] for display alongside the sankey.
+    function parseMobilityPaths(markdown) {
+        const section = String(markdown).split('## Cross-domain mobility paths')[1];
+        if (!section) return [];
+        const out = [];
+        for (const line of section.split(/\r?\n/)) {
+            const m = line.match(/^-\s+\*\*(.+?)\*\*\s*(?:\((.*?)\))?\s*—\s*(.+)$/);
+            if (m) out.push({ path: m[1].trim(), description: m[3].trim() });
+        }
+        return out;
+    }
+
     // Map each domain label to its chapter label (for graph node
     // categories). Labels not covered by any chapter map to null.
     function labelToChapter(domains, chapters) {
@@ -348,6 +440,9 @@
         buildOrgTree,
         parseInteractions,
         labelToChapter,
+        parseProgressionLadders,
+        buildCareerSankey,
+        parseMobilityPaths,
         resolveDocHref,
     };
 });


### PR DESCRIPTION
## What changed

- **"📈 Careers" header toggle** → ECharts sankey of the catalog's career ladders, parsed live from SKILLS_PROGRESSION.md (which #1 just completed and CI-pinned).
- **Encoding**: rungs as columns (Engineer → … → Executive), band width = role count at the target rung per domain; PO (39 roles) branches off Senior Engineer, Reliability Engineer off Engineer — no ladder role vanishes from the flow. Node colors are an **ordinal blue ramp** (one hue, monotonic lightness with seniority — the dataviz method for ordered levels), branch rungs in aqua.
- **Parsers in viewer-logic.js** (`parseProgressionLadders`, `buildCareerSankey`, `parseMobilityPaths`), 4 new tests (76 total) incl. integration against the real doc: 32 ladders, exactly 216 roles, main-line volume sanity. Combined with #61's drift guards, doc → chart breakage fails CI at two layers.
- **Mobility paths**: rendered as text in the fallback (per issue) — as sankey links they'd be volume-less noise against 40+-role bands; the honest encoding is the list.
- **Accessibility (#17 bar)**: reduced-motion support, `role=img` + aria pointer, keyboard-operable "View as table" fallback with the full flow table + mobility list.
- Mutually exclusive with Matrix/Org/Graph/Stale (verified both directions); closes from all navigation paths; theme-aware re-render.

## Verification (live)
- 9 rungs, 8 aggregate flows; Engineer → Senior = 51 (matches: 55 senior-grade roles minus the 4 in domains with no Engineer rung); Senior → PO = 39 (every PO in the catalog).
- Pixel-verified painting in light (27.1%) and dark (26.3%) modes; fallback renders 8 flow rows + 9 mobility paths; no console errors.
- `npm test` **76/76**; markdownlint clean; CHANGELOG included.

Completes the In-App Data Visualization milestone's original chart set.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)