### PR TITLE
feat: per-role career stepper in the role view (closes #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-role career stepper (#55).** The role view now opens with a
+  From → current role → To strip parsed from the role's own Career
+  Development Path section (both heading variants in the catalog are
+  handled; every one of the 216 role files parses). Steps whose text
+  exactly matches a catalog role title become keyboard-operable chips
+  that open that role; unmatched steps render as plain chips. Plain
+  HTML/CSS — no chart library, accessible by construction, hidden in
+  print and in the compare column.
+
 ## [1.4.0] - 2026-07-12
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -488,6 +488,52 @@
         .chart-table td:last-child { text-align: right; color: var(--text-primary); font-weight: 600; }
         @media print { .charts-row { display: none; } }
 
+        /* ── Career stepper (role view, #55) ────────────────── */
+        .career-stepper {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 12px 0 4px;
+            padding: 12px 16px;
+            background: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-md);
+            font-size: 0.82em;
+        }
+        .career-stepper .cs-group { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+        .career-stepper .cs-label {
+            font-size: 0.85em;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: var(--text-muted);
+            margin-right: 2px;
+        }
+        .career-stepper .cs-chip {
+            padding: 3px 10px;
+            border-radius: 20px;
+            background: var(--bg-input);
+            border: 1px solid var(--border-color);
+            color: var(--text-secondary);
+            white-space: nowrap;
+        }
+        .career-stepper .cs-chip[data-file] {
+            color: var(--accent-blue);
+            border-color: var(--border-hover);
+            cursor: pointer;
+        }
+        .career-stepper .cs-chip[data-file]:hover { background: var(--bg-card-hover); text-decoration: underline; }
+        .career-stepper .cs-current {
+            padding: 3px 12px;
+            border-radius: 20px;
+            background: var(--accent-blue);
+            color: #fff;
+            font-weight: 700;
+            white-space: nowrap;
+        }
+        .career-stepper .cs-arrow { color: var(--text-muted); font-weight: 700; }
+        @media print { .career-stepper { display: none; } }
+
         /* ── Org chart view ─────────────────────────────────── */
         .org-canvas {
             width: 100%;
@@ -1055,6 +1101,7 @@
             <!-- Primary role -->
             <div class="role-view" id="roleView">
                 <div class="role-card" id="roleHeader"></div>
+                <nav class="career-stepper" id="careerStepper" aria-label="Career progression for this role" hidden></nav>
                 <div class="md-body"  id="roleBody"></div>
             </div>
 
@@ -1144,7 +1191,7 @@
         STALE_MONTHS, REFERENCE_DOC_PATTERN, LEVEL_ORDER, LEVEL_SHORT,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
-        parseProgressionLadders, buildCareerSankey, parseMobilityPaths,
+        parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
     } = ViewerLogic;
 
     // ── State ───────────────────────────────────────────
@@ -2184,6 +2231,43 @@
         cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
     }
 
