### PR TITLE
feat: flag duplicate role titles in the validator (closes #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **The validator now flags duplicate role titles (#67).**
+  `validate-roles.js` groups H1 titles across all non-reference role files
+  and fails (exit 1, blocking CI) on any title held by more than one role,
+  naming both paths. Duplicate titles shipped in v1.2.0 (3 cross-domain
+  pairs) and v1.3.0 (a pair the filename scan missed because the files
+  differed); this closes the recurrence. Covered by fixture tests; the
+  current catalog has zero duplicates.
+
 ### Fixed
 
 - **Org chart: the CISO now carries the security-governance line (#71).**

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -7,7 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-const { listRoleFiles, validateFile, REQUIRED_SECTIONS } = require('../validate-roles');
+const { listRoleFiles, validateFile, findDuplicateTitles, REQUIRED_SECTIONS } = require('../validate-roles');
 
 // All fixtures are generated into a temp tree at runtime — nothing under
 // Roles/ or test/ is touched, so `npm run validate` and markdownlint on the
@@ -182,9 +182,11 @@ function runCli(rolesDir, args = []) {
 test('CLI exits 0 on a clean tree, and warnings do not fail a normal run', () => {
   const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-'));
   fs.mkdirSync(path.join(cliRoot, 'testdomain'));
-  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'), completeRole());
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'),
+    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role') }));
   fs.writeFileSync(path.join(cliRoot, 'testdomain', 'warny.md'), completeRole({
-    transform: c => c.replace('| **Role Level** | Engineer |', '| **Role Level** | Grand Wizard |'),
+    transform: c => c.replace('# Test Role', '# Warny Role')
+                     .replace('| **Role Level** | Engineer |', '| **Role Level** | Grand Wizard |'),
   }));
   const normal = runCli(cliRoot);
   assert.equal(normal.status, 0, normal.stdout);
@@ -205,4 +207,63 @@ test('CLI exits 1 when a file has errors', () => {
   assert.equal(run.status, 1);
   assert.match(run.stdout, /Missing section: ## Business Impact/);
   fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+
+// ── findDuplicateTitles (#67) ────────────────────────────
+// Isolated temp trees (not the shared tmpRoot, which accumulates many
+// "Test Role" H1s across the other tests).
+
+function isolatedTree(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-dupe-'));
+  fs.mkdirSync(path.join(root, 'dom_a'));
+  fs.mkdirSync(path.join(root, 'dom_b'));
+  for (const [rel, title] of Object.entries(files)) {
+    fs.writeFileSync(path.join(root, rel), `# ${title}\n\n| Field | Value |\n|---|---|\n| **Domain** | x |\n`);
+  }
+  return root;
+}
+
+test('findDuplicateTitles reports a title shared by two role files, with both paths', () => {
+  const root = isolatedTree({
+    'dom_a/one.md': 'Platform Owner',
+    'dom_b/two.md': 'Platform Owner',
+    'dom_a/three.md': 'Unique Role',
+  });
+  const dupes = findDuplicateTitles(root);
+  assert.equal(dupes.length, 1);
+  assert.equal(dupes[0].title, 'Platform Owner');
+  // rel paths carry the temp-dir basename prefix; assert on the tail.
+  assert.deepEqual(dupes[0].files.map(f => f.split('/').slice(-2).join('/')),
+    ['dom_a/one.md', 'dom_b/two.md']);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('findDuplicateTitles returns nothing when every title is unique', () => {
+  const root = isolatedTree({ 'dom_a/one.md': 'Alpha', 'dom_b/two.md': 'Beta' });
+  assert.deepEqual(findDuplicateTitles(root), []);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('findDuplicateTitles ignores _standards.md reference docs', () => {
+  const root = isolatedTree({
+    'dom_a/role.md': 'Shared Name',
+    'dom_a/cost_standards.md': 'Shared Name', // reference doc, must not count
+  });
+  assert.deepEqual(findDuplicateTitles(root), []);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('CLI exits 1 and names both files when a duplicate title exists', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-dupe-cli-'));
+  fs.mkdirSync(path.join(root, 'testdomain'));
+  fs.writeFileSync(path.join(root, 'testdomain', 'a.md'), completeRole({ transform: c => c.replace('# Test Role', '# Same Title') }));
+  fs.writeFileSync(path.join(root, 'testdomain', 'b.md'), completeRole({ transform: c => c.replace('# Test Role', '# Same Title') }));
+  const run = spawnSync(process.execPath, [path.join(__dirname, '..', 'validate-roles.js')], {
+    env: { ...process.env, ROLES_DIR: root }, encoding: 'utf8',
+  });
+  assert.equal(run.status, 1);
+  assert.match(run.stdout, /Duplicate role title: "Same Title"/);
+  assert.match(run.stdout, /testdomain\/a\.md/);
+  assert.match(run.stdout, /testdomain\/b\.md/);
+  fs.rmSync(root, { recursive: true, force: true });
 });

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -96,6 +96,26 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
   return { rel, errors, warnings, skipped: false };
 }
 
+// Group H1 titles across all non-reference role files and return
+// [{ title, files: [rel, …] }] for any title held by more than one role.
+// Duplicate titles shipped in both v1.2.0 (3 cross-domain pairs) and
+// v1.3.0 (a pair the filename scan missed because the files differed);
+// this makes the recurrence a blocking validation error.
+function findDuplicateTitles(rolesDir = ROLES_DIR) {
+  const byTitle = new Map();
+  for (const filePath of listRoleFiles(rolesDir)) {
+    if (REFERENCE_DOC_PATTERN.test(path.basename(filePath))) continue;
+    const title = parseMeta(fs.readFileSync(filePath, 'utf8')).title;
+    if (!title) continue; // a missing H1 is already a per-file error
+    const rel = path.relative(path.dirname(rolesDir), filePath).replace(/\\/g, '/');
+    if (!byTitle.has(title)) byTitle.set(title, []);
+    byTitle.get(title).push(rel);
+  }
+  return [...byTitle.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([title, files]) => ({ title, files: files.sort() }));
+}
+
 function main() {
   const files   = listRoleFiles();
   const results = files.map(f => validateFile(f));
@@ -103,6 +123,7 @@ function main() {
   const withErrors   = results.filter(r => r.errors.length > 0);
   const withWarnings = results.filter(r => r.warnings.length > 0);
   const skipped      = results.filter(r => r.skipped);
+  const duplicates   = findDuplicateTitles();
 
   for (const r of withErrors) {
     console.log(`\n✖ ${r.rel}`);
@@ -114,13 +135,19 @@ function main() {
     for (const w of r.warnings) console.log(`  warn:  ${w}`);
   }
 
+  for (const d of duplicates) {
+    console.log(`\n✖ Duplicate role title: "${d.title}"`);
+    for (const f of d.files) console.log(`  ${f}`);
+  }
+
   console.log(`\n${'─'.repeat(60)}`);
   console.log(`Checked ${files.length} role files (${skipped.length} reference docs skipped)`);
   console.log(`  ${withErrors.length} file(s) with errors`);
   console.log(`  ${withWarnings.length} file(s) with warnings`);
+  console.log(`  ${duplicates.length} duplicate title(s)`);
   console.log('─'.repeat(60));
 
-  if (withErrors.length > 0 || (STRICT && withWarnings.length > 0)) {
+  if (withErrors.length > 0 || duplicates.length > 0 || (STRICT && withWarnings.length > 0)) {
     process.exitCode = 1;
   }
 }
@@ -131,4 +158,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { listRoleFiles, validateFile, REQUIRED_SECTIONS };
+module.exports = { listRoleFiles, validateFile, findDuplicateTitles, REQUIRED_SECTIONS };


### PR DESCRIPTION
## What changed
- **`findDuplicateTitles()`** (exported) groups H1 titles across all non-reference role files and returns `[{ title, files: [...] }]` for any title used by more than one role.
- **`main()`** prints each duplicate with both paths, adds a `N duplicate title(s)` summary line, and includes duplicates in the exit-1 condition — so a dupe fails `npm run validate` and therefore the blocking CI step.
- Reference docs (`_standards.md`) are excluded; a missing H1 is left to the existing per-file error.

## Why
Duplicate titles have shipped **twice** — v1.2.0 (3 cross-domain pairs) and v1.3.0 (Java Platform Product Owner, which the filename scan missed because the two files differed). Nothing guarded the recurrence until now.

## Verification
- 4 new fixture tests (dup detected with both paths, unique-clean, reference-doc excluded, CLI exit-1 + both paths named). Fixed a pre-existing CLI test that accidentally wrote two identically-titled files.
- `npm test` **87/87**; `npm run validate` on the real catalog: **0 duplicate titles**, 0 errors, 0 warnings.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)