### PR TITLE
feat: backfill Reports To / Scope / Interaction Mode for DevOps & Delivery chapter (#86, batch 4/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
+  Mode backfilled for the DevOps & Delivery chapter (#86, batch 4/7:
+  24 of 219 files).** DevOps, App Platforms (API, .NET, Java), and
+  Integration & Middleware all follow the standard IC-ladder pattern:
+  Engineer reports to Senior Engineer, Senior Engineer and Architect and
+  Product Owner report to the DevOps & Delivery Chapter Lead. API Strategy
+  Architect and API Platform Architect are modeled as peers per the
+  domain's own text (each the other's "primary technical counterpart"),
+  both reporting to the Chapter Lead rather than one managing the other.
+  Developer Experience Engineer and Platform Reliability Engineer — two
+  Engineer-grade specialists with no dedicated Senior Engineer tier —
+  report to the DevOps Architect. `devops_engineer.md`,
+  `devops_senior_engineer.md`, and `devops_product_owner.md` had their
+  "Relationships & Collaboration" heading renamed to the canonical
+  "Interactions with Other Roles" (mirroring the #7 fix). Consolidated a
+  duplicate Security Architect row in `devops_architect.md`'s interactions
+  table into one entry.
+- **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
   Mode backfilled for the Service & Governance chapter (#85, batch 3/7:
   15 of 219 files — the domain's 4 governance specialists, built in the
   v1.2.0 batch, were already on the modern template).** ITSM &

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors API Platform Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The API Platform Architect designs comprehensive strategies and architectures for the organization's API ecosystem. This role establishes the technical vision for API platforms, gateways, and management tools, creating architectures that balance performance, scalability, security, and developer experience while aligning with business objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — API platform architecture standards, gateway topology design, and API management platform selection across the chapter
+- **Experience Anchor:** 8+ years in API or software architecture with demonstrated architecture-level delivery — operates independently on domain-wide API platform architecture decisions
+- **Out of Scope:** Enterprise integration strategy and application architecture decisions (Enterprise/application architects-owned); cloud platform selection and deployment architecture (Cloud Architects-owned); API governance policy and lifecycle framework definition (API Strategy Architect-owned, this role implements it)
+- **Escalates To:** DevOps & Delivery Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and investment decisions beyond API platform scope
+- **Escalated To By:** API Platform Senior Engineers on design exceptions and platform standards clarification
 
 ## Business Impact
 
@@ -63,14 +73,14 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Security Architects | API security patterns |
-| Integration Architects | Enterprise integration |
-| API Platform Product Owner | Technical strategy |
-| API Platform Senior Engineers |  |
-| Application Architects | API consumption patterns |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Security Architects | API security patterns | Governed By |
+| Integration Architects | Enterprise integration | Collaborates |
+| API Platform Product Owner | Technical strategy | Collaborates |
+| API Platform Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| Application Architects | API consumption patterns | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | API Platform Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The API Platform Engineer implements and maintains API management solutions across the organization. Working with the API Platform Senior Engineers and Architects, this role ensures reliable, secure, and optimized API solutions supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of API implementation and deployment tasks to defined standards
+- **Experience Anchor:** 1-3 years in API or software engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** API platform architecture and standards (Senior Engineers and the Architect-owned); API security control design; integration guidance strategy beyond assigned implementation tasks
+- **Escalates To:** API Platform Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** API Consumers on integration guidance and implementation support requests
 
 ## Business Impact
 
@@ -63,14 +73,14 @@ The API Platform Engineer implements and maintains API management solutions acro
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| API Platform Product Owner | Task prioritization |
-| Application Developers | API implementation |
-| DevOps Engineers | API deployment |
-| Security Engineers | API security controls |
-| API Consumers | Integration guidance |
-| API Platform Senior Engineers |  |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| API Platform Product Owner | Task prioritization | Consumes From |
+| Application Developers | API implementation | Provides To |
+| DevOps Engineers | API deployment | Collaborates |
+| Security Engineers | API security controls | Governed By |
+| API Consumers | Integration guidance | Provides To |
+| API Platform Senior Engineers | Escalate complex issues; receive implementation guidance | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The API Platform Product Owner manages the development and lifecycle of the organization's API management platform, tools, and shared components. This role leads a team of API platform engineers, ensuring that the API ecosystem meets the needs of application teams while maintaining technical excellence, security, and operational standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — API platform product backlog, strategic roadmap, and developer experience prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Technical API architecture design and platform technology selection (API Architect-owned); enterprise integration strategy (Enterprise/Integration Architects-owned); API security standards (Security Teams-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on API requirements and roadmap alignment
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Application Product Owners | API requirements |
-| DevOps Product Owner | CI/CD integration for APIs |
-| Security Teams | API security standards |
-| Application Teams | API adoption and consumption |
-| IT Leadership | API platform strategy |
-| API Architect | Technical strategy |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Application Product Owners | API requirements | Consumes From |
+| DevOps Product Owner | CI/CD integration for APIs | Collaborates |
+| Security Teams | API security standards | Governed By |
+| Application Teams | API adoption and consumption | Provides To |
+| IT Leadership | API platform strategy | Provides To |
+| API Architect | Technical strategy | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | API Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The API Platform Senior Engineer leads the implementation and optimization of API management platforms across the organization. This role provides technical leadership for API gateways, design standards, and developer experiences while working closely with architects to translate API strategies into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced API platform solution design and delivery within the API Platform Architect's reference architecture
+- **Experience Anchor:** 5+ years in API or platform engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** API platform architecture standards (Architect-owned); enterprise integration pattern definition (Integration Senior Engineers-owned); API security policy definition (Security Senior Engineers-owned, implements controls)
+- **Escalates To:** API Platform Architect — architecture-level questions and platform standards exceptions
+- **Escalated To By:** API Platform Engineers on complex implementation and API consumption issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| API Architect | API platform strategy |
-| API Platform Product Owner | Technical planning |
-| Integration Senior Engineers | Enterprise integration patterns |
-| Security Senior Engineers | API security controls |
-| API Platform Engineers | Implementation best practices |
-| application teams | API consumption patterns |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| API Architect | API platform strategy | Escalates To |
+| API Platform Product Owner | Technical planning | Collaborates |
+| Integration Senior Engineers | Enterprise integration patterns | Collaborates |
+| Security Senior Engineers | API security controls | Governed By |
+| API Platform Engineers | Implementation best practices | Provides To |
+| application teams | API consumption patterns | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/api_strategy_architect.md
+++ b/Roles/app_platforms/api_strategy_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (sets API governance strategy; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The API Strategy Architect defines and governs the organisation's end-to-end API strategy — encompassing API design standards, versioning and lifecycle policies, API gateway selection, developer portal strategy, API monetisation patterns, and the boundary between internal platform APIs and externally published APIs. This role owns the API governance framework that all API Platform Engineers, Integration Architects, and application teams operate within. Distinct from the API Platform Architect (who owns the implementation of the platform itself), the API Strategy Architect is concerned with what APIs are built, how they are governed, how they are discovered, and how they deliver value to the business and its partners — setting the strategic direction that shapes every API created across the organisation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — API governance framework, design standards, versioning policy, and API lifecycle strategy across the chapter
+- **Experience Anchor:** 8+ years in API strategy, architecture, or governance with demonstrated organisation-wide standards ownership — operates independently on domain-wide API governance decisions, as a peer counterpart to the API Platform Architect rather than in a hierarchical relationship
+- **Out of Scope:** API platform implementation and gateway configuration (API Platform Architect-owned); integration platform selection and enterprise integration patterns (Integration Architect-owned); API security control implementation (Security Architect-owned, this role sets governance requirements)
+- **Escalates To:** DevOps & Delivery Chapter Lead — chapter-wide priorities and cross-domain governance disputes
+- **Escalated To By:** API Platform Senior Engineers and Engineers on API design standards compliance and lifecycle policy questions
 
 ## Business Impact
 
@@ -74,17 +84,17 @@ The API Strategy Architect defines and governs the organisation's end-to-end API
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| API Platform Architect | As the primary technical counterpart — aligns strategic governance with platform implementation decisions; this relationship is the most critical in the role |
-| Integration Architect | Align API strategy with enterprise integration patterns, event-driven integration, and the use of APIs as integration mechanisms |
-| Security Architect | Define and enforce API security governance standards: authentication flows, authorisation models, API threat protection, and security review requirements |
-| DevOps Architect | API CI/CD integration, contract testing pipeline standards, and APIOps practices |
-| Enterprise Architect | Ensure the API strategy aligns with enterprise architecture governance, technology standards, and digital transformation initiatives |
-| business product owners | Partner-facing teams to define external API products, developer portal strategy, and API monetisation models |
-| API Platform Senior Engineers | API design standards compliance and lifecycle policy adherence |
-| API Platform Engineers | API design standards compliance and lifecycle policy adherence |
-| application development teams | API design best practices, OpenAPI specification authoring, and conformance to the organisation's API governance framework |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| API Platform Architect | As the primary technical counterpart — aligns strategic governance with platform implementation decisions; this relationship is the most critical in the role | Collaborates |
+| Integration Architect | Align API strategy with enterprise integration patterns, event-driven integration, and the use of APIs as integration mechanisms | Collaborates |
+| Security Architect | Define and enforce API security governance standards: authentication flows, authorisation models, API threat protection, and security review requirements | Governed By |
+| DevOps Architect | API CI/CD integration, contract testing pipeline standards, and APIOps practices | Collaborates |
+| Enterprise Architect | Ensure the API strategy aligns with enterprise architecture governance, technology standards, and digital transformation initiatives | Governed By |
+| business product owners | Partner-facing teams to define external API products, developer portal strategy, and API monetisation models | Collaborates |
+| API Platform Senior Engineers | API design standards compliance and lifecycle policy adherence | Provides To |
+| API Platform Engineers | API design standards compliance and lifecycle policy adherence | Provides To |
+| application development teams | API design best practices, OpenAPI specification authoring, and conformance to the organisation's API governance framework | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors .NET Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The .NET Architect designs comprehensive strategies and architectures for the organization's .NET ecosystem. This role establishes the technical vision for .NET platforms, frameworks, and applications, creating architectures that balance performance, scalability, security, and developer productivity while aligning with business objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — .NET platform architecture standards and technology stack decisions across the chapter
+- **Experience Anchor:** 8+ years in .NET engineering or software architecture with demonstrated architecture-level delivery — operates independently on domain-wide .NET architecture decisions
+- **Out of Scope:** Enterprise-wide technology standards (Enterprise Architects-owned); .NET security control implementation detail (Security Architects-owned, this role aligns to it); cloud deployment architecture (Cloud Architects-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and investment decisions beyond .NET platform scope
+- **Escalated To By:** .NET Senior Engineers on design exceptions and standards clarification
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Security Architects | .NET security patterns |
-| Cloud Architects | .NET cloud deployment |
-| .NET Platform Product Owner | Technical strategy |
-| .NET Senior Engineers |  |
-| application architects | .NET implementation patterns |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Security Architects | .NET security patterns | Governed By |
+| Cloud Architects | .NET cloud deployment | Collaborates |
+| .NET Platform Product Owner | Technical strategy | Collaborates |
+| .NET Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| application architects | .NET implementation patterns | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | .NET Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The .NET Engineer implements and maintains .NET-based applications and platform components across the organization. Working with the .NET Senior Engineers and Architects, this role ensures reliable, secure, and optimized .NET solutions supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of .NET implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in .NET or software engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** .NET platform architecture and standards (Senior Engineers and the Architect-owned); data access layer design (Database Engineers-owned); deployment pipeline design (DevOps Engineers-owned)
+- **Escalates To:** .NET Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on .NET implementation support requests
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| .NET Platform Product Owner | Task prioritization |
-| QA Engineers | Testing strategies |
-| DevOps Engineers | Deployment |
-| Database Engineers | Data access |
-| .NET Senior Engineers |  |
-| application teams | .NET implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| .NET Platform Product Owner | Task prioritization | Consumes From |
+| QA Engineers | Testing strategies | Collaborates |
+| DevOps Engineers | Deployment | Collaborates |
+| Database Engineers | Data access | Collaborates |
+| .NET Senior Engineers | Escalate complex issues; receive implementation guidance | Escalates To |
+| application teams | .NET implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The .NET Platform Product Owner manages the development and lifecycle of the organization's .NET platform, frameworks, and shared components. This role leads a team of .NET platform engineers, ensuring that the .NET ecosystem meets the needs of application teams while maintaining technical excellence, security, and operational standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — .NET platform backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** .NET technical architecture design (.NET Architect-owned); CI/CD integration design (DevOps Product Owner-owned); platform security standards (Security Teams-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** development teams on .NET platform adoption and roadmap alignment
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Product Owner | CI/CD integration |
-| Security Teams | .NET security standards |
-| .NET Architect | Technical strategy |
-| Application Product Owners | Platform requirements |
-| development teams | Platform adoption |
-| IT leadership | Platform strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Product Owner | CI/CD integration | Collaborates |
+| Security Teams | .NET security standards | Governed By |
+| .NET Architect | Technical strategy | Consumes From |
+| Application Product Owners | Platform requirements | Consumes From |
+| development teams | Platform adoption | Provides To |
+| IT leadership | Platform strategy and investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | .NET Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The .NET Senior Engineer leads the implementation and optimization of complex .NET platform solutions across the organization. This role provides technical leadership for .NET application platforms, frameworks, and services while working closely with architects to translate platform designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced .NET solution design and delivery within the .NET Architect's reference architecture
+- **Experience Anchor:** 5+ years in .NET engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** .NET platform architecture standards (Architect-owned); CI/CD pipeline design (DevOps Senior Engineers-owned); application security policy definition (Security Senior Engineers-owned, implements controls)
+- **Escalates To:** .NET Architect — architecture-level questions and standards exceptions
+- **Escalated To By:** .NET Engineers on complex implementation and technical design issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| .NET Architect | Solution design |
-| .NET Platform Product Owner | Technical planning |
-| DevOps Senior Engineers | CI/CD pipelines |
-| Security Senior Engineers | Application security |
-| Database Senior Engineers | Data access layers |
-| .NET Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| .NET Architect | Solution design | Escalates To |
+| .NET Platform Product Owner | Technical planning | Collaborates |
+| DevOps Senior Engineers | CI/CD pipelines | Collaborates |
+| Security Senior Engineers | Application security | Governed By |
+| Database Senior Engineers | Data access layers | Collaborates |
+| .NET Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Java Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Java Platform Architect designs comprehensive strategies and architectures for the organization's Java ecosystem. This role establishes the technical vision for Java platforms, frameworks, and applications, creating architectures that balance performance, scalability, security, and developer productivity while aligning with business objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Java platform architecture standards and technology stack decisions across the chapter
+- **Experience Anchor:** 8+ years in Java engineering or software architecture with demonstrated architecture-level delivery — operates independently on domain-wide Java architecture decisions
+- **Out of Scope:** Enterprise-wide technology standards (Enterprise Architects-owned); Java security control implementation detail (Security Architects-owned, this role aligns to it); cloud deployment architecture (Cloud Architects-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and investment decisions beyond Java platform scope
+- **Escalated To By:** Java Senior Engineers on design exceptions and standards clarification
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Security Architects | Java security patterns |
-| Cloud Architects | Java cloud deployment |
-| Java Platform Product Owner | Technical strategy |
-| Java Senior Engineers |  |
-| application architects | Java implementation patterns |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Security Architects | Java security patterns | Governed By |
+| Cloud Architects | Java cloud deployment | Collaborates |
+| Java Platform Product Owner | Technical strategy | Collaborates |
+| Java Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| application architects | Java implementation patterns | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | Java Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Java Engineer implements and maintains Java-based applications and platform components across the organization. Working with the Java Senior Engineers and Architects, this role ensures reliable, secure, and optimized Java solutions supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Java implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in Java or software engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Java platform architecture and standards (Senior Engineers and the Architect-owned); data access layer design (Database Engineers-owned); deployment pipeline design (DevOps Engineers-owned)
+- **Escalates To:** Java Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on Java implementation support requests
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Java Engineer implements and maintains Java-based applications and platform 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Java Platform Product Owner | Task prioritization |
-| QA Engineers | Testing strategies |
-| DevOps Engineers | Deployment |
-| Database Engineers | Data access |
-| Java Senior Engineers |  |
-| application teams | Java implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Java Platform Product Owner | Task prioritization | Consumes From |
+| QA Engineers | Testing strategies | Collaborates |
+| DevOps Engineers | Deployment | Collaborates |
+| Database Engineers | Data access | Collaborates |
+| Java Senior Engineers | Escalate complex issues; receive implementation guidance | Escalates To |
+| application teams | Java implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Java Platform Product Owner manages the development and lifecycle of the organization's Java platform, frameworks, and shared components. This role leads a team of Java platform engineers, ensuring that the Java ecosystem meets the needs of application teams while maintaining technical excellence, security, and operational standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Java platform backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Java technical architecture design (Java Architect-owned); CI/CD integration design (DevOps Product Owner-owned); platform security standards (Security Teams-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** development teams on Java platform adoption and roadmap alignment
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Product Owner | CI/CD integration |
-| Security Teams | Java security standards |
-| Java Architect | Technical strategy |
-| Application Product Owners | Platform requirements |
-| development teams | Platform adoption |
-| IT leadership | Platform strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Product Owner | CI/CD integration | Collaborates |
+| Security Teams | Java security standards | Governed By |
+| Java Architect | Technical strategy | Consumes From |
+| Application Product Owners | Platform requirements | Consumes From |
+| development teams | Platform adoption | Provides To |
+| IT leadership | Platform strategy and investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | Java Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Java Senior Engineer leads the implementation and optimization of complex Java platform solutions. This role provides technical leadership for Java applications, frameworks, and services while working closely with architects to translate platform designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Java solution design and delivery within the Java Architect's reference architecture
+- **Experience Anchor:** 5+ years in Java engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Java platform architecture standards (Architect-owned); CI/CD pipeline design (DevOps Senior Engineers-owned); application security policy definition (Security Senior Engineers-owned, implements controls)
+- **Escalates To:** Java Architect — architecture-level questions and standards exceptions
+- **Escalated To By:** Java Engineers on complex implementation and technical design issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Java Architect | Solution design |
-| Java Platform Product Owner | Technical planning |
-| DevOps Senior Engineers | CI/CD pipelines |
-| Security Senior Engineers | Application security |
-| Database Senior Engineers | Data access layers |
-| Java Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Java Architect | Solution design | Escalates To |
+| Java Platform Product Owner | Technical planning | Collaborates |
+| DevOps Senior Engineers | CI/CD pipelines | Collaborates |
+| Security Senior Engineers | Application security | Governed By |
+| Database Senior Engineers | Data access layers | Collaborates |
+| Java Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | DevOps Senior Engineer or DevOps Architect (depending on team structure) |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Automation Framework Engineer designs, builds, and maintains the reusable automation primitives that accelerate delivery across all engineering teams. This role operates at the meta-level — rather than automating individual workloads, it owns the shared frameworks, libraries, and tooling that other engineers consume to build their own automation. Core outputs include test automation frameworks, infrastructure provisioning libraries, runbook automation platforms, shared pipeline templates, and SDK/API wrappers that standardise how automation is written and maintained across the organisation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — shared automation frameworks, reusable pipeline modules, and self-service tooling consumed across engineering teams
+- **Experience Anchor:** 5+ years in automation, DevOps, or platform engineering with demonstrated framework/tooling ownership — operates independently within DevOps platform standards
+- **Out of Scope:** DevOps platform architecture and IDP strategy (DevOps Architect-owned); infrastructure automation module governance (Infrastructure Automation Architect-owned); test strategy definition (QA/test engineering-owned, aligns published frameworks to it)
+- **Escalates To:** DevOps Senior Engineer or DevOps Architect (depending on team structure) — framework standards exceptions and cross-team adoption conflicts
+- **Escalated To By:** domain engineering teams on issues consuming published automation frameworks
 
 ## Business Impact
 
@@ -82,11 +92,15 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to: | DevOps Senior Engineer or DevOps Architect (depending on team structure) |
-| Works closely with: | Developer Experience Engineer (inner developer portal and golden paths), Platform Reliability Engineer (operational automation and runbook alignment), Infrastructure Automation Architect (strategic direction and module governance) |
-| Collaborates with: | Domain engineering teams who consume published frameworks; QA/test engineering leads aligning on test automation standards; security engineering on compliance controls embedded in shared templates |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Senior Engineer or DevOps Architect | Reports to, depending on team structure | Escalates To |
+| Developer Experience Engineer | Inner developer portal and golden paths | Collaborates |
+| Platform Reliability Engineer | Operational automation and runbook alignment | Collaborates |
+| Infrastructure Automation Architect | Strategic direction and module governance | Governed By |
+| domain engineering teams | Consume published frameworks | Provides To |
+| QA/test engineering leads | Aligning on test automation standards | Collaborates |
+| security engineering | Compliance controls embedded in shared templates | Governed By |
 
 ## Key Technologies
 

--- a/Roles/devops/developer_experience_engineer.md
+++ b/Roles/devops/developer_experience_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | DevOps Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Developer Experience Engineer designs, builds, and operates internal developer platforms (IDPs) and self-service tooling that reduce cognitive load for engineering teams across the organisation. This role owns the golden path templates, developer portals, CLI tooling, and platform scaffolding that allow application teams to provision infrastructure, deploy services, and manage their software delivery lifecycle without deep platform expertise. The Developer Experience Engineer uses DORA metrics and the SPACE framework to measure and continuously improve developer productivity, treating application teams as their primary customers.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — internal developer platform (IDP) design, golden path standards, and developer tooling
+- **Experience Anchor:** 5+ years in platform or DevOps engineering with a developer-productivity focus — operates independently within the DevOps Architect's platform strategy
+- **Out of Scope:** DevOps platform architecture and toolchain standards (DevOps Architect-owned); cluster and cloud infrastructure provisioning design (Kubernetes/Cloud Architect-owned); security guardrail policy definition (Security Architect-owned, embeds controls into golden paths)
+- **Escalates To:** DevOps Architect — platform architecture decisions and IDP strategy exceptions
+- **Escalated To By:** application development teams on golden path adoption and self-service platform issues
 
 ## Business Impact
 
@@ -72,15 +82,15 @@ The Developer Experience Engineer designs, builds, and operates internal develop
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Architect | Platform architecture, IDP strategy, and golden path standards |
-| Azure, AWS, and GCP Cloud Architects | Designing self-service infrastructure provisioning workflows and cloud resource templates |
-| Kubernetes Architect | Align platform compute (cluster provisioning, namespace management, workload templates) with self-service IDP capabilities |
-| Security Architect | Embed security guardrails, policy-as-code checks, and compliance gates into golden path templates and platform scaffolding |
-| application development teams | As primary customers — gathering productivity feedback, co-designing workflows, and supporting onboarding onto the IDP |
-| Platform Reliability Engineer | Ensure IDP components and developer tooling meet reliability and availability standards |
-| Observability Architect | Or **Observability Senior Engineers** to include default instrumentation templates in golden paths |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Architect | Platform architecture, IDP strategy, and golden path standards | Escalates To |
+| Azure, AWS, and GCP Cloud Architects | Designing self-service infrastructure provisioning workflows and cloud resource templates | Collaborates |
+| Kubernetes Architect | Align platform compute (cluster provisioning, namespace management, workload templates) with self-service IDP capabilities | Collaborates |
+| Security Architect | Embed security guardrails, policy-as-code checks, and compliance gates into golden path templates and platform scaffolding | Governed By |
+| application development teams | As primary customers — gathering productivity feedback, co-designing workflows, and supporting onboarding onto the IDP | Provides To |
+| Platform Reliability Engineer | Ensure IDP components and developer tooling meet reliability and availability standards | Collaborates |
+| Observability Architect | Or Observability Senior Engineers to include default instrumentation templates in golden paths | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors DevOps Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevOps Architect designs comprehensive strategies and architectures for enabling efficient software delivery and operations across the organization. This role establishes the technical vision for DevOps practices, creating architectures that balance delivery speed, operational stability, security, and quality while aligning with business objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — DevOps platform architecture, CI/CD toolchain strategy, and DevSecOps reference architecture across the DevOps & Delivery chapter
+- **Experience Anchor:** 8+ years in DevOps, platform, or release engineering with demonstrated architecture-level delivery — operates independently on domain-wide toolchain and pipeline architecture decisions
+- **Out of Scope:** Application architecture and technology stack selection (Application Architect-owned); cloud infrastructure design (Cloud Architect-owned); security control requirements and DevSecOps policy detail (Security Architect-owned, DevOps Architect implements); data pipeline CI/CD governance beyond shared toolchain standards (Data Platform Architect-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and investment decisions beyond DevOps platform scope
+- **Escalated To By:** DevOps Senior Engineers on platform design exceptions and toolchain standards clarification
 
 ## Business Impact
 
@@ -78,16 +88,15 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Security Architects | DevSecOps patterns |
-| Cloud Architects | Deployment architectures |
-| DevOps Product Owner | Technical strategy |
-| DevOps Senior Engineers |  |
-| Security Architect | Define the DevSecOps control framework, supply chain security policies (SLSA, SBOM), and security gate standards within CI/CD pipelines |
-| Data Platform Architect | Data pipeline CI/CD governance, data quality gates, and dbt/Spark job deployment automation |
-| application architects | Delivery pipelines |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Align DevOps platform standards with enterprise technology standards | Governed By |
+| Security Architects | Define the DevSecOps control framework, supply chain security policies (SLSA, SBOM), and security gate standards within CI/CD pipelines | Collaborates |
+| Cloud Architects | Align deployment architectures with cloud platform design | Collaborates |
+| DevOps Product Owner | Technical strategy input to backlog and roadmap prioritisation | Collaborates |
+| DevOps Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| Data Platform Architect | Data pipeline CI/CD governance, data quality gates, and dbt/Spark job deployment automation | Collaborates |
+| application architects | Delivery pipeline design and consumption patterns | Provides To |
 
 ## Key Technologies
 

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | DevOps Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevOps Engineer implements and maintains CI/CD pipelines and automation tools that enable efficient, reliable software delivery. This role focuses on building and supporting DevOps infrastructure, troubleshooting pipeline issues, and assisting development teams with CI/CD integration.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of CI/CD pipeline implementation, automation, and support tasks to defined standards
+- **Experience Anchor:** 1-3 years in DevOps, release, or infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Pipeline architecture and platform design (Senior Engineers and the Architect-owned); DevSecOps policy and control framework definition; deployment automation strategy beyond assigned implementation tasks
+- **Escalates To:** DevOps Senior Engineer — design-level questions, complex automation issues, and escalated pipeline incidents
+- **Escalated To By:** development and operations teams on day-to-day pipeline and deployment support requests
 
 ## Business Impact
 
@@ -68,15 +78,15 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 - **Working Knowledge required:** ArgoCD/Flux (GitOps deployment), automated testing framework integration in pipelines, security scanning tools (SBOM generation, Sigstore/Cosign)
 - **Awareness level expected:** Supply chain security standards (SLSA verification), AI-assisted development tools (GitHub Copilot), Kubernetes as a pipeline deployment target
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| development teams | Pipeline implementation |
-| QA teams | Test automation integration |
-| infrastructure teams | Deployment environments |
-| Senior DevOps Engineers and DevOps Architect | Day-to-day guidance and direction |
-| operations | Deployment processes |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| development teams | Pipeline implementation | Provides To |
+| QA teams | Test automation integration | Collaborates |
+| infrastructure teams | Deployment environments | Collaborates |
+| Senior DevOps Engineers and DevOps Architect | Day-to-day guidance and direction | Escalates To |
+| operations | Deployment processes | Collaborates |
 
 ## Key Performance Indicators
 

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevOps Product Owner manages the DevOps platform roadmap and adoption strategy, ensuring CI/CD infrastructure and automation tools meet the needs of development and operations teams. This role prioritizes DevOps capabilities, coordinates implementation schedules, and drives platform adoption across the organization.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — DevOps platform backlog, sprint roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Technical architecture and toolchain design (DevOps Architect-owned); security requirements for pipeline tooling (Security PO-owned); engineering team hiring and resourcing (Chapter Lead-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** DevOps Engineers on backlog refinement and delivery-transparency questions
 
 ## Business Impact
 
@@ -67,16 +77,16 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 - **Working Knowledge required:** Container registry and artifact management concepts, value stream management tooling, code quality and security scanning pipeline integrations
 - **Awareness level expected:** AI-assisted development toolchain impacts on DevOps adoption metrics, FinOps tooling for DevOps platform cost management, platform engineering maturity model frameworks
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Architect | Platform strategy and design |
-| DevOps Engineers | Implementation priorities |
-| development teams | Understand pipeline requirements |
-| operations teams | Operational readiness |
-| training teams | DevOps enablement |
-| IT leadership | DevOps platform value and metrics |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Architect | Platform strategy and design | Consumes From |
+| DevOps Engineers | Implementation priorities | Provides To |
+| development teams | Understand pipeline requirements | Consumes From |
+| operations teams | Operational readiness | Collaborates |
+| training teams | DevOps enablement | Collaborates |
+| IT leadership | DevOps platform value and metrics | Provides To |
 
 ## Key Performance Indicators
 

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | DevOps Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevOps Senior Engineer leads complex DevOps initiatives and transformations, focusing on advanced automation, pipeline optimization, and innovative delivery approaches. This role implements sophisticated CI/CD patterns, develops reusable pipeline components, and provides technical leadership while mentoring team members.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced CI/CD solution design and delivery within the DevOps Architect's reference architecture
+- **Experience Anchor:** 5+ years in DevOps or release engineering with demonstrated independent delivery of advanced pipeline solutions — operates independently within the Architect's reference architecture
+- **Out of Scope:** DevOps platform architecture and toolchain standards (Architect-owned); security policy definition (Security teams-owned, implements DevSecOps controls); application architecture decisions (application architects-owned)
+- **Escalates To:** DevOps Architect — architecture-level questions and platform standards exceptions
+- **Escalated To By:** DevOps Engineers on complex pipeline, automation, and deployment issues
 
 ## Business Impact
 
@@ -70,15 +80,15 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 - **Working Knowledge required:** Istio/Linkerd (service mesh implementation), canary and Blue/Green deployment tooling, observability platform integration with CI/CD, Artifactory/Nexus (artifact management)
 - **Awareness level expected:** eBPF-based security and observability tooling, SLSA supply chain security standards, WebAssembly for serverless pipeline patterns
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Architect | Platform design decisions |
-| DevOps Engineers | Technical matters |
-| security teams | DevSecOps implementations |
-| application architects | Delivery pipeline design |
-| development teams | Advanced CI/CD approaches |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Architect | Platform design decisions | Escalates To |
+| DevOps Engineers | Technical matters | Provides To |
+| security teams | DevSecOps implementations | Governed By |
+| application architects | Delivery pipeline design | Collaborates |
+| development teams | Advanced CI/CD approaches | Provides To |
 
 ## Key Performance Indicators
 

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | DevOps Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Platform Reliability Engineer applies site reliability engineering (SRE) principles specifically to the internal developer platform and shared engineering infrastructure — treating internal engineering teams as the primary customers rather than end users. This role owns the reliability, availability, and performance of platform services including CI/CD infrastructure, developer portals, self-service provisioning tooling, and shared Kubernetes clusters. The Platform Reliability Engineer defines and tracks SLOs for platform services, manages error budgets, runs chaos engineering experiments to validate platform resilience, and leads blameless incident reviews when platform failures affect developer productivity.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — internal developer platform reliability, resilience, and SLO management
+- **Experience Anchor:** 5+ years in site reliability or platform engineering with demonstrated ownership of production reliability — operates independently within the DevOps Architect's platform strategy
+- **Out of Scope:** DevOps platform architecture and toolchain standards (DevOps Architect-owned); organisation-wide observability standards (Observability Architect-owned, this role aligns to them); infrastructure cost optimisation targets (FinOps-owned, balanced against reliability)
+- **Escalates To:** DevOps Architect — platform architecture decisions and reliability standards exceptions
+- **Escalated To By:** application development teams on platform SLO status and reliability-impacting incidents
 
 ## Business Impact
 
@@ -72,15 +82,15 @@ The Platform Reliability Engineer applies site reliability engineering (SRE) pri
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Developer Experience Engineer | Review platform feature designs for reliability risks and to jointly respond to IDP incidents |
-| DevOps Architect | Platform design reviews — providing reliability and resilience input to IDP architecture decisions |
-| Observability Architect | Align platform monitoring with organisation-wide observability standards and telemetry pipeline governance |
-| Azure, AWS, and GCP Cloud Architects | Underlying infrastructure reliability, autoscaling, and multi-zone availability design for shared platform components |
-| Kubernetes Architect | Cluster reliability, workload isolation, and failure domain analysis for platform services hosted on shared clusters |
-| application development teams | Communicate platform SLO status, planned maintenance, and reliability improvements |
-| FinOps team | Platform infrastructure cost optimisation initiatives that must be balanced against reliability requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Developer Experience Engineer | Review platform feature designs for reliability risks and to jointly respond to IDP incidents | Collaborates |
+| DevOps Architect | Platform design reviews — providing reliability and resilience input to IDP architecture decisions | Escalates To |
+| Observability Architect | Align platform monitoring with organisation-wide observability standards and telemetry pipeline governance | Governed By |
+| Azure, AWS, and GCP Cloud Architects | Underlying infrastructure reliability, autoscaling, and multi-zone availability design for shared platform components | Collaborates |
+| Kubernetes Architect | Cluster reliability, workload isolation, and failure domain analysis for platform services hosted on shared clusters | Collaborates |
+| application development teams | Communicate platform SLO status, planned maintenance, and reliability improvements | Provides To |
+| FinOps team | Platform infrastructure cost optimisation initiatives that must be balanced against reliability requirements | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/integration_middleware/integration_architect.md
+++ b/Roles/integration_middleware/integration_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Integration Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Integration Architect designs and governs the organisation's enterprise integration strategy and architecture, covering API management, event-driven messaging, enterprise service bus (ESB) patterns, and point-to-point integration across on-premises, cloud, and SaaS platforms. This role ensures that systems integrate securely, reliably, and in a maintainable way - moving the organisation away from fragile point-to-point integrations toward governed, reusable integration platforms. The Integration Architect works across the full integration stack: synchronous APIs, asynchronous messaging, event streaming, and MFT.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — integration platform architecture, API design standards, and event-driven architecture patterns across the chapter
+- **Experience Anchor:** 8+ years in integration or middleware architecture with demonstrated architecture-level delivery — operates independently on domain-wide integration architecture decisions
+- **Out of Scope:** Cloud platform architecture (Cloud Architects-owned); application data model and business process design (application teams-owned); security policy for API and integration access (CISO-owned, this role implements controls)
+- **Escalates To:** DevOps & Delivery Chapter Lead — chapter-wide priorities, cross-domain boundary disputes, and investment decisions beyond integration platform scope
+- **Escalated To By:** Integration Senior Engineers on architectural direction and design exception questions
 
 ## Business Impact
 
@@ -76,16 +86,16 @@ The Integration Architect designs and governs the organisation's enterprise inte
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architect / Solution Architects: | Provide integration patterns; governance review of integration designs in project proposals |
-| Cloud Architects: | Align integration platform architecture with cloud platform standards |
-| Application Teams: | Define and enforce API design standards; support integration design within applications |
-| Security Architect: | Implement API security patterns and B2B credential governance |
-| ERP / Business Systems Teams: | Design integration between core enterprise systems and surrounding applications |
-| DataOps / Data Platform: | Define event sourcing and CDC patterns where integration feeds data platforms |
-| DevOps Architect | Govern CI/CD integration pipeline standards, deployment automation for integration artifacts, and integration testing practices |
-| API Platform Architect | API design standards, versioning policies, and the boundary between API gateway capabilities and integration platform responsibilities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architect / Solution Architects | Provide integration patterns; governance review of integration designs in project proposals | Governed By |
+| Cloud Architects | Align integration platform architecture with cloud platform standards | Collaborates |
+| Application Teams | Define and enforce API design standards; support integration design within applications | Provides To |
+| Security Architect | Implement API security patterns and B2B credential governance | Governed By |
+| ERP / Business Systems Teams | Design integration between core enterprise systems and surrounding applications | Collaborates |
+| DataOps / Data Platform | Define event sourcing and CDC patterns where integration feeds data platforms | Collaborates |
+| DevOps Architect | Govern CI/CD integration pipeline standards, deployment automation for integration artifacts, and integration testing practices | Collaborates |
+| API Platform Architect | API design standards, versioning policies, and the boundary between API gateway capabilities and integration platform responsibilities | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |
+| **Reports To** | Integration Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Integration Engineer builds, maintains, and supports enterprise integration flows connecting applications, cloud services, and SaaS platforms. This role implements integrations using iPaaS platforms (MuleSoft, Azure Logic Apps, Boomi) and messaging systems, working from specifications and integration designs provided by senior engineers and the Integration Architect. The Integration Engineer is responsible for reliable day-to-day operation of integration workflows, monitoring, and first-response to integration incidents.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of integration build, testing, and support tasks to defined standards
+- **Experience Anchor:** 1-3 years in integration or middleware engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Integration platform architecture and design (Senior Engineers and the Architect-owned); integration contract negotiation with application teams (Senior Engineer-owned); event-driven data feed strategy
+- **Escalates To:** Integration Senior Engineer — complex issues and implementation guidance
+- **Escalated To By:** Help Desk / Operations on integration-related support requests
 
 ## Business Impact
 
@@ -70,11 +80,11 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Integration Senior Engineers: | Escalate complex issues; receive implementation guidance |
-| Application Teams: | Communicate integration errors and coordinate on API changes |
-| Help Desk / Operations: | Receive integration-related support requests |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Integration Senior Engineers | Escalate complex issues; receive implementation guidance | Escalates To |
+| Application Teams | Communicate integration errors and coordinate on API changes | Collaborates |
+| Help Desk / Operations | Receive integration-related support requests | Provides To |
 
 ## Key Technologies
 

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Integration Product Owner owns the integration platform product backlog — covering API gateway capabilities, ESB and message broker services, event streaming infrastructure, and middleware platform offerings. This role manages the integration platform roadmap, prioritises integration capability investments, defines SLAs for integration services, and aligns the platform direction with the needs of consuming application teams and business stakeholders. Working closely with the Integration Architect as the technical counterpart, the Integration Product Owner translates integration requirements from across the organisation into a coherent, sequenced delivery plan that advances integration maturity, reduces technical debt, and supports digital transformation programmes.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — integration platform backlog, SLA governance, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Integration platform architecture and technical design (Integration Architect-owned); API gateway roadmap where separately owned (API Platform Architect-owned); enterprise architecture direction (Enterprise Architect-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Integration Senior Engineers and Integration Engineers on ceremony direction and delivery-transparency questions
 
 ## Business Impact
 
@@ -72,17 +82,17 @@ The Integration Product Owner owns the integration platform product backlog — 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Integration Architect | As the technical counterpart — receives architectural direction and ensures that backlog prioritisation reflects integration platform architectural strategy and delivery dependencies |
-| API Platform Architect | (where separate) to align API gateway roadmap and developer portal features with the broader API management strategy |
-| DevOps Architect | Ensure integration platform CI/CD pipeline requirements and deployment automation are included in DevOps platform delivery planning |
-| Security Architect | Incorporate API security, OAuth 2.0 / mTLS, and B2B credential governance requirements into the integration platform backlog |
-| Enterprise Architect | Integration platform direction within the overall enterprise architecture strategy and digital transformation programme |
-| consuming application teams | Gather requirements, manage onboarding to integration services, and communicate deprecation timelines |
-| Integration Senior Engineers | As the team's product owner, leading ceremonies and providing delivery direction |
-| Integration Engineers | As the team's product owner, leading ceremonies and providing delivery direction |
-| vendor TAL/PAL (MuleSoft, Confluent, IBM, TIBCO) | Product roadmap updates, support agreements, and licensing strategy |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Integration Architect | As the technical counterpart — receives architectural direction and ensures that backlog prioritisation reflects integration platform architectural strategy and delivery dependencies | Consumes From |
+| API Platform Architect | (where separate) to align API gateway roadmap and developer portal features with the broader API management strategy | Collaborates |
+| DevOps Architect | Ensure integration platform CI/CD pipeline requirements and deployment automation are included in DevOps platform delivery planning | Collaborates |
+| Security Architect | Incorporate API security, OAuth 2.0 / mTLS, and B2B credential governance requirements into the integration platform backlog | Governed By |
+| Enterprise Architect | Integration platform direction within the overall enterprise architecture strategy and digital transformation programme | Governed By |
+| consuming application teams | Gather requirements, manage onboarding to integration services, and communicate deprecation timelines | Provides To |
+| Integration Senior Engineers | As the team's product owner, leading ceremonies and providing delivery direction | Provides To |
+| Integration Engineers | As the team's product owner, leading ceremonies and providing delivery direction | Provides To |
+| vendor TAL/PAL (MuleSoft, Confluent, IBM, TIBCO) | Product roadmap updates, support agreements, and licensing strategy | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | Integration Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Integration Senior Engineer designs and implements complex enterprise integrations across on-premises, cloud, and SaaS platforms. This role serves as the deep technical specialist and escalation point for the integration team, leading delivery of sophisticated integration workflows, API implementations, and event-driven integration patterns. The Senior Engineer drives adoption of integration platform standards, mentors integration engineers, and contributes to integration architecture decisions.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced integration solution design and delivery within the Integration Architect's reference architecture
+- **Experience Anchor:** 5+ years in integration or middleware engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Integration platform architecture and standards (Architect-owned); event-driven data feed integration strategy beyond assigned implementation (DataOps-owned, jointly implemented); API security control design (Security Engineers-owned, implements controls)
+- **Escalates To:** Integration Architect — architecture-level questions and standards exceptions
+- **Escalated To By:** Integration Engineers on complex issues and implementation guidance requests
 
 ## Business Impact
 
@@ -75,13 +85,13 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Integration Architect: | Receive architectural direction; contribute implementation feedback |
-| Integration Engineers: | Mentor and review work |
-| Application Teams: | Design and agree integration contracts and API specifications |
-| DataOps Teams: | Implement event-driven data feed integrations for the data platform |
-| Security Engineers: | Implement API security controls |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Integration Architect | Receive architectural direction; contribute implementation feedback | Escalates To |
+| Integration Engineers | Mentor and review work | Provides To |
+| Application Teams | Design and agree integration contracts and API specifications | Collaborates |
+| DataOps Teams | Implement event-driven data feed integrations for the data platform | Collaborates |
+| Security Engineers | Implement API security controls | Governed By |
 
 ## Key Technologies
 


### PR DESCRIPTION
## Summary

Batch 4/7 of #5: backfills **Reports To**, **Direct Reports**, **Role Scope & Boundaries**, and **Interaction Mode** across all 24 files in the DevOps & Delivery chapter (DevOps, App Platforms, Integration & Middleware), per `docs/role_template.md`. Closes #86.

- **DevOps (7 files):** `devops_architect`, `devops_senior_engineer`, `devops_engineer`, `devops_product_owner`, `developer_experience_engineer`, `platform_reliability_engineer`, `automation_framework_engineer`.
- **App Platforms (13 files):** API Platform ladder (`api_platform_architect/senior_engineer/engineer/product_owner`, `api_strategy_architect`), .NET ladder (4), Java ladder (4).
- **Integration & Middleware (4 files):** `integration_architect/senior_engineer/engineer/product_owner`.

## Reporting model

Standard IC ladder, consistent with batch 2's pattern: Engineer → Senior Engineer; Senior Engineer, Architect, and Product Owner → **DevOps & Delivery Chapter Lead**. Two deliberate exceptions grounded in the domain's own existing text:

- **API Strategy Architect and API Platform Architect are peers, not a hierarchy** — each role's own interactions table already describes the other as its "primary technical counterpart," so both report to the Chapter Lead rather than one managing the other.
- **Developer Experience Engineer and Platform Reliability Engineer** are Engineer-grade specialists with no dedicated Senior Engineer tier of their own — both report to the DevOps Architect.
- **Automation Framework Engineer** already had an explicit `Reports to:` statement in its interactions table (`DevOps Senior Engineer or DevOps Architect, depending on team structure`); carried that into the new metadata field verbatim.

## Other fixes bundled in

- Renamed `## Relationships & Collaboration` to the canonical `## Interactions with Other Roles` in `devops_engineer.md`, `devops_senior_engineer.md`, and `devops_product_owner.md` (mirroring the original #7 fix — these three were the only files in the chapter using the variant heading).
- Consolidated a duplicate "Security Architect(s)" row in `devops_architect.md`'s interactions table (it appeared twice, once terse and once detailed) into a single row.

## Verification

- `npm run validate` — 220 files checked, 0 errors, 0 warnings, 0 duplicate titles.
- `npm test` — 91/91 passing.
- `npx markdownlint-cli2` on all 24 touched files — 0 issues.
- Cross-file directional consistency spot-checked (Reports To / Direct Reports pairs match on both sides, e.g. DevOps Architect's Direct Reports note vs DevOps Senior Engineer's Reports To).

## Test plan

- [x] `npm run validate`
- [x] `npm test`
- [x] `npx markdownlint-cli2` on touched files
- [ ] CI green on both matrix legs

Closes #86.