+    // ── Career stepper (role view, #55) ───────────────────
+    // From → current role → To chips parsed from the role's own Career
+    // Development Path section. Steps whose text exactly matches a catalog
+    // role title (case-insensitive) become keyboard-operable links that
+    // open that role; the rest render as plain chips.
+    function findRoleByTitle(title) {
+        const t = title.trim().toLowerCase();
+        for (const d of Object.values(allDomains)) {
+            const hit = d.roles.find(r => r.title.trim().toLowerCase() === t);
+            if (hit) return { ...hit, domainLabel: d.label };
+        }
+        return null;
+    }
+
+    function renderCareerStepper(markdown, currentTitle) {
+        const el = document.getElementById('careerStepper');
+        const { from, to } = parseCareerPath(markdown);
+        if (!from.length && !to.length) { el.hidden = true; el.innerHTML = ''; return; }
+
+        const chip = title => {
+            const match = findRoleByTitle(title);
+            return match
+                ? `<span class="cs-chip" role="button" tabindex="0"
+                        data-file="${escapeHtml(match.file)}" data-title="${escapeHtml(match.title)}"
+                        data-level="${escapeHtml(match.level)}" data-domain="${escapeHtml(match.domainLabel)}">${escapeHtml(title)}</span>`
+                : `<span class="cs-chip">${escapeHtml(title)}</span>`;
+        };
+
+        el.innerHTML = `
+            <span class="cs-group"><span class="cs-label">From</span>${from.map(chip).join('')}</span>
+            <span class="cs-arrow" aria-hidden="true">→</span>
+            <span class="cs-current">${escapeHtml(currentTitle)}</span>
+            <span class="cs-arrow" aria-hidden="true">→</span>
+            <span class="cs-group"><span class="cs-label">To</span>${to.map(chip).join('')}</span>`;
+        el.hidden = false;
+    }
+
     // ── Shared: build role header HTML ───────────────────
     function buildHeader(title, level, domainLabel, lastReviewed, slot) {
         const isCompare = slot === 'B';
@@ -2233,6 +2317,7 @@
 
         // Placeholder header (no reviewed date yet)
         document.getElementById('roleHeader').innerHTML = buildHeader(title, level, domainLabel, null, 'A');
+        document.getElementById('careerStepper').hidden = true;
         document.getElementById('roleBody').innerHTML =
             '<div class="loading"><div class="spinner"></div> Loading…</div>';
 
@@ -2249,6 +2334,7 @@
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;
             document.getElementById('roleBody').innerHTML = renderMarkdown(body);
+            renderCareerStepper(markdown, title);
             document.getElementById('mainArea').scrollTop = 0;
 
             lastMarkdown      = markdown;
@@ -2755,6 +2841,13 @@
         const chip = e.target.closest('.matrix-chip');
         if (!chip) return;
         openRole(chip.dataset.file, chip.dataset.title, chip.dataset.level, chip.dataset.domain);
+    });
+
+    // ── Career-stepper chip clicks (single delegated listener) ─
+    document.getElementById('careerStepper').addEventListener('click', e => {
+        const chipEl = e.target.closest('.cs-chip[data-file]');
+        if (!chipEl) return;
+        openRole(chipEl.dataset.file, chipEl.dataset.title, chipEl.dataset.level, chipEl.dataset.domain);
     });
 
     // ── Org list-fallback clicks (single delegated listener) ─

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -19,6 +19,7 @@ const {
     parseProgressionLadders,
     buildCareerSankey,
     parseMobilityPaths,
+    parseCareerPath,
     resolveDocHref,
 } = require('../viewer-logic');
 
