### PR TITLE
fix: attach security chapter under the CISO in the org chart (closes #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Org chart: the CISO now carries the security-governance line (#71).**
+  The CISO previously rendered as a childless C-suite leaf while the entire
+  Security & Identity chapter hung under the SVP of Technology —
+  contradicting the role content, in which the CISO "provides strategic
+  direction to the Security & Identity Chapter Lead and senior security
+  architects." `buildOrgTree()` now attaches the Security & Identity chapter
+  (its Chapter Lead, 5 domains, and all security roles) under the CISO, with
+  every other chapter remaining under the SVP; the tree falls back to the
+  old placement when no CISO exists. All 216 roles still appear exactly
+  once, and the org-view copy names the CISO→security relationship.
 - **Retired the one-role "Reliability Engineer" career level (#69).**
   The canonical level was held by exactly one of 216 roles
   (`platform_reliability_engineer`), which made that role render as a

--- a/index.html
+++ b/index.html
@@ -1122,7 +1122,9 @@
             <div class="matrix-header">
                 <div>
                     <h2>🌳 Organisation Chart</h2>
-                    <p>Leadership line and Chapters → Domains → Roles. Click a node to expand or collapse it,
+                    <p>Leadership line and Chapters → Domains → Roles. The CISO carries the
+                       security-governance line (the Security &amp; Identity chapter); the SVP of
+                       Technology carries the rest. Click a node to expand or collapse it,
                        click a role to open it; drag to pan, scroll to zoom.</p>
                 </div>
             </div>

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -342,6 +342,51 @@ test('buildOrgTree falls back to a generic root when no CEO exists', () => {
     assert.equal(collectFiles(tree).length, 7, 'all remaining roles still placed');
 });
 
+function cisoFixture() {
+    const domains = {
+        c_suite:    { label: 'C-Suite',    roles: [{ title: 'CEO', file: 'Roles/c_suite/ceo.md', level: 'CEO' }] },
+        leadership: { label: 'Leadership', roles: [
+            { title: 'SVP of Technology', file: 'Roles/leadership/svp.md', level: 'SVP' },
+            { title: 'Chief Information Security Officer', file: 'Roles/leadership/ciso.md', level: 'CISO' },
+            { title: 'Security & Identity Chapter Lead', file: 'Roles/leadership/sec_lead.md', level: 'Chapter Lead' },
+        ] },
+        security:   { label: 'Security', roles: [{ title: 'Security Engineer', file: 'Roles/security/eng.md', level: 'Engineer' }] },
+        devops:     { label: 'DevOps',   roles: [{ title: 'DevOps Engineer', file: 'Roles/devops/eng.md', level: 'Engineer' }] },
+    };
+    const chapters = {
+        security_identity: { label: 'Security & Identity', domains: ['security'], leadFile: 'Roles/leadership/sec_lead.md' },
+        devops_delivery:   { label: 'DevOps & Delivery',   domains: ['devops'],   leadFile: null },
+        leadership_chapter:{ label: 'Leadership',           domains: ['c_suite', 'leadership'], leadFile: null },
+    };
+    return { domains, chapters };
+}
+
+test('buildOrgTree attaches the Security & Identity chapter under the CISO, not the SVP (#71)', () => {
+    const { domains, chapters } = cisoFixture();
+    const tree = buildOrgTree(domains, chapters);
+    const ciso = tree.children.find(c => c.name === 'Chief Information Security Officer');
+    const svp  = tree.children.find(c => c.name === 'SVP of Technology');
+    assert.ok(ciso, 'CISO sits on the executive line');
+    const cisoChapters = (ciso.children || []).map(c => c.name);
+    assert.ok(cisoChapters.includes('Security & Identity'), 'security chapter hangs under the CISO');
+    const svpChapters = (svp.children || []).map(c => c.name);
+    assert.ok(!svpChapters.includes('Security & Identity'), 'security chapter no longer under the SVP');
+    assert.ok(svpChapters.includes('DevOps & Delivery'), 'other chapters remain under the SVP');
+    // The security engineer still appears exactly once, now beneath the CISO.
+    assert.ok(collectFiles(ciso).includes('Roles/security/eng.md'));
+    const all = collectFiles(tree);
+    assert.equal(new Set(all).size, all.length, 'no role duplicated by the re-parenting');
+});
+
+test('buildOrgTree leaves the security chapter under the SVP when there is no CISO', () => {
+    const { domains, chapters } = cisoFixture();
+    domains.leadership.roles = domains.leadership.roles.filter(r => r.level !== 'CISO');
+    const tree = buildOrgTree(domains, chapters);
+    const svp = tree.children.find(c => c.name === 'SVP of Technology');
+    assert.ok((svp.children || []).some(c => c.name === 'Security & Identity'),
+        'without a CISO the security chapter falls back under the SVP');
+});
+
 // ── parseInteractions ────────────────────────────────────
 
 const INTERACTIONS_FIXTURE = `# Cross-domain interactions

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -344,8 +344,12 @@
         // Leadership line
         const ceo  = take(r => r.level === 'CEO');
         const svp  = take(r => r.level === 'SVP');
-        const suite = ['CTO', 'CIO', 'CFO', 'CISO']
+        const suite = ['CTO', 'CIO', 'CFO']
             .map(lvl => take(r => r.level === lvl)).filter(Boolean);
+        // The CISO is placed separately from the flat C-suite: it owns the
+        // security-governance line (the Security & Identity chapter) per the
+        // CISO role content, rather than dangling as a childless leaf (#71).
+        const ciso = take(r => r.level === 'CISO');
         const areaLeads = [];
         for (;;) {
             const lead = take(r => r.level === 'Product Area Lead' || r.level === 'Technical Area Lead');
@@ -353,9 +357,10 @@
             areaLeads.push(lead);
         }
 
-        // Chapter nodes (the Leadership chapter IS the line above — skip any
-        // chapter whose domains are all consumed by leadership placement).
-        const chapterNodes = Object.entries(chapters)
+        // Chapter nodes, kept keyed so the security chapter can be re-parented
+        // under the CISO. (The Leadership chapter IS the line above — skip any
+        // chapter whose domains are all consumed by leadership placement.)
+        const chapterEntries = Object.entries(chapters)
             .filter(([, ch]) => ch.domains.some(d => domains[d] && !['c_suite', 'leadership'].includes(d)))
             .map(([key, ch]) => {
                 const lead = ch.leadFile
@@ -372,14 +377,14 @@
                             return roleNode(r);
                         }),
                     }));
-                return {
+                return [key, {
                     name: ch.label,
                     kind: 'chapter',
                     file: lead ? lead.file : null,
                     leadTitle: lead ? lead.title : null,
                     count: domainNodes.reduce((n, d) => n + d.count, 0),
                     children: domainNodes,
-                };
+                }];
             });
 
         // Anything not yet placed (e.g. cross-cutting leadership roles)
@@ -393,13 +398,28 @@
             }]
             : [];
 
+        // The Security & Identity chapter attaches under the CISO (its
+        // security-governance line, per the CISO content); every other chapter
+        // sits under the SVP. When no CISO exists it stays under the SVP.
+        const CISO_CHAPTER_KEY = 'security_identity';
+        const attachSecurityToCiso = !!ciso && chapterEntries.some(([k]) => k === CISO_CHAPTER_KEY);
+        const cisoNode = ciso
+            ? (attachSecurityToCiso
+                ? { ...roleNode(ciso, 'exec'), children: chapterEntries.filter(([k]) => k === CISO_CHAPTER_KEY).map(([, n]) => n) }
+                : roleNode(ciso, 'exec'))
+            : null;
+        const svpChapterNodes = chapterEntries
+            .filter(([k]) => !(attachSecurityToCiso && k === CISO_CHAPTER_KEY))
+            .map(([, n]) => n);
+
         const svpNode = svp
-            ? { ...roleNode(svp, 'exec'), children: [...areaLeads.map(r => roleNode(r, 'lead')), ...crossCutting, ...chapterNodes] }
+            ? { ...roleNode(svp, 'exec'), children: [...areaLeads.map(r => roleNode(r, 'lead')), ...crossCutting, ...svpChapterNodes] }
             : null;
 
         const rootChildren = [
             ...suite.map(r => roleNode(r, 'exec')),
-            ...(svpNode ? [svpNode] : [...areaLeads.map(r => roleNode(r, 'lead')), ...crossCutting, ...chapterNodes]),
+            ...(cisoNode ? [cisoNode] : []),
+            ...(svpNode ? [svpNode] : [...areaLeads.map(r => roleNode(r, 'lead')), ...crossCutting, ...svpChapterNodes]),
         ];
 
         return ceo


### PR DESCRIPTION
## What changed

The CISO rendered as a childless leaf while the whole Security & Identity chapter hung under the SVP — the org's top security executive appeared to govern nothing (maintainer-reported). The role content says otherwise: the CISO *'provides strategic direction to the Security & Identity Chapter Lead and senior security architects'* and *'sits above the PAL and TAL on matters of security governance.'*

- **`buildOrgTree()`**: the CISO is pulled out of the flat C-suite array and receives the `security_identity` chapter (its Chapter Lead, 5 domains, all security roles) as its child; that chapter is removed from the SVP's children. Guarded for the no-CISO case (chapter stays under the SVP — prior behavior).
- **Org-view copy** now names the split: CISO carries the security-governance line, SVP carries the rest.

### On the nuance
The Chapter Lead's HR line manager is a TAL/PAL, not the CISO — the CISO relationship is strategic direction. But the org tree already abstracts the TAL/PAL layer away (every chapter hangs directly off the SVP, not its actual line manager), so it is a leadership/governance view; showing the security-governance line the CISO content explicitly claims is the faithful parallel.

## Verification (live)
- CISO node now parents **Security & Identity (38 roles)**; SVP keeps the other five chapters and no longer shows security.
- Tree still has **216 unique role nodes** — the re-parenting moves the subtree, drops nothing (invariant preserved).
- Canvas paints (pixel-verified 4.4%; Browser-pane screenshots still unavailable — same backgrounded-pane rAF suspension noted in #11/#13); no console errors.
- 2 new tests (CISO parenting + no-CISO fallback); `npm test` **83/83**; validate 0/0; markdownlint clean; CHANGELOG included.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)