### PR TITLE
feat: backfill Reports To / Scope / Interaction Mode for Service & Governance chapter (#85, #5 batch 3/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
+  Mode backfilled for the Service & Governance chapter (#85, batch 3/7:
+  15 of 219 files — the domain's 4 governance specialists, built in the
+  v1.2.0 batch, were already on the modern template).** ITSM &
+  Configuration, Service Management, and Infrastructure Onboarding follow
+  the standard IC-ladder pattern from batch 2. Enterprise Architecture is
+  modeled as a sub-hierarchy rather than three flat peer architects: its
+  own existing text has the Solution Architect explicitly "receiving
+  strategic direction from" and "escalating enterprise-wide decisions to"
+  the Enterprise Architect, and the Senior Engineer providing "operational
+  and documentation support" to both — so both report to the Enterprise
+  Architect, who alone reports to the Chapter Lead, rather than all three
+  reporting straight to the Chapter Lead like the chapter's other domains.
+- **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
   Mode backfilled for the End User & Workplace chapter (#84, batch 2/7:
   13 of 219 files — the domain's 3 Service Desk files were already on the
   modern template).** Client Platform, Endpoint Management, and Modern

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | Solution Architect; Enterprise Architecture Senior Engineer |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Enterprise Architect develops and maintains the overall technological vision and roadmap for the organization. This role designs comprehensive enterprise-wide architectures that align technology investments with business strategy, ensuring that disparate systems and platforms work together effectively within a cohesive framework.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, organisation-wide — enterprise architecture framework, cross-domain standards, and technology roadmap governance, referenced and governed-by across every domain in the catalog
+- **Experience Anchor:** Minimum 10 years in enterprise/solution architecture, with demonstrated organisation-wide governance impact — operates independently, chairs the architecture review board
+- **Out of Scope:** Business strategy priorities, investment priorities, and commercial decisions (business/CTO-CIO-owned); domain-specific technical designs and implementation approaches (domain Architects-owned); individual domain architecture decisions and project-level design choices
+- **Escalates To:** Service & Governance Chapter Lead and CTO/CIO — enterprise architecture investment, cross-domain governance disputes, and strategic technology direction
+- **Escalated To By:** Solution Architect on decisions with enterprise-wide impact; domain Architects across the catalog on cross-domain integration and standards questions
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Enterprise Architect develops and maintains the overall technological vision
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Business Leaders | Strategic technology alignment |
-| Domain Architects | (Security, Cloud, Network, etc.) on cross-domain integration |
-| Product Owners | Technology roadmap priorities |
-| CTO/CIO | Strategic technology decisions |
-| Senior Engineering Leaders | Architecture implementation |
-| Project and Program Managers | Technology transformation initiatives |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Business Leaders | Strategic technology alignment | Collaborates |
+| Domain Architects | (Security, Cloud, Network, etc.) sets enterprise architecture standards they operate within, on cross-domain integration | Governed By |
+| Product Owners | Technology roadmap priorities | Collaborates |
+| CTO/CIO | Strategic technology decisions | Escalates To |
+| Senior Engineering Leaders | Architecture implementation | Collaborates |
+| Project and Program Managers | Technology transformation initiatives | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Enterprise Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Enterprise Architecture Senior Engineer operates at the intersection of technical delivery and architectural governance. This role maintains and develops the organization's enterprise architecture repository, tooling, and processes — ensuring that architecture artifacts, patterns, and standards are accurately documented, accessible, and actionable for engineering and architecture teams. The Senior Engineer supports the Enterprise Architect and Solution Architect in running architecture governance processes, building reference architectures, and enabling teams across the organization to apply enterprise architecture standards in their day-to-day work.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain — operational and documentation support for enterprise architecture governance processes (architecture repository, CMDB accuracy, review board administration)
+- **Experience Anchor:** 5+ years in architecture, ITSM, or technical documentation roles — operates independently maintaining the architecture governance operating rhythm
+- **Out of Scope:** Enterprise architecture standards and framework decisions (Enterprise Architect-owned); solution-level design decisions (Solution Architect-owned); domain-specific architecture decisions (domain Architects-owned)
+- **Escalates To:** Enterprise Architect — governance process gaps and architecture data quality issues requiring authority to resolve
+- **Escalated To By:** domain architects on architecture repository and documentation questions
 
 ## Business Impact
 
@@ -64,15 +74,17 @@ The Enterprise Architecture Senior Engineer operates at the intersection of tech
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| domain architects | (Cloud, Security, Network, Data, etc.) to gather, review, and maintain accurate architecture data |
-| delivery teams | Understanding and applying architecture standards and documentation requirements |
-| CMDB and IT asset management teams | Maintain accurate application and technology inventory data |
-| CTO/CIO office | Architecture reporting, maturity assessments, and executive communications |
-| Enterprise Architect | Providing operational and documentation support for governance processes |
-| Solution Architect | Providing operational and documentation support for governance processes |
-| architecture review board | Chaired by the Enterprise Architect |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| domain architects | (Cloud, Security, Network, Data, etc.) gathers, reviews, and maintains accurate architecture data from | Consumes From |
+| delivery teams | Understanding and applying architecture standards and documentation requirements | Provides To |
+| CMDB and IT asset management teams | Maintain accurate application and technology inventory data | Collaborates |
+| CTO/CIO office | Architecture reporting, maturity assessments, and executive communications | Provides To |
+| Enterprise Architect | Providing operational and documentation support for governance processes | Escalates To |
+| Solution Architect | Providing operational and documentation support for governance processes | Provides To |
+| architecture review board | Chaired by the Enterprise Architect | Provides To |
 
 ## Key Technologies
 

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |
+| **Reports To** | Enterprise Architect |
+| **Direct Reports** | None (technical direction role, not a people manager) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Solution Architect is responsible for designing end-to-end technical solutions for specific projects, programmes, or business problems. Where the Enterprise Architect operates at the strategic portfolio and long-term roadmap level, the Solution Architect works at the *initiative* level - translating defined business requirements into a coherent, feasible technical design that can be handed to engineering teams for delivery. This role is the primary technical authority for a solution's scope: from component selection and integration design to security, performance, and cost considerations. Solution Architects are found across all IT domains and frequently operate in a cross-functional, cross-platform capacity.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain, engagement-scoped — solution design and component selection within enterprise architecture standards for a specific initiative or programme
+- **Experience Anchor:** 8+ years in solution/technical architecture with demonstrated delivery of enterprise-scale solutions — operates independently within EA-set guardrails, escalating enterprise-wide-impact decisions
+- **Out of Scope:** Enterprise architecture standards and guardrails (set by the Enterprise Architect); business requirements and scope definition (with Business/PO); budget and commercial decisions (with Finance/Procurement); security policy and organisational risk appetite (with CISO)
+- **Escalates To:** Enterprise Architect — decisions with enterprise-wide impact and guardrail exceptions
+- **Escalated To By:** Engineering Teams on implementation-level design clarification
 
 ## Business Impact
 
@@ -78,14 +88,16 @@ The Solution Architect is responsible for designing end-to-end technical solutio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architect: | Receive strategic direction, architecture principles, and guardrail policies; escalate decisions with enterprise-wide impact |
-| Product Owner / Programme Manager: | Receive and clarify business requirements; manage scope of design engagement |
-| Security Architect: | Collaborate on security design within the solution; obtain security sign-off |
-| Engineering Teams: | Provide technical direction during delivery; review implementation against design |
-| Domain Architects (Cloud, Network, Data, etc.): | Engage domain specialists for deep-dive design in their areas |
-| Vendors / System Integrators: | Lead technical engagement during procurement and delivery |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architect: | Receive strategic direction, architecture principles, and guardrail policies; escalate decisions with enterprise-wide impact | Escalates To |
+| Product Owner / Programme Manager: | Receive and clarify business requirements; manage scope of design engagement | Consumes From |
+| Security Architect: | Collaborate on security design within the solution; obtain security sign-off | Governed By |
+| Engineering Teams: | Provide technical direction during delivery; review implementation against design | Provides To |
+| Domain Architects (Cloud, Network, Data, etc.): | Engage domain specialists for deep-dive design in their areas | Collaborates |
+| Vendors / System Integrators: | Lead technical engagement during procurement and delivery | Governed By |
 
 ## Key Technologies
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Enterprise Infrastructure Onboarding Architect designs comprehensive strategies and frameworks for efficient infrastructure provisioning across all technology domains. This role creates the architectural vision for standardized, automated, and governance-controlled infrastructure deployment processes.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — enterprise infrastructure provisioning reference architecture and automation standards
+- **Experience Anchor:** Minimum 8 years in infrastructure engineering, with at least 3 years in an architecture role — operates independently on domain-wide architecture decisions
+- **Out of Scope:** Domain-specific architecture decisions and technology selection (owned by the relevant domain Architect); ITSM platform configuration and workflow design (ITSM-owned); tool selection, vendor procurement, and commercial infrastructure decisions (Procurement-owned)
+- **Escalates To:** Service & Governance Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and decisions beyond onboarding scope
+- **Escalated To By:** Infrastructure Onboarding Senior Engineers and Engineers on design-level questions and standards clarification
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standardization |
-| ITSM Architects | Service catalog design |
-| Infrastructure Onboarding Product Owner | Technical strategy |
-| Infrastructure Onboarding Senior Engineers |  |
-| domain-specific Architects | Integration approaches |
-| business stakeholders | Onboarding requirements |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standardization | Governed By |
+| ITSM Architects | Service catalog design | Collaborates |
+| Infrastructure Onboarding Product Owner | Technical strategy | Collaborates |
+| Infrastructure Onboarding Senior Engineers | Provide architectural direction and review engineering designs | Provides To |
+| domain-specific Architects | Integration approaches | Collaborates |
+| business stakeholders | Onboarding requirements | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |
+| **Reports To** | Infrastructure Onboarding Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Enterprise Infrastructure Onboarding Engineer implements and maintains provisioning processes and automation for deploying infrastructure across multiple technology domains. This role focuses on creating efficient, standardized, and reliable methods for infrastructure deployment and configuration.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of infrastructure provisioning and onboarding tasks to defined standards
+- **Experience Anchor:** 1-3 years in infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Infrastructure provisioning reference architecture (Senior Engineer/Architect-owned); ITSM service catalog management (ITSM-owned); backlog prioritisation (Product Owner-owned)
+- **Escalates To:** Infrastructure Onboarding Senior Engineers — complex provisioning issues and design-level questions
+- **Escalated To By:** end users on infrastructure provisioning request clarification
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Infrastructure Onboarding Product Owner | Task prioritization |
-| DevOps Engineers | Pipeline integration |
-| ITSM teams | Service catalog management |
-| Infrastructure Onboarding Senior Engineers |  |
-| domain-specific Engineers | Infrastructure requirements |
-| end users | Infrastructure provisioning requests |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Infrastructure Onboarding Product Owner | Task prioritization | Consumes From |
+| DevOps Engineers | Pipeline integration | Collaborates |
+| ITSM teams | Service catalog management | Governed By |
+| Infrastructure Onboarding Senior Engineers | Escalate complex provisioning and integration issues; receive guidance and mentoring | Escalates To |
+| domain-specific Engineers | Infrastructure requirements | Collaborates |
+| end users | Infrastructure provisioning requests | Provides To |
 
 ## Key Technologies
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Enterprise Infrastructure Onboarding Product Owner manages the infrastructure onboarding service portfolio, ensuring that provisioning processes meet business requirements for speed, efficiency, and compliance. This role prioritizes onboarding capabilities, coordinates implementation schedules, and drives adoption of standardized onboarding processes across the organization.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — infrastructure onboarding backlog, service roadmap, and SLA targets
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Architecture design and technical implementation decisions (Architect-owned); ITSM platform configuration and domain-specific tooling decisions; enterprise architecture direction and platform strategy decisions (Enterprise Architect-owned)
+- **Escalates To:** Service & Governance Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Onboarding Architect on roadmap and architecture-alignment questions
 
 ## Business Impact
 
@@ -62,14 +72,16 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Onboarding Architect | Platform strategy and design |
-| Onboarding Engineers | Implementation priorities |
-| business units | Understand provisioning requirements |
-| domain-specific teams | Service integration |
-| ITSM teams | Service request processes |
-| IT leadership | Onboarding service performance |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Onboarding Architect | Platform strategy and design | Collaborates |
+| Onboarding Engineers | Implementation priorities | Consumes From |
+| business units | Understand provisioning requirements | Consumes From |
+| domain-specific teams | Service integration | Collaborates |
+| ITSM teams | Service request processes | Collaborates |
+| IT leadership | Onboarding service performance | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | Infrastructure Onboarding Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Enterprise Infrastructure Onboarding Senior Engineer leads the implementation of complex infrastructure provisioning and onboarding solutions that span multiple technology domains. This role provides technical leadership for creating standardized, automated, and efficient processes for deploying infrastructure resources.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — detailed engineering design and delivery within the infrastructure onboarding reference architecture
+- **Experience Anchor:** 5+ years in infrastructure engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Enterprise infrastructure provisioning reference architecture (Architect-owned); ITSM platform configuration (ITSM-owned); commercial infrastructure decisions (Procurement-owned)
+- **Escalates To:** Infrastructure Onboarding Architect — architecture-level questions and design direction
+- **Escalated To By:** Infrastructure Onboarding Engineers on complex provisioning and integration issues
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Infrastructure Onboarding Architect | Solution design |
-| Infrastructure Onboarding Product Owner | Technical planning |
-| DevOps Senior Engineers | Pipeline integration |
-| Security Cross-Platform Senior Engineers | Security controls |
-| Infrastructure Onboarding Engineers | Technical implementation |
-| domain-specific Senior Engineers | Integration points |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Infrastructure Onboarding Architect | Solution design | Escalates To |
+| Infrastructure Onboarding Product Owner | Technical planning | Collaborates |
+| DevOps Senior Engineers | Pipeline integration | Collaborates |
+| Security Cross-Platform Senior Engineers | Security controls | Collaborates |
+| Infrastructure Onboarding Engineers | Technical implementation | Provides To |
+| domain-specific Senior Engineers | Integration points | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Application Configuration Management Architect designs comprehensive strategies and architectures for managing application configurations across the enterprise. This role establishes the technical vision for configuration management, creating architectures that ensure consistency, security, auditability, and automation of application configurations throughout their lifecycle.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — application configuration management reference architecture and automation standards
+- **Experience Anchor:** Minimum 8 years in configuration management/ITSM engineering, with at least 3 years in an architecture role — operates independently on domain-wide architecture decisions
+- **Out of Scope:** Domain-specific application configuration decisions (owned by application teams); DevOps CI/CD toolchain decisions and pipeline design (DevOps-owned); ITSM platform selection and procurement decisions (ITSM Product Owner/Procurement-owned)
+- **Escalates To:** Service & Governance Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and decisions beyond configuration management scope
+- **Escalated To By:** Configuration Management Senior Engineers and Engineers on design-level questions and standards clarification
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Security Architects | Secure configuration patterns |
-| DevOps Architects | CI/CD integration |
-| ITSM Product Owner | Technical strategy |
-| Configuration Management Senior Engineers |  |
-| application architects | Configuration requirements |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Security Architects | Secure configuration patterns | Governed By |
+| DevOps Architects | CI/CD integration | Collaborates |
+| ITSM Product Owner | Technical strategy | Collaborates |
+| Configuration Management Senior Engineers | Provide architectural direction and review engineering designs | Provides To |
+| application architects | Configuration requirements | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |
+| **Reports To** | Configuration Management Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Application Configuration Management Engineer implements and maintains configuration management processes and tools for applications across the enterprise. This role focuses on ensuring consistent, controlled, and secure management of application configurations throughout different environments and release cycles.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of application configuration management tasks to defined standards
+- **Experience Anchor:** 1-3 years in configuration/ITSM engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Configuration management reference architecture (Senior Engineer/Architect-owned); DevOps pipeline design (DevOps-owned); release scheduling strategy (Release Management-owned)
+- **Escalates To:** Configuration Management Senior Engineers — complex configuration issues and design-level questions
+- **Escalated To By:** application teams on configuration requirement questions
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Application Configuration Management Engineer implements and maintains confi
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| ITSM Product Owner | Task prioritization |
-| Release Management | Deployment configurations |
-| DevOps Engineers | Pipeline integration |
-| Application Support | Configuration troubleshooting |
-| Configuration Management Senior Engineers |  |
-| application teams | Configuration requirements |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| ITSM Product Owner | Task prioritization | Consumes From |
+| Release Management | Deployment configurations | Collaborates |
+| DevOps Engineers | Pipeline integration | Collaborates |
+| Application Support | Configuration troubleshooting | Provides To |
+| Configuration Management Senior Engineers | Escalate complex configuration issues; receive guidance and mentoring | Escalates To |
+| application teams | Configuration requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | Configuration Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Application Configuration Management Senior Engineer leads the implementation and optimization of complex configuration management solutions for applications across the enterprise. This role provides technical leadership for creating standardized, repeatable, and secure approaches to managing application settings, parameters, and environmental configurations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — detailed engineering design and delivery within the configuration management reference architecture
+- **Experience Anchor:** 5+ years in configuration/ITSM engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Configuration management reference architecture and automation standards (Architect-owned); DevOps CI/CD toolchain decisions (DevOps-owned); ITSM platform commercial decisions (ITSM Product Owner-owned)
+- **Escalates To:** Configuration Management Architect — architecture-level questions and standards exceptions
+- **Escalated To By:** Configuration Management Engineers on complex configuration and implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Application Configuration Management Senior Engineer leads the implementatio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Configuration Management Architect | Solution design |
-| ITSM Product Owner | Technical planning |
-| DevOps Senior Engineers | CI/CD integration |
-| Security Engineers | Secure configuration practices |
-| Application Teams | Configuration requirements |
-| Configuration Management Engineers | Technical implementation |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Configuration Management Architect | Solution design | Escalates To |
+| ITSM Product Owner | Technical planning | Collaborates |
+| DevOps Senior Engineers | CI/CD integration | Collaborates |
+| Security Engineers | Secure configuration practices | Collaborates |
+| Application Teams | Configuration requirements | Consumes From |
+| Configuration Management Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The ITSM Product Owner owns the product vision, roadmap, and backlog for the organisation's IT Service Management platform and Configuration Management Database (CMDB). This role ensures the ITSM platform (typically ServiceNow or equivalent) evolves to meet the changing needs of IT Operations, end users, and the business - covering Incident, Problem, Change, Service Request, Asset, CMDB, and related ITSM processes. The PO balances platform capability development, process improvement, and stakeholder expectations across IT and business domains.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — ITSM platform backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** ITIL process design (with Process Owners/Service Management Architect); ITSM tooling procurement commercial decisions (with Procurement); organisational ITSM process adoption strategy; IT security policies applicable to the ITSM platform
+- **Escalates To:** Service & Governance Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** ITSM / ConfigMgr Engineers on backlog clarification and acceptance criteria questions
 
 ## Business Impact
 
@@ -72,13 +82,15 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Service Management Architect: | Align platform development with ITSM process design and standards |
-| ITSM / ConfigMgr Engineers: | Direct the delivery team; provide clear stories and acceptance criteria |
-| IT Process Owners (Incident, Change, Problem Managers): | Translate process needs into backlog items |
-| IT Operations and Help Desk: | Represent their operational requirements in the backlog |
-| Finance / Procurement: | Align licensing and tooling costs with budget cycles |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Service Management Architect: | Align platform development with ITSM process design and standards | Collaborates |
+| ITSM / ConfigMgr Engineers: | Direct the delivery team; provide clear stories and acceptance criteria | Provides To |
+| IT Process Owners (Incident, Change, Problem Managers): | Translate process needs into backlog items | Consumes From |
+| IT Operations and Help Desk: | Represent their operational requirements in the backlog | Consumes From |
+| Finance / Procurement: | Align licensing and tooling costs with budget cycles | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Service Management Architect designs comprehensive strategies and architectures for IT service management across the enterprise. This role establishes the technical vision for ITSM platforms, processes, and integrations, creating architectures that enable efficient service delivery while aligning with business objectives and industry best practices.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — ITSM platform architecture, process reference models, and service integration design standards
+- **Experience Anchor:** Minimum 8 years in ITSM/service management engineering, with at least 3 years in an architecture role — operates independently on domain-wide architecture decisions
+- **Out of Scope:** Enterprise architecture decisions and cross-domain technology standards (Enterprise Architect-owned); business process design and service SLA target-setting (Process Owners-owned); platform procurement, licensing, and commercial decisions (Procurement-owned)
+- **Escalates To:** Service & Governance Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and decisions beyond service management scope
+- **Escalated To By:** Service Management Senior Engineers and Engineers on design-level questions and standards clarification
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Process Owners | Process design |
-| Business Relationship Managers | Service portfolio |
-| Service Management Product Owner | Technical strategy |
-| Service Management Senior Engineers |  |
-| executives | Service management strategy |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Process Owners | Process design | Collaborates |
+| Business Relationship Managers | Service portfolio | Collaborates |
+| Service Management Product Owner | Technical strategy | Collaborates |
+| Service Management Senior Engineers | Provide architectural direction and review engineering designs | Provides To |
+| executives | Service management strategy | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |
+| **Reports To** | Service Management Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Service Management Engineer implements and maintains IT service management platforms and processes across the organization. This role focuses on configuring ITSM tools, automating workflows, and supporting service management processes to ensure efficient IT service delivery.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of ITSM platform configuration and process implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in ITSM/service management engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** ITSM platform architecture (Senior Engineer/Architect-owned); process design (Process Owners-owned); backlog prioritisation (Product Owner-owned)
+- **Escalates To:** Service Management Senior Engineers — complex implementation issues and design-level questions
+- **Escalated To By:** stakeholders on service management need clarification
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Service Management Engineer implements and maintains IT service management p
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Service Management Product Owner | Task prioritization |
-| Process Owners | Process implementations |
-| Service Desk Staff | Operational requirements |
-| Knowledge Management | Documentation |
-| Service Management Senior Engineers |  |
-| stakeholders | Service management needs |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Service Management Product Owner | Task prioritization | Consumes From |
+| Process Owners | Process implementations | Collaborates |
+| Service Desk Staff | Operational requirements | Provides To |
+| Knowledge Management | Documentation | Collaborates |
+| Service Management Senior Engineers | Escalate complex implementation issues; receive guidance and mentoring | Escalates To |
+| stakeholders | Service management needs | Provides To |
 
 ## Key Technologies
 

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Service Management Product Owner manages the development and lifecycle of the organization's IT service management capabilities. This role leads a team of ITSM specialists, ensuring that service management processes, tools, and practices meet business requirements, operational standards, and continual improvement objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — ITSM product backlog, service management roadmap, and service catalog portfolio governance
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Architecture decisions and technical ITSM platform design (Architect-owned); ITSM platform commercial procurement and licensing decisions (Procurement-owned); enterprise service architecture direction and governance standards (Enterprise Architect-owned)
+- **Escalates To:** Service & Governance Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** ITSM Architect on roadmap and architecture-alignment questions
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Service Management Product Owner manages the development and lifecycle of th
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Continual Improvement Manager | ITSM enhancements |
-| Service Desk Manager | Operational requirements |
-| ITSM Architect | Process design |
-| IT Team Leaders | Service delivery |
-| business relationship managers | Service expectations |
-| IT leadership | Service strategy and investments |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Continual Improvement Manager | ITSM enhancements | Collaborates |
+| Service Desk Manager | Operational requirements | Consumes From |
+| ITSM Architect | Process design | Collaborates |
+| IT Team Leaders | Service delivery | Consumes From |
+| business relationship managers | Service expectations | Consumes From |
+| IT leadership | Service strategy and investments | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | Service Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Service Management Senior Engineer leads the implementation and optimization of complex IT service management solutions across the organization. This role provides technical leadership for ITSM platform configurations, workflows, and integrations while working closely with process owners to translate service management requirements into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — detailed engineering design and delivery within the ITSM reference architecture
+- **Experience Anchor:** 5+ years in ITSM/service management engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** ITSM platform architecture and process reference models (Architect-owned); business process/SLA target-setting (Process Owners-owned); platform commercial decisions (Product Owner-owned)
+- **Escalates To:** ITSM Architect — architecture-level questions and design direction
+- **Escalated To By:** Service Management Engineers on complex implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,16 @@ The Service Management Senior Engineer leads the implementation and optimization
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| ITSM Architect | Solution design |
-| Service Management Product Owner | Technical planning |
-| Process Owners | Process automation |
-| Integration Engineers | System connections |
-| Service Desk Teams | Operational requirements |
-| Service Management Engineers | Technical implementation |
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| ITSM Architect | Solution design | Escalates To |
+| Service Management Product Owner | Technical planning | Collaborates |
+| Process Owners | Process automation | Collaborates |
+| Integration Engineers | System connections | Collaborates |
+| Service Desk Teams | Operational requirements | Provides To |
+| Service Management Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 


### PR DESCRIPTION
## What changed
Batch 3 of 7 for #5 — Service & Governance chapter's 15 remaining files (itsm_configuration x4, service_management x4 of 8, infrastructure_onboarding_cross_platform x4, enterprise_architecture x3) now carry the full modern `role_template.md` field set. 4 governance specialists in service_management (change/incident/vendor/TPM) were already complete from the v1.2.0 batch, untouched.

## Reporting model
ITSM & Configuration, Service Management, and Infrastructure Onboarding follow the standard IC-ladder pattern established in batch 2 (Engineer → Senior Engineer → Chapter Lead; Architect and Product Owner report to the Chapter Lead directly).

**Enterprise Architecture is the exception**, and it's grounded, not arbitrary: unlike the other 3 domains where architects are flat peers, this domain's own existing text describes an internal sub-hierarchy — the Solution Architect "receives strategic direction" from and "escalates decisions with enterprise-wide impact" to the Enterprise Architect, and the Senior Engineer provides "operational and documentation support" to both. So Solution Architect and the Senior Engineer report to the Enterprise Architect, who alone reports to the Service & Governance Chapter Lead — matching the Chapter Lead's own Direct Reports claim ("...across ITSM & Configuration, Service Management, Infrastructure Onboarding, and Enterprise Architecture domains") without contradicting the domain's own internal structure.

## Verification
- `npm run validate`: 220 files, 0 errors/warnings/duplicates.
- `npm test`: 91/91.
- markdownlint: 0 issues across all 15 files + CHANGELOG.
- Live-rendered: Enterprise Architect's metadata correctly shows Direct Reports = Solution Architect + Senior Engineer; 219 roles intact in matrix and org chart (no role lost or duplicated).
- Cross-file consistency checked: Chapter Lead's existing Direct Reports field already claims the Enterprise Architecture domain, confirming no contradiction.

Closes #85. Remaining: DevOps & Delivery (24), Data & AI (29), Security & Identity (38), Cloud/Platform/Infrastructure (77) — 168 files, tracked in #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)