@@ -486,4 +487,48 @@ test('career sankey handles the real SKILLS_PROGRESSION.md', () => {
     const mobility = parseMobilityPaths(md);
     assert.ok(mobility.length >= 7, 'mobility bullets parse');
     assert.ok(mobility.some(m => m.path.includes('TAL')));
+});
+
+// ── parseCareerPath ──────────────────────────────────────
+
+test('parseCareerPath handles the dominant heading variant', () => {
+    const md = `# Role\n\n## Career Development Path\n\n**Previous Roles:**\n\n- System Administrator\n- Build Engineer\n\n**Potential Next Roles:**\n\n- Senior Engineer\n\n## Interactions with Other Roles\n\n- stuff`;
+    assert.deepEqual(parseCareerPath(md), {
+        from: ['System Administrator', 'Build Engineer'],
+        to:   ['Senior Engineer'],
+    });
+});
+
+test('parseCareerPath handles the From/To (typical …) variant', () => {
+    const md = `## Career Development Path\n\n**From (typical previous roles):**\n\n- VMware Senior Engineer\n\n**To (typical next roles):**\n\n- Cloud Lead Architect\n- Enterprise Architect\n`;
+    assert.deepEqual(parseCareerPath(md), {
+        from: ['VMware Senior Engineer'],
+        to:   ['Cloud Lead Architect', 'Enterprise Architect'],
+    });
+});
+
+test('parseCareerPath returns empty lists when the section is absent', () => {
+    assert.deepEqual(parseCareerPath('# Role\n\n## Role Overview\n\nText.'), { from: [], to: [] });
+});
+
+test('parseCareerPath ignores bullets outside the from/to sub-lists', () => {
+    const md = `## Career Development Path\n\nIntro text.\n\n- stray bullet\n\n**Previous Roles:**\n\n- Real Entry\n\n**Growth areas:**\n\n- not a role list\n`;
+    assert.deepEqual(parseCareerPath(md), { from: ['Real Entry'], to: [] });
+});
+
+test('parseCareerPath parses every role file in the catalog', () => {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    let withBoth = 0, total = 0;
+    for (const d of fs.readdirSync(path.join(__dirname, '..', 'Roles'), { withFileTypes: true })) {
+        if (!d.isDirectory()) continue;
+        for (const f of fs.readdirSync(path.join(__dirname, '..', 'Roles', d.name))) {
+            if (!f.endsWith('.md') || f === 'README.md' || /_standards\.md$/.test(f)) continue;
+            total++;
+            const cp = parseCareerPath(fs.readFileSync(path.join(__dirname, '..', 'Roles', d.name, f), 'utf8'));
+            if (cp.from.length && cp.to.length) withBoth++;
+        }
+    }
+    assert.equal(total, 216);
+    assert.equal(withBoth, 216, 'every role file yields both From and To lists');
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -411,6 +411,32 @@
             : { name: 'IT Organisation', kind: 'group', children: rootChildren };
     }
 
+    // Parse a role file's "## Career Development Path" section into
+    // { from: [...], to: [...] }. The catalog uses two heading variants
+    // ("Previous Roles:" / "Potential Next Roles:" in 210 files,
+    // "From (typical previous roles):" / "To (typical next roles):" in 6);
+    // both are handled. Returns empty lists when the section is absent.
+    function parseCareerPath(markdown) {
+        const section = String(markdown).split(/^## Career Development Path\s*$/m)[1];
+        const out = { from: [], to: [] };
+        if (!section) return out;
+        const body = section.split(/\r?\n## /)[0];
+        let current = null;
+        for (const line of body.split(/\r?\n/)) {
+            const bold = line.match(/^\*\*(.+?):?\*\*/);
+            if (bold) {
+                const h = bold[1].toLowerCase();
+                current = /previous|from \(/.test(h) ? 'from'
+                        : /next|to \(/.test(h)       ? 'to'
+                        : null;
+                continue;
+            }
+            const item = current && line.match(/^-\s+(.+)$/);
+            if (item) out[current].push(item[1].trim());
+        }
+        return out;
+    }
+
     // Resolve a Markdown link href relative to the file it appears in.
     // Repo-absolute hrefs (Roles/…, docs/…) pass through unchanged.
     function resolveDocHref(href, baseFile = '') {
@@ -443,6 +469,7 @@
         parseProgressionLadders,
         buildCareerSankey,
         parseMobilityPaths,
+        parseCareerPath,
         resolveDocHref,
     };
 });


### PR DESCRIPTION
## What changed

- **Career stepper strip** between the role header and body: `From [chips] → Current → To [chips]`, parsed client-side from the already-fetched role markdown — no server change.
- **`parseCareerPath()` in viewer-logic.js**, 5 new tests (81 total): both heading variants ('Previous/Potential Next Roles' ×210 files, 'From/To (typical …)' ×6), absent-section fallback, stray-bullet rejection, and an integration test proving **all 216 role files parse with both lists**.
- **Catalog matching**: steps whose text exactly matches a role title (case-insensitive) become `role=button tabindex=0` chips (the #24 keyboard pattern, activated by the existing global Enter/Space handler) that open that role via the standard delegated-click path; unmatched steps ('System Administrator', 'Developer with infrastructure focus') render as plain chips — no guessing.
- Plain HTML/CSS per the issue's approach — accessible by construction (`<nav aria-label>`), themed via CSS variables, hidden in print, absent from the compare column (slot B untouched), hidden while loading and when the section is missing.

## Verification (live, with screenshot this time)
- Kubernetes Engineer: 5 From chips, 3 catalog-linked chips; clicking 'DevOps Engineer' opened that role, whose own stepper rendered in turn.
- Visual: linked chips in accent blue, current role highlighted, wraps cleanly.
- No console errors; `npm test` **81/81**; markdownlint clean; CHANGELOG included.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)