### PR TITLE
feat: backfill Reports To / Scope / Interaction Mode for Leadership chapter (#5 batch 1/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
+  Mode backfilled for the Leadership chapter (#5, batch 1/7: 16 of 219
+  files).** All 4 C-suite roles and all 12 Leadership-domain roles now
+  carry the full modern role_template.md field set. Reporting hierarchy is
+  grounded in each file's own existing content (Key Decisions &
+  Accountabilities Owns/Advises tables, Key Stakeholders, and prior
+  "Reports to:" prose) rather than invented: CEO → Board of Directors;
+  CTO/CIO/SVP of Technology → CEO (documented equivalent titles); CISO →
+  SVP/CTO/CIO or directly to CEO/Board (dual governance model per the
+  file's own text); PAL/TAL → CTO/CIO/SVP as the delivery/technical
+  leadership pair; the 6 Chapter Leads → TAL or PAL; the Engineering
+  Practices Champion and Technical Community Leader → Engineering
+  Director or TAL. The 8 files that previously jammed "Reports to:" and
+  "Line manages:" into the Interactions table as a workaround (predating
+  the metadata fields) had those now-redundant rows removed and the
+  remaining stakeholder rows re-authored with real role names and an
+  Interaction Mode, matching the modern-template convention already
+  established by the Service Desk roles (downward = Provides To, upward =
+  Escalates To, peer = Collaborates). Remaining 6 chapters (203 files)
+  tracked in #5.
+
 ### Fixed
 
 - **End User & Workplace Chapter Lead's domain list now names all four

--- a/Roles/c_suite/chief_executive_officer.md
+++ b/Roles/c_suite/chief_executive_officer.md
@@ -5,6 +5,8 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CEO |
+| **Reports To** | Board of Directors |
+| **Direct Reports** | CTO, CIO, or SVP of Technology (equivalent titles — org uses one); CFO; CISO (in direct-reporting governance models) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -16,6 +18,14 @@ The Chief Executive Officer (CEO) is the most senior executive in the organisati
 The CEO holds the reporting line for the Chief Technology Officer (CTO), Chief Information Officer (CIO), or equivalent SVP of Technology. In organisations where a single senior technology executive exists (for example, an SVP of Technology or a combined CTO/CIO), that person is the primary technology accountability point to the CEO. In organisations with both a CTO and a CIO, the CEO is responsible for maintaining coherence between both reporting lines and ensuring technology strategy and IT operations work in alignment.
 
 In some governance models — particularly in heavily regulated industries or where the Board requires independent security assurance — the CEO also holds the direct CISO reporting line, outside the technology chain of command.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Organisation-wide — full P&L and enterprise capital allocation authority
+- **Experience Anchor:** 20+ years of progressive leadership across multiple business functions, 5-10+ years at C-suite or Group level — operates with full autonomy, accountable only to the Board
+- **Out of Scope:** Detailed functional strategies and delivery execution (owned by respective C-suite function heads); departmental budget management and functional spend (CFO and function heads-owned); broader people policies and HR frameworks (CPO-owned)
+- **Escalates To:** Board of Directors — strategic decisions, major risk issues, executive appointments, or decisions requiring board-level visibility
+- **Escalated To By:** CTO / CIO / SVP of Technology, CFO, COO, CISO, and other C-suite peers on enterprise-level risk, investment, or cross-functional conflicts they cannot resolve at their own level
 
 ## Business Impact
 
@@ -137,16 +147,18 @@ Degree in Business, Economics, Law, Engineering, or a related field. An MBA or o
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CTO / CIO / SVP of Technology | Direct reporting line; holds technology strategy, investment performance, and enterprise technology risk accountable |
-| CISO | Direct or indirect reporting line (model-dependent); receives executive cyber risk briefings and sets risk appetite for security governance |
-| CFO | Joint P&L oversight; capital allocation, investment governance, and Board financial reporting |
-| COO | Operational performance accountability; business continuity, enterprise operational risk, and cross-functional delivery |
-| CPO (Chief People Officer) | Executive talent strategy, succession planning, organisational design, and culture leadership |
-| Board of Directors | Primary governance accountability; strategy, performance, risk, executive appointments, and regulatory posture |
-| Investors / Shareholders | External accountability relationship; investor relations, capital markets, and shareholder communications |
-| Regulators | External engagement; regulatory posture, formal notifications, government relations, and sector compliance |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CTO / CIO / SVP of Technology | Direct reporting line; holds technology strategy, investment performance, and enterprise technology risk accountable | Provides To |
+| CISO | Direct or indirect reporting line (model-dependent); receives executive cyber risk briefings and sets risk appetite for security governance | Provides To |
+| CFO | Joint P&L oversight; capital allocation, investment governance, and Board financial reporting | Collaborates |
+| COO | Operational performance accountability; business continuity, enterprise operational risk, and cross-functional delivery | Collaborates |
+| CPO (Chief People Officer) | Executive talent strategy, succession planning, organisational design, and culture leadership | Collaborates |
+| Board of Directors | Primary governance accountability; strategy, performance, risk, executive appointments, and regulatory posture | Escalates To |
+| Investors / Shareholders | External accountability relationship; investor relations, capital markets, and shareholder communications | Escalates To |
+| Regulators | External engagement; regulatory posture, formal notifications, government relations, and sector compliance | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/c_suite/chief_financial_officer.md
+++ b/Roles/c_suite/chief_financial_officer.md
@@ -5,6 +5,8 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CFO |
+| **Reports To** | CEO |
+| **Direct Reports** | None (no subordinate finance roles modelled in this catalog) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -16,6 +18,14 @@ The Chief Financial Officer (CFO) is the senior executive accountable for the or
 In most organisations the CFO reports directly to the CEO and is a peer of the CTO and CIO. The CFO holds formal accountability to the Board's Audit and Risk Committee, acts as the primary contact for external auditors and investors, and — in publicly listed organisations — leads investor relations and financial disclosure obligations.
 
 The CFO's remit intersects closely with technology leadership: enterprise financial systems (ERP, FP&A platforms, treasury management systems) sit at the boundary of IT and Finance governance; cloud and technology spend increasingly falls under FinOps disciplines that the CFO co-owns with the CIO and CTO; and major technology investment decisions require the CFO's sign-off through capital allocation and business case governance processes.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Organisation-wide — full financial strategy, capital structure, and reporting authority
+- **Experience Anchor:** 15+ years of progressive finance leadership, typically 5+ years at CFO or deputy-CFO level — operates independently, accountable to the CEO and Board Audit Committee
+- **Out of Scope:** Corporate strategy direction and business model decisions (CEO and Board-owned); operational strategy and business unit performance improvement (COO and business leaders-owned); technology product strategy and engineering investment prioritisation (CTO-owned)
+- **Escalates To:** CEO and Board Audit/Risk Committee — material financial risk, capital structure decisions, and statutory reporting matters
+- **Escalated To By:** CIO, CTO, SVP of Technology, and business unit leaders on investment business cases and budget requests requiring capital allocation approval
 
 ## Business Impact
 
@@ -139,17 +149,19 @@ Degree in Finance, Accounting, Economics, or a related field. A postgraduate qua
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CEO | Primary reporting line; financial strategy, capital allocation, Board financial reporting, and enterprise risk |
-| Board / Audit Committee | Direct accountability for financial reporting accuracy, internal controls, audit outcomes, and regulatory compliance |
-| CIO | Close collaboration on IT cost governance, ERP financial systems strategy, IT investment ROI, and audit readiness |
-| CTO | Technology capital investment governance, FinOps cloud cost management, and build-vs-buy financial evaluation |
-| COO | Operational cost management, working capital efficiency, financial controls in operational processes, and procurement governance |
-| CPO (Chief People Officer) | Compensation and benefits cost governance, headcount financial planning, and HRIS financial data integrity |
-| CISO | Financial risk dimensions of cyber and data incidents; regulatory financial penalties; cyber insurance governance |
-| Business unit and functional leaders | Budget ownership, financial performance management, investment business cases, and financial reporting obligations |
-| External auditors and regulators | Primary executive contact for statutory audit, regulatory financial submissions, and financial compliance assurance |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CEO | Primary reporting line; financial strategy, capital allocation, Board financial reporting, and enterprise risk | Escalates To |
+| Board / Audit Committee | Direct accountability for financial reporting accuracy, internal controls, audit outcomes, and regulatory compliance | Escalates To |
+| CIO | Close collaboration on IT cost governance, ERP financial systems strategy, IT investment ROI, and audit readiness | Collaborates |
+| CTO | Technology capital investment governance, FinOps cloud cost management, and build-vs-buy financial evaluation | Collaborates |
+| COO | Operational cost management, working capital efficiency, financial controls in operational processes, and procurement governance | Collaborates |
+| CPO (Chief People Officer) | Compensation and benefits cost governance, headcount financial planning, and HRIS financial data integrity | Collaborates |
+| CISO | Financial risk dimensions of cyber and data incidents; regulatory financial penalties; cyber insurance governance | Collaborates |
+| Business unit and functional leaders | Budget ownership, financial performance management, investment business cases, and financial reporting obligations | Provides To |
+| External auditors and regulators | Primary executive contact for statutory audit, regulatory financial submissions, and financial compliance assurance | Provides To |
 
 ## Key Technologies
 

--- a/Roles/c_suite/chief_information_officer.md
+++ b/Roles/c_suite/chief_information_officer.md
@@ -5,6 +5,8 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CIO |
+| **Reports To** | CEO |
+| **Direct Reports** | Product Area Lead, Technical Area Lead (equivalent title to CTO/SVP of Technology — org uses one) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -16,6 +18,14 @@ The Chief Information Officer (CIO) is the senior executive accountable for the 
 In most organisations the CIO reports directly to the CEO and operates as a peer of the CTO. Where both roles exist, the CTO is typically accountable for technology product strategy and engineering capability, while the CIO is accountable for enterprise IT operations, internal systems, and IT service delivery. In some organisations — particularly those where IT is viewed primarily as an operational cost centre — the CIO may report to the COO rather than the CEO; both models are valid. In organisations where only one senior technology executive exists (for example, an SVP of Technology), that role typically combines the mandates of both CIO and CTO; this is explicitly noted in the SVP of Technology role definition.
 
 In some governance models the CISO reports to the CIO, particularly where security is positioned as an IT operational risk and compliance function rather than an engineering or product concern.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Organisation-wide — enterprise IT strategy, infrastructure, and internal digital services
+- **Experience Anchor:** 15+ years of IT leadership, 5+ years at CIO or senior IT executive level — operates independently on enterprise IT strategy
+- **Out of Scope:** Technology product strategy and external-facing platform direction (CTO-owned, where both roles exist); enterprise-wide capital allocation and financial governance (CFO and CEO-owned); business process design and operational change management (COO and business leaders-owned)
+- **Escalates To:** CEO — enterprise IT risk, major investment decisions, and cross-functional strategic conflicts
+- **Escalated To By:** Product Area Lead, Technical Area Lead, and business operations leaders on IT service delivery, infrastructure, and enterprise systems decisions
 
 ## Business Impact
 
@@ -138,16 +148,18 @@ Degree in Information Technology, Computer Science, Business Information Systems
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CEO | Primary reporting line; IT risk, IT investment performance, enterprise IT governance, and operational IT resilience |
-| CFO | Close collaboration on IT cost governance, ERP financial systems, IT investment ROI, and audit readiness |
-| COO | IT operational continuity, ITSM alignment to business operations, and IT enablement of business process performance |
-| CPO (Chief People Officer) | HRIS strategy, digital employee experience, and people system lifecycle governance |
-| CTO | Peer collaboration on enterprise architecture, cloud strategy, and shared infrastructure; boundary management where product engineering and IT operations overlap |
-| CISO | IT security posture, IT compliance obligations, and security requirements for enterprise systems and IT infrastructure; CISO may report to CIO in some governance models |
-| Business operations leaders | IT as an enabler of operational performance; SLA management, service improvement prioritisation, and operational IT requirements |
-| Enterprise system vendors and system integrators | Executive vendor relationships for ERP, HRIS, ITSM, and collaboration platforms; performance management and contract governance |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CEO | Primary reporting line; IT risk, IT investment performance, enterprise IT governance, and operational IT resilience | Escalates To |
+| CFO | Close collaboration on IT cost governance, ERP financial systems, IT investment ROI, and audit readiness | Collaborates |
+| COO | IT operational continuity, ITSM alignment to business operations, and IT enablement of business process performance | Collaborates |
+| CPO (Chief People Officer) | HRIS strategy, digital employee experience, and people system lifecycle governance | Collaborates |
+| CTO | Peer collaboration on enterprise architecture, cloud strategy, and shared infrastructure; boundary management where product engineering and IT operations overlap | Collaborates |
+| CISO | IT security posture, IT compliance obligations, and security requirements for enterprise systems and IT infrastructure; CISO may report to CIO in some governance models | Collaborates |
+| Business operations leaders | IT as an enabler of operational performance; SLA management, service improvement prioritisation, and operational IT requirements | Provides To |
+| Enterprise system vendors and system integrators | Executive vendor relationships for ERP, HRIS, ITSM, and collaboration platforms; performance management and contract governance | Governed By |
 
 ## Key Technologies
 

--- a/Roles/c_suite/chief_technology_officer.md
+++ b/Roles/c_suite/chief_technology_officer.md
@@ -5,6 +5,8 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CTO |
+| **Reports To** | CEO |
+| **Direct Reports** | Product Area Lead, Technical Area Lead (equivalent title to CIO/SVP of Technology — org uses one) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -16,6 +18,14 @@ The Chief Technology Officer (CTO) is the senior executive accountable for the o
 In most organisations the CTO reports directly to the CEO and operates as a peer of the CIO (where both roles exist). The CTO is primarily accountable for _how_ the organisation uses technology to build products and create competitive advantage, while the CIO is accountable for the reliability, cost, and governance of internal IT systems and operations. In organisations where only one senior technology executive exists — such as an SVP of Technology — that role typically combines the mandates of both CTO and CIO; this is explicitly noted in the SVP of Technology role definition.
 
 In some governance models the CISO reports to the CTO, particularly where security is positioned as a product and engineering concern (DevSecOps, security architecture, and platform security) rather than primarily an operational compliance function.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Organisation-wide — technology product vision, engineering standards, and multi-year technology roadmap
+- **Experience Anchor:** 15+ years of engineering/technology leadership, 5+ years at CTO or VP Engineering level — operates independently on technology strategy
+- **Out of Scope:** Overall corporate strategy and investment prioritisation (CEO and Board-owned); enterprise-wide capital allocation and financial governance (CFO and CEO-owned); architecture domain detail and workload-level technical decisions (Enterprise Architect and TAL-owned)
+- **Escalates To:** CEO — technology risk, major platform investment, and strategic conflicts beyond engineering scope
+- **Escalated To By:** Product Area Leads, Technical Area Lead, and principal engineers on technology roadmap and engineering capability decisions
 
 ## Business Impact
 
@@ -137,16 +147,18 @@ Degree in Computer Science, Software Engineering, Mathematics, or a related tech
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CEO | Primary reporting line; technology product strategy, innovation pipeline, and engineering risk |
-| CIO | Close peer collaboration on enterprise architecture, cloud strategy, and shared infrastructure; joint decisions where product engineering and IT operations overlap |
-| CISO | Security architecture standards, DevSecOps requirements, and security posture of product platforms; CISO may report to CTO in some governance models |
-| CPO (Chief Product Officer) | Joint ownership of product platform direction; CTO owns technical strategy and engineering execution, CPO owns product vision and customer outcomes |
-| Product Area Leads (PALs) | Direct or indirect leadership of engineering delivery; PALs operate within the engineering standards and architecture direction set by the CTO |
-| Technical Area Lead (TAL) | Close partnership on enterprise architecture, engineering standards, principal engineering community, and technology governance |
-| Strategic technology vendors / cloud providers | Executive relationship management for platform strategy, roadmap alignment, and strategic commercial agreements |
-| Board / Investors | Technical credibility, innovation narrative, and technology risk assurance for investor and Board engagement |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CEO | Primary reporting line; technology product strategy, innovation pipeline, and engineering risk | Escalates To |
+| CIO | Close peer collaboration on enterprise architecture, cloud strategy, and shared infrastructure; joint decisions where product engineering and IT operations overlap | Collaborates |
+| CISO | Security architecture standards, DevSecOps requirements, and security posture of product platforms; CISO may report to CTO in some governance models | Collaborates |
+| CPO (Chief Product Officer) | Joint ownership of product platform direction; CTO owns technical strategy and engineering execution, CPO owns product vision and customer outcomes | Collaborates |
+| Product Area Leads (PALs) | Direct or indirect leadership of engineering delivery; PALs operate within the engineering standards and architecture direction set by the CTO | Provides To |
+| Technical Area Lead (TAL) | Close partnership on enterprise architecture, engineering standards, principal engineering community, and technology governance | Provides To |
+| Strategic technology vendors / cloud providers | Executive relationship management for platform strategy, roadmap alignment, and strategic commercial agreements | Governed By |
+| Board / Investors | Technical credibility, innovation narrative, and technology risk assurance for investor and Board engagement | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CISO |
+| **Reports To** | SVP of Technology (or CTO/CIO equivalent); CEO or Board in independent governance models |
+| **Direct Reports** | None (strategic direction over the Security & Identity Chapter Lead and senior security architects — not formal line management; see the org chart / #71) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -16,6 +18,14 @@ The Chief Information Security Officer (CISO) is the senior executive accountabl
 In many organisations the CISO reports into the SVP of Technology (or equivalent CTO/CIO), forming a close executive partnership on technology risk and investment. In some organisations — particularly those with independent security governance or heavily regulated operating environments — the CISO reports directly to the CEO or Board. Both models are valid and reflected in this definition. In some organisations, the SVP of Technology and the CISO role may be held by the same person; the CISO responsibilities are documented separately here for clarity and for organisations where the roles are distinct.
 
 The CISO sits above the PAL and TAL in the technology leadership hierarchy on matters of security governance and risk, and provides strategic direction to the Security & Identity Chapter Lead and senior security architects who deliver operational security.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Organisation-wide — information security strategy, risk framework, and security architecture direction
+- **Experience Anchor:** 15+ years of security leadership, 5+ years at CISO or senior security executive level — operates independently on security strategy and risk acceptance
+- **Out of Scope:** Overall technology strategy and platform investment priorities (SVP of Technology-owned); total technology budget authority and enterprise-wide financial governance (SVP of Technology and CFO-owned); corporate legal strategy and regulatory engagement beyond security obligations (Legal and CEO-owned)
+- **Escalates To:** SVP of Technology (or CEO/Board directly, in independent governance models) for enterprise risk acceptance and major security investment
+- **Escalated To By:** Security & Identity Chapter Lead and senior security architects on unresolved security risk, incident escalation, and architecture decisions requiring executive risk acceptance
 
 ## Business Impact
 
@@ -94,17 +104,19 @@ The CISO sits above the PAL and TAL in the technology leadership hierarchy on ma
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| SVP of Technology | (or equivalent CTO/CIO) on security strategy, risk posture, and technology investment decisions with security implications; reports directly to the CEO or Board in independent governance models |
-| Security & Identity Chapter Lead | Who owns the operational delivery of security services, tooling, and engineering within the technology function |
-| security architects | Cloud, identity, application, and data security domains as technical advisors and delivery leaders |
-| Board Risk or Audit Committee | Providing executive-level assurance on the organisation's security posture |
-| Product Area Lead (PAL) | Ensure security requirements are embedded in product area roadmaps, architectural decisions, and delivery practices |
-| Technical Area Lead (TAL) | Ensure security requirements are embedded in product area roadmaps, architectural decisions, and delivery practices |
-| Legal team and Data Protection Officer (DPO) | Regulatory compliance, data breach notification obligations, and contractual security requirements |
-| third-party vendors and technology partners | Security requirements, contractual obligations, and ongoing risk management |
-| Enterprise Architect | Ensure security architecture principles are embedded in the enterprise architecture framework |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| SVP of Technology | (or equivalent CTO/CIO) on security strategy, risk posture, and technology investment decisions with security implications; reports directly to the CEO or Board in independent governance models | Escalates To |
+| Security & Identity Chapter Lead | Who owns the operational delivery of security services, tooling, and engineering within the technology function | Provides To |
+| security architects | Cloud, identity, application, and data security domains as technical advisors and delivery leaders | Provides To |
+| Board Risk or Audit Committee | Providing executive-level assurance on the organisation's security posture | Escalates To |
+| Product Area Lead (PAL) | Ensure security requirements are embedded in product area roadmaps, architectural decisions, and delivery practices | Collaborates |
+| Technical Area Lead (TAL) | Ensure security requirements are embedded in product area roadmaps, architectural decisions, and delivery practices | Collaborates |
+| Legal team and Data Protection Officer (DPO) | Regulatory compliance, data breach notification obligations, and contractual security requirements | Collaborates |
+| third-party vendors and technology partners | Security requirements, contractual obligations, and ongoing risk management | Governed By |
+| Enterprise Architect | Ensure security architecture principles are embedded in the enterprise architecture framework | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | Domain Architects and Senior Engineers across all eleven infrastructure chapter domains (Cloud Platforms, Kubernetes, Modern Infrastructure, Virtualisation, Specialised Computing, Server Hardware ×2, Linux/Windows Server OS, Network, FinOps) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical manager and people leader for the organisation's largest technology chapter, spanning eleven domains across the full infrastructure stack from bare metal to cloud-native — including FinOps & Cloud Economics. This role combines direct line management of architect-level practitioners across Cloud Platforms, Kubernetes, Modern Infrastructure, Virtualisation, Specialised Computing, Server Hardware, Linux and Windows Server OS, Network, and FinOps with authoritative technical direction over the entire infrastructure estate. The Chapter Lead owns the infrastructure technology radar, ensures coherence between cloud and on-premises platforms, governs cloud financial discipline, and is accountable for architecture standards across all eleven domains. Reporting to a Technical Area Lead or Product Area Lead, this role is the definitive "Head of Infrastructure" voice below the TAL layer. FinOps sits within this chapter due to the close relationship between cloud cost governance and infrastructure investment decisions, capacity planning, and direct budget accountability to the PAL and TAL.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, chapter-wide — line management and technical authority across eleven infrastructure domains
+- **Experience Anchor:** 8+ years in senior technical roles with 2+ years of demonstrated line management or formal mentorship of architect-level practitioners — operates independently across the full chapter scope
+- **Out of Scope:** Enterprise-wide architecture policy and cross-chapter technology standards (Enterprise Architect-owned); strategic investment priorities, budget allocation, and programme governance (TAL/PAL-owned); compensation bands, HR policy, and organisational structure (PAL and HR-owned); vendor contracts, procurement decisions, and enterprise supplier strategy (commercial and PAL-owned)
+- **Escalates To:** Technical Area Lead (TAL) or Product Area Lead (PAL) — strategic priorities, budget allocation, and decisions beyond chapter-level authority
+- **Escalated To By:** Domain Architects and Senior Engineers within the chapter on cross-domain technical conflicts, standards disputes, or decisions requiring chapter-wide authority
 
 ## Business Impact
 
@@ -80,15 +90,15 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Technical Area Lead (TAL) or Product Area Lead (PAL) |
-| Line manages: | Domain Architects and Senior Engineers across all eleven infrastructure chapter domains (Cloud Platforms, Kubernetes, Modern Infrastructure, Virtualisation, Specialised Computing, Server Hardware ×2, Linux/Windows Server OS, Network, FinOps) |
-| Collaborates with: | Other Chapter Leads (DevOps & Delivery, Security & Identity, Data & AI, End User & Workplace, Service & Governance) for cross-chapter technical dependencies |
-| Engages with: | Enterprise Architect on infrastructure alignment with enterprise architecture standards |
-| Partners with: | Finance and procurement on cloud budget governance and vendor spend optimisation; FinOps domain practitioners within the chapter own the cloud cost governance practice |
-| Works with: | CISO and Security & Identity Chapter Lead on infrastructure security posture and compliance |
-| Participates in: | CTO/CIO-level infrastructure forums, vendor and partner technical evaluations, and cross-area capacity planning |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Other Chapter Leads | Cross-chapter technical dependencies with DevOps & Delivery, Security & Identity, Data & AI, End User & Workplace, and Service & Governance | Collaborates |
+| Enterprise Architect | Infrastructure alignment with enterprise architecture standards | Governed By |
+| Finance and Procurement | Cloud budget governance and vendor spend optimisation; FinOps domain practitioners within the chapter own the cloud cost governance practice | Collaborates |
+| CISO and Security & Identity Chapter Lead | Infrastructure security posture and compliance | Collaborates |
+| CTO/CIO-level infrastructure forums | Vendor and partner technical evaluations and cross-area capacity planning | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | Domain Architects and Senior Engineers across Data Engineering, Data Management, Database Management, and AI Governance domains |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data & AI Chapter Lead is the most senior technical manager and people leader for the organisation's data and artificial intelligence capability, spanning four domains: Data Engineering, Data Management, Database Management, and AI Governance. This role combines direct line management of architects and senior engineers across these domains with authoritative ownership of the enterprise data strategy, AI platform governance, data architecture standards, and data governance frameworks. The Chapter Lead is accountable for ensuring data quality, lineage, and accessibility across the estate while overseeing responsible and compliant AI adoption — including the governance of ML model lifecycles and AI ethics policy. Reporting to a Technical Area Lead or Product Area Lead, this role is the definitive "Head of Data & AI" voice below the TAL layer.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, chapter-wide — line management and technical authority across data and AI domains
+- **Experience Anchor:** 8+ years in senior technical roles with 2+ years of demonstrated line management or formal mentorship of architect-level practitioners — operates independently across the full chapter scope
+- **Out of Scope:** Enterprise-wide architecture policy and cross-chapter technical standards (Enterprise Architect-owned); AI investment strategy, business use-case prioritisation, and AI programme governance (TAL/PAL and CDO-owned); data regulatory compliance decisions and legal interpretations (Legal and Compliance-owned); compensation bands, HR policy, and organisational structure (PAL and HR-owned); enterprise AI ethics policy and regulatory reporting obligations (Legal, Risk, and CDO-owned)
+- **Escalates To:** Technical Area Lead (TAL) or Product Area Lead (PAL) — strategic priorities, budget allocation, and decisions beyond chapter-level authority
+- **Escalated To By:** Domain Architects and Senior Engineers within the chapter on cross-domain technical conflicts, standards disputes, or decisions requiring chapter-wide authority
 
 ## Business Impact
 
@@ -80,15 +90,15 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Technical Area Lead (TAL) or Product Area Lead (PAL) |
-| Line manages: | Domain Architects and Senior Engineers across Data Engineering, Data Management, Database Management, and AI Governance domains |
-| Collaborates with: | Enterprise Architect on alignment of data and AI architecture with enterprise standards and patterns |
-| Partners with: | Chief Data Officer (CDO) on enterprise data strategy, data governance policy, and AI programme direction |
-| Works with: | Security & Identity Chapter Lead and CISO on data protection, data privacy architecture, and secure data platform design |
-| Engages with: | Legal and Compliance on AI ethics, GDPR obligations, data residency, and regulatory AI requirements |
-| Participates in: | Enterprise architecture forums, data governance boards, AI ethics committees, and cross-chapter technology forums |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architect | Alignment of data and AI architecture with enterprise standards and patterns | Governed By |
+| Chief Data Officer (CDO) | Enterprise data strategy, data governance policy, and AI programme direction | Collaborates |
+| Security & Identity Chapter Lead and CISO | Data protection, data privacy architecture, and secure data platform design | Collaborates |
+| Legal and Compliance | AI ethics, GDPR obligations, data residency, and regulatory AI requirements | Governed By |
+| Enterprise architecture forums, data governance boards, AI ethics committees | Cross-chapter technology and governance forums | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | Domain Architects and Senior Engineers across DevOps, App Platforms, and Integration & Middleware domains |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevOps & Delivery Chapter Lead is the most senior technical manager and people leader for the organisation's software delivery capability, spanning three domains: DevOps, App Platforms, and Integration & Middleware. This role combines direct line management of architects and senior engineers across these domains with authoritative technical direction over the delivery toolchain, platform engineering maturity, and integration platform governance. The Chapter Lead owns the delivery toolchain strategy — CI/CD, Internal Developer Platforms (IDP), and pipeline architecture — while also governing API standards. Cloud cost discipline for delivery workloads is a close collaboration with the Cloud, Platform & Infrastructure Chapter Lead who owns FinOps. Reporting to a Technical Area Lead or Product Area Lead, this role is the definitive technical voice for how software is built and integrated across the organisation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, chapter-wide — line management and technical authority across delivery and integration domains
+- **Experience Anchor:** 8+ years in senior technical roles with 2+ years of demonstrated line management or formal mentorship of architect-level practitioners — operates independently across the full chapter scope
+- **Out of Scope:** Enterprise-wide architecture policy and cross-chapter standards (Enterprise Architect-owned); platform infrastructure decisions and cloud service selection (Cloud, Platform & Infrastructure Chapter Lead-owned); compensation bands, HR policy, and organisational structure (PAL and HR-owned); cloud spend and FinOps governance (Cloud, Platform & Infrastructure Chapter Lead-owned)
+- **Escalates To:** Technical Area Lead (TAL) or Product Area Lead (PAL) — strategic priorities, budget allocation, and decisions beyond chapter-level authority
+- **Escalated To By:** Domain Architects and Senior Engineers within the chapter on cross-domain technical conflicts, standards disputes, or decisions requiring chapter-wide authority
 
 ## Business Impact
 
@@ -79,15 +89,15 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Technical Area Lead (TAL) or Product Area Lead (PAL) |
-| Line manages: | Domain Architects and Senior Engineers across DevOps, App Platforms, and Integration & Middleware domains |
-| Collaborates closely with: | Cloud, Platform & Infrastructure Chapter Lead on platform decisions, cloud architecture, and delivery workload cost visibility |
-| Engages with: | Enterprise Architect on delivery and integration alignment with enterprise architecture standards |
-| Works with: | Security & Identity Chapter Lead on pipeline security, SAST/DAST toolchain integration, and secure delivery practices |
-| Partners with: | Finance stakeholders for delivery toolchain investment visibility; cloud spend governance is handled via the Cloud & Platform Infrastructure Chapter Lead |
-| Participates in: | Enterprise architecture forums, cloud strategy governance, developer experience communities of practice, and engineering leadership forums |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Cloud, Platform & Infrastructure Chapter Lead | Platform decisions, cloud architecture, and delivery workload cost visibility | Collaborates |
+| Enterprise Architect | Delivery and integration alignment with enterprise architecture standards | Governed By |
+| Security & Identity Chapter Lead | Pipeline security, SAST/DAST toolchain integration, and secure delivery practices | Collaborates |
+| Finance stakeholders | Delivery toolchain investment visibility; cloud spend governance is handled via the Cloud, Platform & Infrastructure Chapter Lead | Collaborates |
+| Enterprise architecture forums, cloud strategy governance, developer experience communities of practice | Cross-chapter engineering leadership forums | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | Domain Architects and Senior Engineers across Client Platform, Endpoint Management, Modern Workplace, and Service Desk domains |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The End User & Workplace Chapter Lead is the most senior technical manager and people leader for the organisation's end-user technology capability, spanning four domains: Client Platform, Endpoint Management, Modern Workplace, and Service Desk. This role combines direct line management of architects and senior engineers in these domains with authoritative ownership of the client OS engineering strategy, device management platform, Microsoft 365 governance, collaboration tooling architecture, and the digital workplace roadmap. The Chapter Lead is accountable for delivering a consistent, secure, and productive user experience across all endpoints and workplace platforms — from client OS image engineering for Lenovo ThinkPad/ThinkCentre, MacBook, and Linux laptop fleets through to robust endpoint management and M365 governance — balancing technology innovation in the employee experience with strong endpoint security posture, managed in close collaboration with the Security & Identity Chapter Lead. Reporting to a Technical Area Lead or Product Area Lead, this role is the definitive "Head of End User Technology" voice below the TAL layer.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, chapter-wide — line management and technical authority across end-user and workplace domains
+- **Experience Anchor:** 8+ years in senior technical roles with 2+ years of demonstrated line management or formal mentorship of architect-level practitioners — operates independently across the full chapter scope
+- **Out of Scope:** Enterprise security policy and zero trust architecture (Security & Identity Chapter Lead and CISO-owned); M365 licensing, procurement, and Microsoft enterprise agreement decisions (commercial and PAL-owned); HR policy, people management, and employee wellbeing strategy (HR/People-owned); compensation bands, HR policy, and organisational structure (PAL and HR-owned); business strategy, hybrid working policy, and organisational change decisions (PAL, HR, and business leadership-owned)
+- **Escalates To:** Technical Area Lead (TAL) or Product Area Lead (PAL) — strategic priorities, budget allocation, and decisions beyond chapter-level authority
+- **Escalated To By:** Domain Architects and Senior Engineers within the chapter on cross-domain technical conflicts, standards disputes, or decisions requiring chapter-wide authority
 
 ## Business Impact
 
@@ -81,15 +91,15 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Technical Area Lead (TAL) or Product Area Lead (PAL) |
-| Line manages: | Domain Architects and Senior Engineers across Client Platform, Endpoint Management, Modern Workplace, and Service Desk domains |
-| Partners closely with: | Security & Identity Chapter Lead on endpoint security posture, EDR coverage, and conditional access architecture aligned to the zero trust roadmap |
-| Collaborates with: | Service & Governance Chapter Lead on ITSM processes for end-user services, device onboarding, and service catalogue entries |
-| Engages with: | Enterprise Architect on M365 platform alignment with enterprise architecture standards |
-| Works with: | HR and People function on digital employee experience strategy, hybrid working technology requirements, and people technology roadmap |
-| Participates in: | Enterprise architecture forums, endpoint security reviews, M365 governance boards, and digital workplace steering groups |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security & Identity Chapter Lead | Endpoint security posture, EDR coverage, and conditional access architecture aligned to the zero trust roadmap | Collaborates |
+| Service & Governance Chapter Lead | ITSM processes for end-user services, device onboarding, and service catalogue entries | Collaborates |
+| Enterprise Architect | M365 platform alignment with enterprise architecture standards | Governed By |
+| HR and People function | Digital employee experience strategy, hybrid working technology requirements, and people technology roadmap | Collaborates |
+| Enterprise architecture forums, endpoint security reviews, M365 governance boards, digital workplace steering groups | Cross-chapter governance forums | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Engineering Director or Technical Area Lead (PAL/TAL pair for the relevant product area or cross-cutting engineering enablement function) |
+| **Direct Reports** | None (individual contributor and internal consultant — no line management authority; drives change through coaching influence) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Engineering Practices Champion is a senior individual contributor and internal consultant focused on embedding and continuously improving software engineering quality across delivery teams. This role works team-by-team — coaching engineers on test-driven development (TDD), behaviour-driven development (BDD), code review culture, trunk-based development, pair programming, and CI/CD maturity — with the goal of systematically uplifting the engineering capability and health of the organisation. The Engineering Practices Champion translates abstract engineering quality principles into concrete, team-applicable habits, tooling configurations, and measurable health metrics (DORA, SPACE), and is the organisation's go-to authority for the question: *how should we be engineering software?*
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, organisation-wide (as an internal consultant) — no budget or headcount authority; influence through coaching and standards
+- **Experience Anchor:** 8+ years in senior engineering roles with demonstrated coaching/mentoring impact — operates independently across delivery teams organisation-wide
+- **Out of Scope:** CI/CD platform architecture and pipeline infrastructure (DevOps Architect-owned); mandatory security policy controls embedded in pipelines (Security Architect-owned); team structure, sprint capacity, and delivery prioritisation (Team Lead and Delivery Lead-owned)
+- **Escalates To:** Engineering Director or Technical Area Lead — engineering-culture investment decisions and cross-team quality escalations beyond coaching influence
+- **Escalated To By:** Team Leads and Engineering Managers on team-level engineering health issues; not a formal escalation target — engages proactively rather than reactively
 
 ## Business Impact
 
@@ -87,11 +97,14 @@ The Engineering Practices Champion is a senior individual contributor and intern
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Engineering Director or Technical Area Lead (PAL/TAL pair for the relevant product area or cross-cutting engineering enablement function) |
-| Works closely with: | DevOps Architect, Developer Experience Engineer, Automation Framework Engineer, and Technical Community Leader |
-| Collaborates with: | Delivery teams across all domains (as the primary coaching audience), Team Leads, Engineering Managers, and product owners as DoR/DoD stakeholders |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Architect, Developer Experience Engineer, Automation Framework Engineer | Joint ownership of tooling and platform capability that engineering practices depend on | Collaborates |
+| Technical Community Leader | Coordinate engineering-culture initiatives with the wider technical community programme | Collaborates |
+| Delivery teams, Team Leads, Engineering Managers | Primary coaching audience for TDD/BDD, code review culture, and CI/CD maturity uplift | Provides To |
+| Product Owners | Definition of Ready / Definition of Done governance as DoR/DoD stakeholders | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Product Area Lead |
+| **Reports To** | CTO/CIO (or SVP of Technology) |
+| **Direct Reports** | Chapter Leads (jointly with the Technical Area Lead, as the PAL/TAL leadership pair); Product Owners within the area |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Product Area Lead (PAL) is a senior IT management role responsible for the end-to-end delivery, operational health, and strategic direction of a defined product area within IT. A product area typically spans one or more related technical domains — for example, Cloud & Infrastructure, Security & Identity, or Data & Integration. The PAL owns the area's roadmap, budget, people, and stakeholder relationships, operating as the primary accountability point between the business and the IT teams within their area.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, product-area-wide — roadmap, budget, and people authority within the area
+- **Experience Anchor:** 10+ years of IT management experience, 3-5+ years in senior delivery/product leadership — operates independently on area strategy and delivery
+- **Out of Scope:** IT-wide strategic direction and cross-area portfolio prioritization (CTO/CIO-owned); compensation frameworks and organization-wide HR policy (HR-owned); enterprise-wide vendor strategy and strategic procurement decisions (Procurement-owned)
+- **Escalates To:** CTO/CIO — cross-area conflicts, budget escalation, and strategic decisions beyond area scope
+- **Escalated To By:** Chapter Leads and domain architects on delivery blockers, resourcing conflicts, and business stakeholder escalations
 
 ## Business Impact
 
@@ -76,16 +86,18 @@ The Product Area Lead (PAL) is a senior IT management role responsible for the e
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Technical Area Lead (TAL) | As a leadership pair — the PAL owns delivery, people, and business alignment; the TAL owns technical direction and quality |
-| Domain Architects | Within the area as direct reports or close collaborators |
-| Product Owners | Within the area as direct reports or close collaborators |
-| CTO/CIO | Area strategy and investment |
-| other Product Area Leads | Cross-area dependencies, shared services, and portfolio alignment |
-| business stakeholders | Translating IT capability into business value |
-| HR | Talent acquisition, development planning, and organizational design |
-| vendor and partner relationships | Within the area in coordination with procurement |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Technical Area Lead (TAL) | As a leadership pair — the PAL owns delivery, people, and business alignment; the TAL owns technical direction and quality | Collaborates |
+| Domain Architects | Within the area as direct reports or close collaborators | Provides To |
+| Product Owners | Within the area as direct reports or close collaborators | Provides To |
+| CTO/CIO | Area strategy and investment | Escalates To |
+| other Product Area Leads | Cross-area dependencies, shared services, and portfolio alignment | Collaborates |
+| business stakeholders | Translating IT capability into business value | Provides To |
+| HR | Talent acquisition, development planning, and organizational design | Collaborates |
+| vendor and partner relationships | Within the area in coordination with procurement | Governed By |
 
 ## Key Technologies
 

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | Domain Architects and Senior Engineers across Security, Security Cross-Platform, Security & Identity, Data Protection, and Directory Services domains |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security & Identity Chapter Lead is the organisation's most senior security practitioner and people leader below the CISO layer, spanning five domains: Security, Security Cross-Platform, Security & Identity, Data Protection, and Directory Services. This role combines direct line management of security architects and senior engineers with authoritative ownership of the security architecture strategy, identity governance framework, zero trust implementation roadmap, and the organisation's compliance posture. The Chapter Lead is the practitioner-level technical authority for security across the entire technology estate — ensuring security architecture standards, identity platform strategy, data protection policy, and threat modelling standards are coherent, current, and enforced. Reporting to a Technical Area Lead or Product Area Lead, this role works in close partnership with the CISO and is the definitive "Head of Security Architecture" voice for the engineering organisation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, chapter-wide — line management and technical authority across five security and identity domains
+- **Experience Anchor:** 8+ years in senior technical roles with 2+ years of demonstrated line management or formal mentorship of architect-level practitioners — operates independently across the full chapter scope
+- **Out of Scope:** Enterprise security strategy, risk appetite, and security programme investment (CISO-owned); programme funding, sequencing, and organisational risk acceptance decisions (CISO and TAL/PAL-owned); compliance obligations, regulatory requirements, and legal interpretations (Legal, DPO, and Compliance-owned); compensation bands, HR policy, and organisational structure (PAL and HR-owned); vendor contracts, security product procurement, and supplier risk decisions (CISO and commercial-owned)
+- **Escalates To:** Technical Area Lead (TAL) or Product Area Lead (PAL) — strategic priorities, budget allocation, and decisions beyond chapter-level authority
+- **Escalated To By:** Domain Architects and Senior Engineers within the chapter on cross-domain technical conflicts, standards disputes, or decisions requiring chapter-wide authority
 
 ## Business Impact
 
@@ -80,15 +90,15 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Technical Area Lead (TAL) or Product Area Lead (PAL) |
-| Line manages: | Domain Architects and Senior Engineers across Security, Security Cross-Platform, Security & Identity, Data Protection, and Directory Services domains |
-| Partners closely with: | CISO and Head of Security — this role is the practitioner-level counterpart to the CISO's strategic and risk leadership |
-| Engages with: | Enterprise Architect on security architecture alignment with enterprise standards and zero trust principles |
-| Collaborates with: | All other Chapter Leads on embedding security requirements, threat modelling, and security controls into their domain architectures |
-| Works with: | Data Protection Officer (DPO) and Legal/Compliance on GDPR, data privacy, and regulatory security obligations |
-| Participates in: | Security governance boards, risk committees, enterprise architecture forums, and cross-chapter technical governance |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CISO | This role is the practitioner-level counterpart to the CISO's strategic and risk leadership | Escalates To |
+| Enterprise Architect | Security architecture alignment with enterprise standards and zero trust principles | Governed By |
+| All other Chapter Leads | Embedding security requirements, threat modelling, and security controls into their domain architectures | Provides To |
+| Data Protection Officer (DPO) and Legal/Compliance | GDPR, data privacy, and regulatory security obligations | Governed By |
+| Security governance boards, risk committees, enterprise architecture forums | Cross-chapter technical governance | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | Domain Architects and Senior Engineers across ITSM & Configuration, Service Management, Infrastructure Onboarding, and Enterprise Architecture domains |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Service & Governance Chapter Lead is the most senior technical manager and people leader for the organisation's IT service management, enterprise architecture, and governance capability, spanning four domains: ITSM & Configuration, Service Management, Infrastructure Onboarding, and Enterprise Architecture. This role combines direct line management of architects and senior engineers across these domains with authoritative ownership of the IT service management framework, enterprise architecture governance, CMDB integrity, and the processes that make IT run reliably. The Chapter Lead bridges technology and business — owning ITIL process maturity, service catalogue governance, EA governance board operations, and the cross-domain onboarding standards that ensure new infrastructure and services are adopted into the organisation consistently. Reporting to a Technical Area Lead or Product Area Lead, this role is the definitive "Head of Service & Governance" voice below the TAL layer.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, chapter-wide — line management and technical authority across ITSM, governance, and enterprise architecture domains
+- **Experience Anchor:** 8+ years in senior technical roles with 2+ years of demonstrated line management or formal mentorship of architect-level practitioners — operates independently across the full chapter scope
+- **Out of Scope:** IT tool procurement, ITSM platform selection, and vendor contracts (PAL and commercial-owned); IT asset procurement and lifecycle investment decisions (PAL and Finance-owned); enterprise architecture strategy and long-range IT architecture direction (Enterprise Architect and CTO/CIO-owned); compensation bands, HR policy, and organisational structure (PAL and HR-owned); technology investment decisions, programme governance, and business case approval (PAL and Finance-owned)
+- **Escalates To:** Technical Area Lead (TAL) or Product Area Lead (PAL) — strategic priorities, budget allocation, and decisions beyond chapter-level authority
+- **Escalated To By:** Domain Architects and Senior Engineers within the chapter on cross-domain technical conflicts, standards disputes, or decisions requiring chapter-wide authority
 
 ## Business Impact
 
@@ -80,15 +90,15 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Technical Area Lead (TAL) or Product Area Lead (PAL) |
-| Line manages: | Domain Architects and Senior Engineers across ITSM & Configuration, Service Management, Infrastructure Onboarding, and Enterprise Architecture domains |
-| Engages with: | Enterprise Architect as primary partner on EA governance board operations and architecture standards alignment |
-| Collaborates with: | All other Chapter Leads — this chapter owns the processes and governance frameworks that all chapters operate within (change management, onboarding gates, CMDB, service catalogue) |
-| Works with: | Risk and Audit functions on IT compliance reporting, configuration estate audits, and governance evidence |
-| Partners with: | CTO/CIO on EA governance board outcomes, IT service reporting, and governance maturity programme direction |
-| Participates in: | Enterprise architecture forums, IT compliance reviews, cross-chapter operational governance, and business-facing IT service accountability meetings |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architect | Primary partner on EA governance board operations and architecture standards alignment | Collaborates |
+| All other Chapter Leads | This chapter owns the processes and governance frameworks that all chapters operate within — change management, onboarding gates, CMDB, service catalogue | Provides To |
+| Risk and Audit functions | IT compliance reporting, configuration estate audits, and governance evidence | Governed By |
+| CTO/CIO | EA governance board outcomes, IT service reporting, and governance maturity programme direction | Escalates To |
+| Enterprise architecture forums, IT compliance reviews, cross-chapter operational governance | Business-facing IT service accountability meetings | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | SVP of Technology |
+| **Reports To** | CEO |
+| **Direct Reports** | Product Area Leads, Technical Area Lead (equivalent title to CTO/CIO — org uses one) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -14,6 +16,14 @@
 The SVP of Technology (Senior Vice President of Technology) is the most senior technology executive in the organisation, accountable to the CEO and Board of Directors for the full IT and technology strategy, investment, capability, and delivery. The SVP owns the organisation's technology vision and multi-year roadmap, holds budget authority across all technology investment, and represents technology interests at the executive leadership level. In some organisations this role is held by a **CTO (Chief Technology Officer)** or **CIO (Chief Information Officer)** rather than an SVP — these titles are considered equivalent at this level, and the responsibilities described here apply equally to all three. In some organisations, the SVP of Technology and the CISO role may be held by the same person; this is noted where relevant.
 
 The SVP of Technology sits above the Product Area Lead (PAL) and Technical Area Lead (TAL) in the technology leadership hierarchy, providing the strategic direction and organisational context within which PALs and TALs operate.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Organisation-wide — entire technology function, full budget and organisational design authority
+- **Experience Anchor:** 15+ years of technology leadership, 5+ years at SVP/VP Technology level — operates independently, accountable to the CEO and Board
+- **Out of Scope:** Overall corporate strategy and business investment priorities (CEO and Board-owned); corporate financial policy, treasury, and enterprise-wide budget frameworks (CFO-owned); enterprise-wide people policies, HR frameworks, and executive compensation (CPO and Board-owned)
+- **Escalates To:** CEO and Board of Directors — strategic technology risk, major investment decisions, and board-level reporting
+- **Escalated To By:** Product Area Leads, Technical Area Lead, and CISO on technology risk, investment prioritisation, and organisational design decisions
 
 ## Business Impact
 
@@ -96,17 +106,19 @@ The SVP of Technology sits above the Product Area Lead (PAL) and Technical Area 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Product Area Leads (PALs) | Day-to-day operation of the technology function, portfolio alignment, and delivery governance |
-| Technical Area Lead (TAL) | Technical strategy execution, engineering standards, and cross-chapter coordination |
-| CISO | (where the role is separate) on information security strategy, risk posture, and board-level security reporting; in some organisations holds both roles |
-| Enterprise Architect | The long-term technology architecture strategy and platform evolution |
-| CEO and Board of Directors | As the primary technology accountability point for risk, investment, and strategic direction |
-| CFO | Technology investment planning, ROI reporting, and financial governance |
-| CPO (Chief People Officer) | Technology talent strategy, leadership development, and organisational design |
-| executive leadership team | Alongside COO, CFO, CMO, and other C-suite peers |
-| strategic technology vendors and partners | Including cloud hyperscalers, system integrators, and platform providers |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Product Area Leads (PALs) | Day-to-day operation of the technology function, portfolio alignment, and delivery governance | Provides To |
+| Technical Area Lead (TAL) | Technical strategy execution, engineering standards, and cross-chapter coordination | Provides To |
+| CISO | (where the role is separate) on information security strategy, risk posture, and board-level security reporting; in some organisations holds both roles | Collaborates |
+| Enterprise Architect | The long-term technology architecture strategy and platform evolution | Collaborates |
+| CEO and Board of Directors | As the primary technology accountability point for risk, investment, and strategic direction | Escalates To |
+| CFO | Technology investment planning, ROI reporting, and financial governance | Collaborates |
+| CPO (Chief People Officer) | Technology talent strategy, leadership development, and organisational design | Collaborates |
+| executive leadership team | Alongside COO, CFO, CMO, and other C-suite peers | Collaborates |
+| strategic technology vendors and partners | Including cloud hyperscalers, system integrators, and platform providers | Governed By |
 
 ## Key Technologies
 

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Technical Area Lead |
+| **Reports To** | SVP of Technology (or CTO/CIO) |
+| **Direct Reports** | Chapter Leads (jointly with the Product Area Lead, as the PAL/TAL leadership pair); Engineering Practices Champion; Technical Community Leader |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Technical Area Lead (TAL) is the senior technical authority for a defined IT product area, operating as the technical counterpart to the Product Area Lead (PAL). The TAL provides technical direction, architectural governance, and engineering leadership across all domains within the area. Where the PAL owns delivery, people management, and business alignment, the TAL owns technical quality, architecture coherence, platform strategy, and the engineering culture within the area. Together, the PAL and TAL form the leadership pair for the product area.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, product-area-wide — technical direction and architecture authority within the area
+- **Experience Anchor:** 10+ years of technical leadership experience, 3-5+ years in senior architecture/engineering leadership — operates independently on technical direction
+- **Out of Scope:** Roadmap priorities, budget allocation, and people management decisions (PAL-owned); enterprise-wide architecture policy and cross-area standards (Enterprise Architect-owned); vendor and contract decisions (PAL-owned, TAL provides technical input)
+- **Escalates To:** SVP of Technology / CTO/CIO — cross-area technical conflicts and enterprise architecture disputes
+- **Escalated To By:** Chapter Leads and domain architects on technical decisions requiring area-wide authority or cross-domain arbitration
 
 ## Business Impact
 
@@ -73,16 +83,18 @@ The Technical Area Lead (TAL) is the senior technical authority for a defined IT
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Product Area Lead (PAL) | As the leadership pair — the TAL owns technical quality and direction; the PAL owns delivery and business alignment |
-| Domain Architects | Across the area's domains |
-| Senior Engineers | Across the area's domains |
-| Enterprise Architect | Align area technical direction with enterprise architecture standards and patterns |
-| CISO / Security Architect | Ensure security and compliance are embedded in area technical decisions |
-| CTO/CIO-level technical forums | Cross-area technical governance bodies |
-| TALs of other product areas | Shared platforms, integration patterns, and cross-area technical dependencies |
-| vendor and partner technical evaluations | The PAL |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Product Area Lead (PAL) | As the leadership pair — the TAL owns technical quality and direction; the PAL owns delivery and business alignment | Collaborates |
+| Domain Architects | Across the area's domains | Provides To |
+| Senior Engineers | Across the area's domains | Provides To |
+| Enterprise Architect | Align area technical direction with enterprise architecture standards and patterns | Collaborates |
+| CISO / Security Architect | Ensure security and compliance are embedded in area technical decisions | Collaborates |
+| CTO/CIO-level technical forums | Cross-area technical governance bodies | Escalates To |
+| TALs of other product areas | Shared platforms, integration patterns, and cross-area technical dependencies | Collaborates |
+| vendor and partner technical evaluations | The PAL | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -5,6 +5,8 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Engineering Director or Technical Area Lead (PAL/TAL pair for the relevant product area or organisation-wide engineering function) |
+| **Direct Reports** | None (individual contributor — leads through influence, curation, and connection rather than line management) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Technical Community Leader is a senior individual contributor responsible for building and sustaining the technical community across the engineering organisation. This role drives technical excellence not through line management authority but through influence, curation, and connection — establishing and running communities of practice (CoPs), facilitating knowledge sharing across domain boundaries, maintaining shared standards libraries, and operating the organisation's technology radar. The Technical Community Leader ensures that hard-won technical knowledge does not remain siloed within individual teams, that practitioners across all domains have forums for peer learning, and that engineering standards evolve through collective input rather than top-down mandate.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, organisation-wide (as an internal consultant) — no budget or headcount authority; influence through community facilitation and standards curation
+- **Experience Anchor:** 8+ years in senior technical roles with demonstrated cross-domain influence and community-building impact — operates independently organisation-wide
+- **Out of Scope:** Enterprise architecture policy and domain-level technical direction (Architecture function and TAL-owned); technology investment and procurement decisions (TAL and business stakeholders-owned); mandatory standards and architectural constraints for specific domains (Domain Architect-owned)
+- **Escalates To:** Engineering Director or Technical Area Lead — community programme investment and organisation-wide standards adoption decisions
+- **Escalated To By:** Domain Architects and practitioners on cross-domain knowledge-sharing gaps; not a formal escalation target — operates through voluntary community participation
 
 ## Business Impact
 
@@ -71,11 +81,15 @@ The Technical Community Leader is a senior individual contributor responsible fo
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | Engineering Director or Technical Area Lead (PAL/TAL pair for the relevant product area or organisation-wide engineering function) |
-| Works closely with: | Architecture function (all domain Architects), Technical Area Leads, Engineering Practices Champion, HR/L&D team, and DevEx/Developer Experience Engineer |
-| Collaborates with: | All engineering teams and practitioners as community participants; vendor technical communities and industry peer groups for external technology radar input |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Architecture function (all domain Architects), Technical Area Leads | Enterprise architecture policy and domain-level technical direction inform the community's standards library and radar content | Consumes From |
+| Engineering Practices Champion | Coordinate engineering-culture initiatives with the wider technical community programme | Collaborates |
+| HR/L&D team, DevEx/Developer Experience Engineer | Internal learning and development alignment and developer-experience tooling for community platforms | Collaborates |
+| All engineering teams and practitioners | Community of practice participants, knowledge-sharing forums, and peer review | Provides To |
+| Vendor technical communities and industry peer groups | External technology radar input | Consumes From |
 
 ## Key Technologies
 


### PR DESCRIPTION
## What changed
First batch of #5 — the Leadership chapter (16 of 219 files: all 4 C-suite roles + all 12 Leadership-domain roles) now carries the full modern `role_template.md` field set:
- **Reports To** / **Direct Reports** in the metadata table
- **Role Scope & Boundaries** section (Scope of Influence, Experience Anchor, Out of Scope, Escalates To, Escalated To By)
- **Interaction Mode** column on the Interactions with Other Roles table

## Grounding, not invention
Every reporting-line value traces back to content already in the file — Key Decisions & Accountabilities Owns/Advises tables, Key Stakeholders, or prior "Reports to:" prose:
- CEO → Board of Directors
- CTO / CIO / SVP of Technology → CEO (the catalog's own text states these are equivalent titles for one position)
- CISO → SVP of Technology / CTO/CIO, **or** directly to CEO/Board in independent governance models — both stated in the CISO file itself
- PAL / TAL → CTO/CIO/SVP, as the delivery/technical leadership pair
- The 6 Chapter Leads → TAL or PAL (already stated verbatim in every chapter lead file)
- Engineering Practices Champion / Technical Community Leader → Engineering Director or TAL (already stated verbatim in both files)

## Interactions table cleanup
8 files (6 chapter leads + the 2 IC leadership roles) pre-dated the metadata fields and worked around it by jamming "Reports to:" and "Line manages:" into the Interactions table as pseudo-rows. Those are now redundant with the new metadata fields and were removed; the remaining stakeholder rows were re-authored with real role names (the old column-1 values were verb-labels like "Collaborates with:", not role names) and tagged with an Interaction Mode, following the convention already established by the Service Desk roles — checked live before starting: downward to a direct report = **Provides To**, upward to a manager = **Escalates To**, peer = **Collaborates**.

One cross-file consistency fix applied during review: the Security & Identity Chapter Lead's CISO row was tagged `Collaborates`, but the CISO file's own Role Scope states it is "Escalated To By" the chapter lead — corrected to `Escalates To` for directional consistency.

## Verification
- `npm run validate`: 220 files checked, 0 errors/warnings/duplicates.
- `npm test`: 91/91.
- markdownlint: 0 issues across all 16 files + CHANGELOG.
- Live-rendered in the browser: Role Scope & Boundaries appears in the correct position (after Role Overview), Interactions table shows 3 columns, redundant pseudo-rows confirmed gone from rendered output, metadata table renders Reports To/Direct Reports correctly.
- Matrix (219 chips) and org chart (219 unique role nodes) both re-verified unaffected — no role lost or duplicated.

Batch 1 of 7 for #5. Remaining: End User & Workplace (16), Service & Governance (19), DevOps & Delivery (24), Data & AI (29), Security & Identity (38), Cloud/Platform/Infrastructure (77) — 203 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)