### PR TITLE
release: 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-12
+
 ### Added
 
 - **Career path flow view (#15).** New "📈 Careers" header toggle renders
@@ -34,19 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   were added to cross-domain mobility. A new test suite pins the doc to
   the catalog — a missing, duplicate, or phantom ladder entry now fails
   CI. Unblocks the #15 career Sankey.
-
-### Accessibility
-
-- **Charts respect `prefers-reduced-motion` (#17).** Users who ask the OS
-  for reduced motion get all four visuals (distribution charts, org chart,
-  relationship graph) without entrance/update animations; the force graph
-  lays out statically. This closes the chart-accessibility issue — the
-  fallback/labeling requirements it tracked were built into each chart as
-  it shipped: aria-label summaries and table/list fallbacks on every
-  visual, identity via labels and shape cues (solid vs dashed edges)
-  rather than color alone, and validated palettes on both themes.
-
-### Added
 
 - **Reference/standards docs are reachable in the viewer again (#29).**
   `/api/roles` now lists `*_standards.md` files in a per-domain
@@ -130,6 +119,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Accessibility
 
+- **Charts respect `prefers-reduced-motion` (#17).** Users who ask the OS
+  for reduced motion get all four visuals (distribution charts, org chart,
+  relationship graph) without entrance/update animations; the force graph
+  lays out statically. This closes the chart-accessibility issue — the
+  fallback/labeling requirements it tracked were built into each chart as
+  it shipped: aria-label summaries and table/list fallbacks on every
+  visual, identity via labels and shape cues (solid vs dashed edges)
+  rather than color alone, and validated palettes on both themes.
 - **Sidebar and matrix navigation is now keyboard-accessible (#24).** All
   clickable divs/spans (role items, resource docs, domain/chapter headers,
   chapter-panel cards, matrix and stale-panel chips, compare-cancel) are

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Security fixes are provided for the current released version of this repository.
 
 | Version | Supported |
 | ------- | --------- |
-| 1.3.x   | Yes       |
-| < 1.3   | No        |
+| 1.4.x   | Yes       |
+| < 1.4   | No        |
 
 ## Reporting a Vulnerability
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
## Release 1.4.0

Version bump 1.3.0 → 1.4.0, `[Unreleased]` → `## [1.4.0] - 2026-07-12` (with the incremental duplicate Added/Accessibility headings consolidated), SECURITY.md supported-versions table updated to 1.4.x.

**Minor release** — headline content:
- Five data views: distribution charts (#14), org chart (#11), relationship graph (#13), career Sankey (#15), plus the existing matrix
- Security: DOMPurify sanitization + full HTML escaping (#25); SECURITY.md; least-privilege CI; Dependabot
- Accessibility: full keyboard navigation (#24), chart fallbacks + reduced motion (#17)
- Content: all 43 validation failures resolved (#7, now a blocking CI check), all 32 domain ladders (#1), governance interaction map (#2), standards docs reachable (#29)
- Tests: 19 → 76, including doc-drift guards

## Verification
- `npm test` 76/76 · validate 0/0 · check-counts matches · markdownlint clean

After merge: tag `v1.4.0` on main, publish the GitHub release with the changelog section, close finished epics/milestones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)