### PR TITLE
fix: retire one-role Reliability Engineer career level (closes #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Retired the one-role "Reliability Engineer" career level (#69).**
+  The canonical level was held by exactly one of 216 roles
+  (`platform_reliability_engineer`), which made that role render as a
+  career dead end — a terminal Sankey branch, a one-chip matrix column,
+  and a ladder line with no upward connection — while its own Career
+  Development Path listed real next steps. The role is now graded
+  Engineer like the catalog's four other reliability-titled roles; the
+  level was removed from `roleMeta.js`, `viewer-logic.js`
+  (LEVEL_ORDER/LEVEL_SHORT/badge/sankey branch), the welcome stats, and
+  the DevOps ladder. Also fixed the role's phantom "Platform Reliability
+  Senior Engineer" next-step: its To-list now names the real DevOps /
+  Site Reliability / Observability Senior Engineer roles, all of which
+  link in the career stepper.
+
 ### Added
 
 - **Per-role career stepper (#55).** The role view now opens with a

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
-| **Role Level** | Reliability Engineer |
+| **Role Level** | Engineer |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -139,8 +139,8 @@ The Platform Reliability Engineer applies site reliability engineering (SRE) pri
 
 **Potential Next Roles:**
 
-- Platform Reliability Senior Engineer
-- Site Reliability Engineer (Senior)
+- DevOps Senior Engineer
+- Site Reliability Senior Engineer
 - Observability Senior Engineer
 - DevOps Architect (platform reliability specialism)
 - Head of Platform Reliability / SRE Practice Lead

--- a/docs/SKILLS_PROGRESSION.md
+++ b/docs/SKILLS_PROGRESSION.md
@@ -126,9 +126,8 @@ Every domain in the catalog is listed below (alphabetically), with every role fi
 
 ### DevOps
 
-- Engineer: `automation_framework_engineer`, `developer_experience_engineer`, `devops_engineer`
+- Engineer: `automation_framework_engineer`, `developer_experience_engineer`, `devops_engineer`, `platform_reliability_engineer`
 - Senior Engineer: `devops_senior_engineer`
-- Reliability Engineer: `platform_reliability_engineer`
 - Architect: `devops_architect`
 - Product Owner: `devops_product_owner`
 

--- a/index.html
+++ b/index.html
@@ -368,7 +368,6 @@
         .b-eng   { background: rgba(40,167,69,0.14);  color: #28a745; }
         .b-po    { background: rgba(255,152,0,0.14);  color: #e08000; }
         .b-standards { background: rgba(23,162,184,0.12); color: var(--accent-cyan); }
-        .b-sre   { background: rgba(23,162,184,0.14); color: #17a2b8; }
         .b-pal   { background: rgba(30,58,95,0.14);   color: #1e3a5f; }
         .b-tal   { background: rgba(0,120,212,0.22);  color: #005a9e; font-weight: 700; }
 
@@ -386,7 +385,6 @@
         [data-theme="dark"] .b-eng  { background: rgba(40,167,69,0.28);  color: #6bcf7f; }
         [data-theme="dark"] .b-po   { background: rgba(255,152,0,0.28);  color: #ffb84d; }
         [data-theme="dark"] .b-standards { background: rgba(23,162,184,0.25); color: #5fd3e8; }
-        [data-theme="dark"] .b-sre  { background: rgba(23,162,184,0.28); color: #5bc8d9; }
         [data-theme="dark"] .b-pal  { background: rgba(100,160,255,0.2); color: #a0c8ff; font-weight: 700; }
         [data-theme="dark"] .b-tal  { background: rgba(0,120,212,0.35);  color: #90d0ff; font-weight: 700; }
 
@@ -1160,9 +1158,9 @@
                 <div>
                     <h2>📈 Career Path Flow</h2>
                     <p>How the catalog's roles ladder upward — built live from the Skills Progression
-                       reference. Band width shows how many roles each rung offers; Product Owner and
-                       Reliability Engineer branch off the individual-contributor line. Hover any band
-                       for the contributing domains.</p>
+                       reference. Band width shows how many roles each rung offers; Product Owner
+                       branches off the individual-contributor line. Hover any band for the
+                       contributing domains.</p>
                 </div>
             </div>
             <div id="careersChartCanvas" class="org-canvas" role="img"
@@ -1348,7 +1346,7 @@
         const chLeadCount   = count('Chapter Lead');
         const talPalCount   = count('Technical Area Lead') + count('Product Area Lead');
         const execCount     = count('CEO') + count('CTO') + count('CIO') + count('SVP') + count('CISO');
-        const seniorCount   = count('Senior Engineer') + count('Reliability Engineer');
+        const seniorCount   = count('Senior Engineer');
         const poCount       = count('Product Owner');
         const engCount      = count('Engineer');
 
@@ -1810,13 +1808,13 @@
             'Engineer': '#86b6ef', 'Senior Engineer': '#5598e7', 'Architect': '#2a78d6',
             'Lead/Principal': '#1c5cab', 'Chapter Lead': '#184f95', 'Area Lead': '#104281',
             'Executive': '#0d366b',
-            'Reliability Engineer': '#1baf7a', 'Product Owner': '#1baf7a',
+            'Product Owner': '#1baf7a',
         },
         dark: {
             'Engineer': '#9ec5f4', 'Senior Engineer': '#6da7ec', 'Architect': '#3987e5',
             'Lead/Principal': '#2a78d6', 'Chapter Lead': '#256abf', 'Area Lead': '#1c5cab',
             'Executive': '#184f95',
-            'Reliability Engineer': '#199e70', 'Product Owner': '#199e70',
+            'Product Owner': '#199e70',
         },
     };
 

--- a/roleMeta.js
+++ b/roleMeta.js
@@ -67,7 +67,6 @@ const CANONICAL_LEVELS = [
   'Architect',
   'Senior Engineer',
   'Engineer',
-  'Reliability Engineer',
   'Product Owner',
 ];
 
@@ -78,7 +77,6 @@ const KNOWN_LEVELS = new Set(CANONICAL_LEVELS);
 const LEVEL_ALIASES = {
   'svp of technology': 'SVP',
   'svp':               'SVP',
-  'reliability engineer': 'Reliability Engineer',
 };
 
 // Read a single `| **Field** | value |` cell from a markdown metadata table.
@@ -120,7 +118,6 @@ function detectLevelFromFilename(filename) {
   if (/engineering_practices_champion\.md$/.test(filename))     return 'Senior Engineer';
   if (/identity_governance_specialist\.md$/.test(filename))     return 'Senior Engineer';
   if (/_product_owner\.md$/.test(filename))                     return 'Product Owner';
-  if (/_reliability_engineer\.md$/.test(filename))              return 'Reliability Engineer';
   return 'Engineer';
 }
 

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -39,7 +39,6 @@
         'Architect',
         'Senior Engineer',
         'Engineer',
-        'Reliability Engineer',
         'Product Owner',
     ];
 
@@ -59,7 +58,6 @@
         'Architect':           'Architect',
         'Senior Engineer':     'Sr Engineer',
         'Engineer':            'Engineer',
-        'Reliability Engineer':'SRE',
         'Product Owner':       'Prod Owner',
     };
 
@@ -94,7 +92,6 @@
         if (level === 'Architect')           return 'b-arch';
         if (level === 'Senior Engineer')     return 'b-sen';
         if (level === 'Product Owner')       return 'b-po';
-        if (level.includes('Reliability'))   return 'b-sre';
         return 'b-eng';
     }
 
@@ -254,16 +251,15 @@
     // contributes 3 Senior roles reachable from its Engineer rung. Link
     // weight = role count at the TARGET level, so node throughput mirrors
     // how many roles exist at each rung. Product Owner branches off Senior
-    // Engineer; Reliability Engineer branches off Engineer; every ladder
-    // role is represented in exactly one link value (or as a source-only
-    // entry node), so nothing silently disappears (#46 lesson).
+    // Engineer; every ladder role is represented in exactly one link value
+    // (or as a source-only entry node), so nothing silently disappears
+    // (#46 lesson).
     const SANKEY_MAIN_LINE = [
         'Engineer', 'Senior Engineer', 'Architect', 'Lead/Principal',
         'Chapter Lead', 'Area Lead', 'Executive',
     ];
     const SANKEY_BRANCHES = {
-        'Reliability Engineer': 'Engineer',
-        'Product Owner':        'Senior Engineer',
+        'Product Owner': 'Senior Engineer',
     };
 
     function buildCareerSankey(ladders) {


### PR DESCRIPTION
## What changed (Option A per #69)

- **`platform_reliability_engineer` re-graded** `Reliability Engineer` → `Engineer`, consistent with the catalog's four other reliability-titled roles (3× Engineer, 1× Senior Engineer). The reliability identity stays in the title, where the siblings already carry it.
- **Level removed everywhere**: `CANONICAL_LEVELS` + alias + filename-inference rule (roleMeta.js); `LEVEL_ORDER`/`LEVEL_SHORT`/badge branch/sankey branch map (viewer-logic.js); welcome-stat senior count, sankey node colors, careers-panel description, orphaned `.b-sre` CSS (index.html); DevOps ladder line (SKILLS_PROGRESSION.md — the role joins the Engineer line).
- **Phantom next-step fixed**: the To-list's non-existent 'Platform Reliability Senior Engineer' → 'DevOps Senior Engineer', and 'Site Reliability Engineer (Senior)' corrected to the exact catalog title 'Site Reliability Senior Engineer' so both link in the #55 stepper.

## Verification (live)
- Matrix: **216 chips**, no SRE column, the role's chip carries Engineer.
- Sankey: 8 rungs (terminal branch gone); Engineer → Senior flow unchanged at 51 (encoding is target-count-weighted, so absorbing the role into the Engineer rung changes no link values — nothing lost).
- Role view: Engineer badge; stepper now links **three** real senior roles (DevOps / Site Reliability / Observability Senior Engineer).
- The level-parity and ladder-drift test suites pointed at every touch site and pass clean: `npm test` **81/81**; validate 0/0; markdownlint clean; no console errors; CHANGELOG included.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)