### PR TITLE
feat: full-text search across role content (closes #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Full-text search across role content (#68).** The sidebar search still
+  filters titles/domains/chapters instantly, but for queries of 3+ chars it
+  now also asks the server (`/api/search`) to search role *bodies* and
+  prepends a "Content matches" group with a snippet around each hit — so
+  searching "Terraform", "Entra", or "Slurm" finds the roles that mention
+  it, not just those with it in the title. The server keeps a body index
+  cached against the same mtime signature as `/api/roles` (no extra I/O
+  until a search runs, live-edit pickup preserved), excludes reference
+  docs, caps results at 50, and sorts title matches first. Results are
+  keyboard-operable (#24 pattern) and open the role like any sidebar item;
+  the query is debounced and guarded against out-of-order responses.
 - **The validator now flags duplicate role titles (#67).**
   `validate-roles.js` groups H1 titles across all non-reference role files
   and fails (exit 1, blocking CI) on any title held by more than one role,

--- a/index.html
+++ b/index.html
@@ -962,6 +962,35 @@
         }
 
         /* ── RESOURCES SIDEBAR SECTION ───────────────────────────── */
+        /* ── Content-search matches (#68) ─────────────────── */
+        .content-matches {
+            border-bottom: 2px solid var(--border-color);
+            margin: 0 0 6px;
+            padding: 8px 0;
+            background: var(--bg-input);
+        }
+        .cm-hd {
+            padding: 2px 14px 8px;
+            font-size: 0.72em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: var(--text-muted);
+        }
+        .cm-item {
+            display: block;
+            border-left: 3px solid transparent;
+        }
+        .cm-item-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+        .cm-meta { font-size: 0.72em; color: var(--text-muted); margin-top: 2px; }
+        .cm-snippet {
+            font-size: 0.75em;
+            color: var(--text-secondary);
+            margin-top: 4px;
+            line-height: 1.4;
+            opacity: 0.9;
+        }
+
         .resources-sep {
             border-bottom: 1px solid var(--border-color);
             margin: 0 0 6px;
@@ -2142,6 +2171,62 @@
 
     function filterRoles(value) {
         renderSidebar(allDomains, value);
+        scheduleContentSearch(value);
+    }
+
+    // ── Full-text content search (#68) ────────────────────
+    // The sidebar filter above matches titles/domains/chapters instantly.
+    // For queries of 3+ chars we additionally ask the server to search role
+    // bodies and prepend a "Content matches" group with snippets. Debounced,
+    // and guarded against out-of-order responses.
+    let contentSearchTimer = null;
+    let contentSearchSeq   = 0;
+
+    function scheduleContentSearch(value) {
+        clearTimeout(contentSearchTimer);
+        const q = value.trim();
+        if (q.length < 3) { removeContentMatches(); return; }
+        contentSearchTimer = setTimeout(() => runContentSearch(q), 180);
+    }
+
+    function removeContentMatches() {
+        document.getElementById('contentMatches')?.remove();
+    }
+
+    async function runContentSearch(q) {
+        const seq = ++contentSearchSeq;
+        let matches;
+        try {
+            const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+            ({ matches } = await res.json());
+        } catch { return; }
+        // Ignore stale responses and queries the user has since changed.
+        if (seq !== contentSearchSeq) return;
+        if (document.getElementById('searchInput').value.trim() !== q) return;
+
+        removeContentMatches();
+        if (!matches.length) return;
+
+        const section = document.createElement('div');
+        section.id = 'contentMatches';
+        section.className = 'content-matches';
+        section.innerHTML = `
+            <div class="cm-hd">🔎 Content matches (${matches.length})</div>
+            ${matches.map(m => `
+                <div class="role-item cm-item" role="button" tabindex="0"
+                     data-file="${escapeHtml(m.file)}"
+                     data-title="${escapeHtml(m.title)}"
+                     data-level="${escapeHtml(m.level)}"
+                     data-domain="${escapeHtml(m.domain)}">
+                    <div class="cm-item-top">
+                        <span class="role-item-name">${escapeHtml(m.title)}</span>
+                        <span class="badge ${badgeClass(m.level)}">${escapeHtml(m.level)}</span>
+                    </div>
+                    <div class="cm-meta">${escapeHtml(m.domain)}</div>
+                    ${m.snippet ? `<div class="cm-snippet">${escapeHtml(m.snippet)}</div>` : ''}
+                </div>`).join('')}`;
+        const nav = document.getElementById('sidebarNav');
+        nav.insertBefore(section, nav.firstChild);
     }
 
     // ── Navigation history (Back button) ─────────────────

--- a/server.js
+++ b/server.js
@@ -91,6 +91,74 @@ function getRoles() {
   return domains;
 }
 
+// Full-text search index over role bodies (#68). Built lazily and cached
+// against the same mtime signature as getRoles(), so a role edit is picked
+// up without a restart. Reference/standards docs are excluded — they are
+// reachable via their own listing, not the role search.
+let searchCache = { signature: -1, entries: null };
+
+function getSearchIndex() {
+  const signature = rolesTreeSignature();
+  if (searchCache.entries && searchCache.signature === signature) return searchCache.entries;
+
+  const entries = [];
+  for (const entry of fs.readdirSync(ROLES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const domainPath = path.join(ROLES_DIR, entry.name);
+    const label = DOMAIN_LABELS[entry.name] || entry.name.replace(/_/g, ' ');
+    for (const file of fs.readdirSync(domainPath)) {
+      if (!file.endsWith('.md') || file === 'README.md' || REFERENCE_DOC_PATTERN.test(file)) continue;
+      const content = fs.readFileSync(path.join(domainPath, file), 'utf8');
+      const meta = parseMeta(content);
+      entries.push({
+        file:        `Roles/${entry.name}/${file}`,
+        title:       meta.title || file.replace(/_/g, ' ').replace('.md', ''),
+        level:       resolveLevel(content, file),
+        domainLabel: label,
+        text:        content,
+        textLower:   content.toLowerCase(),
+      });
+    }
+  }
+  searchCache = { signature, entries };
+  return entries;
+}
+
+// A ~100-char excerpt of `text` centred on the first match of the query.
+// Whitespace (incl. markdown table pipes/newlines) is collapsed to one
+// space; the raw excerpt is HTML-escaped by the client before rendering.
+function makeSnippet(text, idx, qlen, radius = 50) {
+  const start = Math.max(0, idx - radius);
+  const end   = Math.min(text.length, idx + qlen + radius);
+  let s = text.slice(start, end).replace(/[|#*`]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (start > 0)          s = '… ' + s;
+  if (end < text.length)  s = s + ' …';
+  return s;
+}
+
+// Roles whose title or body contains the query. Title matches sort first,
+// then alphabetically. Query shorter than 2 chars returns nothing.
+function searchRoles(query) {
+  const q = String(query).trim().toLowerCase();
+  if (q.length < 2) return [];
+  const matches = [];
+  for (const e of getSearchIndex()) {
+    const inTitle = e.title.toLowerCase().includes(q);
+    const bodyIdx = e.textLower.indexOf(q);
+    if (!inTitle && bodyIdx === -1) continue;
+    matches.push({
+      file:    e.file,
+      title:   e.title,
+      level:   e.level,
+      domain:  e.domainLabel,
+      inTitle,
+      snippet: bodyIdx === -1 ? '' : makeSnippet(e.text, bodyIdx, q.length),
+    });
+  }
+  matches.sort((a, b) => (Number(b.inTitle) - Number(a.inTitle)) || a.title.localeCompare(b.title));
+  return matches;
+}
+
 // Content Security Policy: this app is a single-origin SPA with inline
 // <script>/<style> and inline onclick handlers, so 'unsafe-inline' is required
 // for script-src/style-src. Everything else is locked to same-origin, and no
@@ -172,6 +240,17 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // Full-text search across role bodies (#68)
+  if (url.pathname === '/api/search') {
+    try {
+      const q = url.searchParams.get('q') || '';
+      send(res, 200, 'application/json', JSON.stringify({ query: q.trim(), matches: searchRoles(q).slice(0, 50) }));
+    } catch (e) {
+      send(res, 500, 'application/json', JSON.stringify({ error: e.message }));
+    }
+    return;
+  }
+
   // Return raw markdown for a single role
   if (url.pathname === '/api/role') {
     const file = url.searchParams.get('file') || '';
@@ -233,4 +312,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { server, getRoles, ROOT, ROLES_DIR };
+module.exports = { server, getRoles, searchRoles, ROOT, ROLES_DIR };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -61,6 +61,40 @@ test('GET /api/roles lists reference docs separately from roles (#29)', async ()
   assert.ok(!finops.roles.some(r => r.file.endsWith('_standards.md')), 'standards docs never appear as roles');
 });
 
+test('GET /api/search finds roles by body content, not just title (#68)', async () => {
+  // "Terraform" appears in many role bodies but few (if any) titles.
+  const res = await request('/api/search?q=terraform');
+  assert.equal(res.status, 200);
+  const { query, matches } = JSON.parse(res.body);
+  assert.equal(query, 'terraform');
+  assert.ok(matches.length > 0, 'body-content search returns results');
+  const bodyOnly = matches.find(m => !m.inTitle);
+  assert.ok(bodyOnly, 'at least one match is a body-only hit');
+  assert.ok(bodyOnly.snippet.length > 0, 'body matches carry a snippet');
+  assert.ok(bodyOnly.file.startsWith('Roles/') && bodyOnly.title && bodyOnly.domain);
+});
+
+test('GET /api/search sorts title matches ahead of body-only matches', async () => {
+  const res = await request('/api/search?q=kubernetes');
+  const { matches } = JSON.parse(res.body);
+  const firstBodyOnly = matches.findIndex(m => !m.inTitle);
+  const lastTitle     = matches.map(m => m.inTitle).lastIndexOf(true);
+  if (firstBodyOnly !== -1 && lastTitle !== -1) {
+    assert.ok(lastTitle < firstBodyOnly, 'all title matches precede body-only matches');
+  }
+});
+
+test('GET /api/search returns nothing for a query shorter than 2 chars', async () => {
+  const res = await request('/api/search?q=a');
+  assert.deepEqual(JSON.parse(res.body).matches, []);
+});
+
+test('GET /api/search excludes reference/standards docs', async () => {
+  const res = await request('/api/search?q=chargeback'); // a standards-doc word
+  const { matches } = JSON.parse(res.body);
+  assert.ok(!matches.some(m => m.file.endsWith('_standards.md')), 'standards docs never appear in role search');
+});
+
 test('GET /api/role returns a real role file', async () => {
   const res = await request('/api/role?file=Roles/kubernetes/kubernetes_architect.md');
   assert.equal(res.status, 200);


### PR DESCRIPTION
## What changed
The sidebar search matched titles/domains/chapters only — 'Terraform', 'Entra', 'Slurm' returned nothing unless they were in a title, missing most of a 216-role catalog whose value is its bodies.

**Server**
- `/api/search?q=` backed by `searchRoles()` over a lazily-built body index, cached against the **same mtime signature as `getRoles()`** — zero extra I/O until a search runs, and live role edits are picked up without a restart.
- Reference/standards docs excluded; results capped at 50; title matches sorted ahead of body-only matches; each body hit carries a whitespace-collapsed ~100-char snippet.

**Client**
- Title filter stays instant; for 3+ char queries a debounced (180 ms) call prepends a '🔎 Content matches (N)' group with title, level badge, domain, and snippet.
- Items reuse `.role-item` + `role=button` so the existing delegated click and global Enter/Space handlers open them (#24 pattern) — no new handlers.
- Out-of-order responses and superseded queries are guarded; short/empty queries clear the group.

**Snippets** are HTML-escaped client-side via the existing `escapeHtml` before rendering (consistent with #25).

## Verification (live)
- 'terraform' → 50 content matches, first carries a snippet, keyboard-focusable; 'kubernetes' → content matches **and** the 4 title-tree items still filter; clicking a content match opens the role (verified: AI Platform Architect); 'ku' (short) clears the group.
- New server tests: body-only hit + snippet + shape, title-before-body ordering, <2-char empty, reference-doc exclusion.
- `npm test` **91/91**; validate 0/0 (incl. the new #67 duplicate-title check); markdownlint clean; no console errors.
- Browser-pane screenshots unavailable again (backgrounded-pane rAF suspension, as noted in #11/#13/#71); verified via DOM + API assertions instead.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)