### PR TITLE
feat: backfill Reports To / Scope / Interaction Mode for Data & AI chapter (#87, batch 5/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
+  Mode backfilled for the Data & AI chapter (#87, batch 5/7: 27 of 219
+  files — Data Management's 2 governance specialists, Data Governance
+  Lead and Data Privacy Officer, were already on the modern template).**
+  AI Governance, Data Engineering, Data Management (Storage and Qumulo
+  Storage ladders), and Database Management all follow the standard
+  IC-ladder pattern: Engineer reports to Senior Engineer, Senior Engineer
+  and Product Owner report to the Data & AI Chapter Lead. Three Architect
+  pairs are modeled as peers rather than a hierarchy, per each pair's own
+  text describing the other as its counterpart rather than its manager:
+  AI Governance Architect / AI Platform Architect, Data Platform Architect
+  / Data Mesh Architect, and Storage Architect / Qumulo Storage Architect
+  (parallel block-storage and unstructured-storage ladders). AI Platform
+  Engineer, Data Platform Engineer, and Responsible AI Engineer — Engineer-
+  grade specialists with no dedicated Senior Engineer tier of their own —
+  report to their nearest Architect. Fixed a malformed interactions-table
+  row in `qumulo_storage_engineer.md` ("Storage Team Lead | Or
+  **Infrastructure Manager**", referencing roles that don't exist in the
+  catalog) by replacing it with the standard escalation row to Qumulo
+  Storage Senior Engineer.
+- **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
   Mode backfilled for the DevOps & Delivery chapter (#86, batch 4/7:
   24 of 219 files).** DevOps, App Platforms (API, .NET, Java), and
   Integration & Middleware all follow the standard IC-ladder pattern:

--- a/Roles/ai_governance/ai_governance_architect.md
+++ b/Roles/ai_governance/ai_governance_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors AI Governance Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AI Governance Architect designs and governs the organisation's frameworks, policies, and technical controls for responsible and compliant use of artificial intelligence across all business units and AI system deployments. As AI and generative AI become deeply embedded in enterprise products, operations, and decision-making, this role ensures that AI systems are trustworthy, explainable, fair, secure, and compliant with applicable regulations (EU AI Act, US Executive Orders, GDPR). The AI Governance Architect bridges technical AI implementation with legal, ethical, and regulatory requirements.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — AI governance framework, model risk assessment methodology, and AI compliance controls across the chapter
+- **Experience Anchor:** 8+ years in AI/ML governance, risk, or compliance engineering with demonstrated framework-level ownership — operates independently on domain-wide AI governance decisions, as a peer counterpart to the AI Platform Architect rather than in a hierarchical relationship
+- **Out of Scope:** AI/ML platform infrastructure design (AI Platform Architect-owned, this role embeds governance controls into it); broader data governance policy (Chief Data Officer-owned, this role integrates with it); AI regulatory legal interpretation (Legal and Compliance-owned, this role translates it into technical controls)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain governance disputes
+- **Escalated To By:** AI Governance Senior Engineers on framework, policy, and complex assessment decisions
 
 ## Business Impact
 
@@ -78,14 +88,14 @@ The AI Governance Architect designs and governs the organisation's frameworks, p
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CISO / Security Architect | Align AI security controls with the AI governance framework |
-| Chief Data Officer / Data Governance | Integrate AI data governance with broader data governance policy |
-| AI Platform Architect | Embed governance controls into AI platform design |
-| Legal and Compliance | Translate regulatory requirements into technical governance controls |
-| HR | Govern workforce AI tools (Copilot, AI assistants, AI-assisted performance management) |
-| Product Teams | Provide AI governance requirements for AI-powered product features |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CISO / Security Architect | Align AI security controls with the AI governance framework | Collaborates |
+| Chief Data Officer / Data Governance | Integrate AI data governance with broader data governance policy | Governed By |
+| AI Platform Architect | Embed governance controls into AI platform design | Collaborates |
+| Legal and Compliance | Translate regulatory requirements into technical governance controls | Governed By |
+| HR | Govern workforce AI tools (Copilot, AI assistants, AI-assisted performance management) | Provides To |
+| Product Teams | Provide AI governance requirements for AI-powered product features | Provides To |
 
 ## Key Technologies
 

--- a/Roles/ai_governance/ai_governance_engineer.md
+++ b/Roles/ai_governance/ai_governance_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | AI Governance Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AI Governance Engineer is an entry-level practitioner role responsible for implementing AI governance controls across the organisation's AI systems under the direction of the AI Governance Architect and Senior AI Governance Engineer. This role conducts bias testing and fairness evaluations, maintains AI system documentation and risk registers, supports AI incident logging and investigation processes, and assists with compliance evidence collection for regulatory requirements. The AI Governance Engineer builds practical hands-on experience with responsible AI toolkits and governance processes, forming the operational backbone of the AI governance function.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of AI governance documentation and evidence-gathering tasks to defined standards
+- **Experience Anchor:** 1-3 years in AI/ML governance, risk, or compliance — works under guidance, building toward independent delivery
+- **Out of Scope:** AI governance framework design (Senior Engineers and the Architect-owned); risk assessment methodology definition; AI platform architecture decisions
+- **Escalates To:** AI Governance Senior Engineer — day-to-day task direction and technical guidance
+- **Escalated To By:** AI Governance Product Owner on documentation and risk register completeness status
 
 ## Business Impact
 
@@ -72,14 +82,14 @@ The AI Governance Engineer is an entry-level practitioner role responsible for i
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AI Platform Architect | Accessing deployed model artefacts, MLOps pipeline outputs, and model registry metadata needed for governance assessments |
-| Legal and Compliance | Team members when collecting compliance evidence or seeking clarification on documentation requirements |
-| AI Governance Senior Engineer | Day-to-day task direction, mentoring, and technical guidance |
-| AI Governance Architect | Technical guidance, framework interpretation, and escalation of complex governance decisions |
-| Data Science and ML Engineering | Teams to collect model documentation, training data lineage, and evaluation metrics required for risk assessments |
-| AI Governance Product Owner | Provide status on documentation and risk register completeness for backlog and programme reporting |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AI Platform Architect | Accessing deployed model artefacts, MLOps pipeline outputs, and model registry metadata needed for governance assessments | Consumes From |
+| Legal and Compliance | Team members when collecting compliance evidence or seeking clarification on documentation requirements | Collaborates |
+| AI Governance Senior Engineer | Day-to-day task direction, mentoring, and technical guidance | Escalates To |
+| AI Governance Architect | Technical guidance, framework interpretation, and escalation of complex governance decisions | Escalates To |
+| Data Science and ML Engineering | Teams to collect model documentation, training data lineage, and evaluation metrics required for risk assessments | Consumes From |
+| AI Governance Product Owner | Provide status on documentation and risk register completeness for backlog and programme reporting | Provides To |
 
 ## Key Technologies
 

--- a/Roles/ai_governance/ai_governance_product_owner.md
+++ b/Roles/ai_governance/ai_governance_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AI Governance Product Owner owns the AI governance product backlog, managing the roadmap for governance platform capabilities and tooling investments. This role bridges business risk and compliance requirements with technical governance implementation — working closely with the AI Governance Architect to translate governance policies into platform features, and with Legal, Compliance, and Risk Management to ensure the governance programme meets organisational and regulatory obligations. The AI Governance Product Owner ensures the governance team delivers prioritised, high-value capabilities that keep the organisation's AI estate compliant, auditable, and responsibly governed.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — AI governance programme backlog, risk register prioritisation, and delivery roadmap
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with risk/compliance domain exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** AI governance framework design (AI Governance Architect-owned); AI platform delivery roadmap (AI Platform Architect-owned, this role aligns to it); enterprise risk appetite setting (Risk Management-owned)
+- **Escalates To:** Data & AI Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** AI Governance Senior Engineers and Engineers on backlog ceremonies and delivery prioritisation
 
 ## Business Impact
 
@@ -72,16 +82,16 @@ The AI Governance Product Owner owns the AI governance product backlog, managing
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AI Platform Architect | Ensure governance controls and tooling integrations are included in ML platform delivery roadmaps and sprint planning |
-| Legal and Compliance | Gather regulatory requirements, validate compliance deliverables, and coordinate evidence for regulatory submissions and audits |
-| Risk Management | Align governance programme priorities with enterprise risk appetite and risk register obligations |
-| Business Unit AI Programme stakeholders | Balance governance requirements against AI development team needs and delivery velocity |
-| AI Governance Senior Engineers and Engineers | Product owner for the team — leads ceremonies, provides delivery prioritisation direction, and owns the governance backlog |
-| TAL and PAL | Vendor tooling roadmaps, support SLAs, and AI governance platform procurement decisions |
-| AI Governance Architect | As the technical counterpart — translates governance framework design into platform backlog items and sequences delivery aligned to architectural strategy and dependencies |
-| Internal Audit | Executive risk governance committees |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AI Platform Architect | Ensure governance controls and tooling integrations are included in ML platform delivery roadmaps and sprint planning | Collaborates |
+| Legal and Compliance | Gather regulatory requirements, validate compliance deliverables, and coordinate evidence for regulatory submissions and audits | Consumes From |
+| Risk Management | Align governance programme priorities with enterprise risk appetite and risk register obligations | Governed By |
+| Business Unit AI Programme stakeholders | Balance governance requirements against AI development team needs and delivery velocity | Collaborates |
+| AI Governance Senior Engineers and Engineers | Product owner for the team — leads ceremonies, provides delivery prioritisation direction, and owns the governance backlog | Provides To |
+| TAL and PAL | Vendor tooling roadmaps, support SLAs, and AI governance platform procurement decisions | Provides To |
+| AI Governance Architect | As the technical counterpart — translates governance framework design into platform backlog items and sequences delivery aligned to architectural strategy and dependencies | Consumes From |
+| Internal Audit | Executive risk governance committees | Provides To |
 
 ## Key Technologies
 

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | AI Governance Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AI Governance Senior Engineer implements, operates, and continuously improves the technical controls, tooling, and processes that make up the organization's AI governance framework. Working under the direction of the AI Governance Architect, this role translates governance policies into working technical implementations — running AI risk assessments, operating bias and explainability tooling, maintaining the AI system inventory, and ensuring that AI deployments comply with applicable regulations and internal policies. The Senior Engineer brings hands-on depth in AI/ML tooling combined with strong governance and compliance awareness.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced AI risk assessments and governance tooling delivery within the AI Governance Architect's framework
+- **Experience Anchor:** 5+ years in AI/ML governance, risk, or compliance engineering with demonstrated independent delivery — operates independently within the Architect's framework
+- **Out of Scope:** AI governance framework and policy design (Architect-owned); AI platform infrastructure (AI Platform Engineers-owned, this role embeds governance checks into it); regulatory legal interpretation (Legal and Compliance-owned)
+- **Escalates To:** AI Governance Architect — framework, policy, and complex assessment decisions
+- **Escalated To By:** AI Governance Engineers on day-to-day task direction and technical guidance
 
 ## Business Impact
 
@@ -65,15 +75,15 @@ The AI Governance Senior Engineer implements, operates, and continuously improve
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AI Platform Engineers | Embed governance checks into AI pipelines |
-| MLOps Engineers | Embed governance checks into AI pipelines |
-| data science and ML teams | Model card completion, bias testing, and documentation |
-| Legal and Compliance | Technical evidence packages for regulatory reviews and audits |
-| Security Engineers | AI-specific security controls (prompt injection mitigations, model access controls) |
-| business AI owners | Complete risk assessment interviews and gather system documentation |
-| AI Governance Architect | Framework, policy, and complex assessment decisions |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AI Platform Engineers | Embed governance checks into AI pipelines | Collaborates |
+| MLOps Engineers | Embed governance checks into AI pipelines | Collaborates |
+| data science and ML teams | Model card completion, bias testing, and documentation | Collaborates |
+| Legal and Compliance | Technical evidence packages for regulatory reviews and audits | Provides To |
+| Security Engineers | AI-specific security controls (prompt injection mitigations, model access controls) | Collaborates |
+| business AI owners | Complete risk assessment interviews and gather system documentation | Consumes From |
+| AI Governance Architect | Framework, policy, and complex assessment decisions | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/ai_governance/ai_platform_architect.md
+++ b/Roles/ai_governance/ai_platform_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors AI Platform Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AI Platform Architect designs and governs the organisation's AI/ML platform infrastructure that enables data science and engineering teams to build, train, deploy, and monitor AI and machine learning models at scale. This role owns the end-to-end MLOps architecture: experiment tracking, model registry, feature stores, model serving infrastructure, and AI workload orchestration. The AI Platform Architect ensures the AI platform is secure, scalable, governable, and aligned with both cloud infrastructure standards and AI governance policies — bridging the gap between raw cloud infrastructure and the AI development lifecycle.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — ML platform infrastructure architecture, MLOps tooling standards, and AI/ML compute strategy across the chapter
+- **Experience Anchor:** 8+ years in ML platform, MLOps, or AI infrastructure engineering with demonstrated architecture-level delivery — operates independently on domain-wide ML platform architecture decisions, as a peer counterpart to the AI Governance Architect rather than in a hierarchical relationship
+- **Out of Scope:** AI governance framework and risk methodology (AI Governance Architect-owned, this role embeds controls into the platform); data pipeline architecture upstream of model training (Data Platform Architect-owned); cloud landing zone design (Cloud Architects-owned)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** AI Platform Engineers on complex design decisions
 
 ## Business Impact
 
@@ -74,15 +84,15 @@ The AI Platform Architect designs and governs the organisation's AI/ML platform 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AI Governance Architect | Embed governance controls, bias evaluation pipelines, audit trail requirements, and AI risk tagging into the ML platform architecture |
-| Data Platform Architect | Data pipeline integration, feature computation patterns, Delta Lake / data lakehouse architecture, and data quality upstream of model training |
-| Azure Cloud Architect | , **AWS Cloud Architect**, and **GCP Cloud Architect** on AI/ML infrastructure provisioning, landing zone design for ML workloads, and managed AI service integration |
-| Kubernetes Architect | GPU workload orchestration, distributed training scheduling, and ML serving infrastructure deployment on Kubernetes |
-| Security Architect | Ensure model artefact security, training data access governance, inference endpoint security, and AI supply chain integrity |
-| MLOps Engineers | Platform tooling, pipeline patterns, and ML infrastructure implementation |
-| data science and ML engineering teams | Platform adoption, experiment tracking standards, and model deployment best practices |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AI Governance Architect | Embed governance controls, bias evaluation pipelines, audit trail requirements, and AI risk tagging into the ML platform architecture | Collaborates |
+| Data Platform Architect | Data pipeline integration, feature computation patterns, Delta Lake / data lakehouse architecture, and data quality upstream of model training | Collaborates |
+| Azure, AWS, and GCP Cloud Architects | AI/ML infrastructure provisioning, landing zone design for ML workloads, and managed AI service integration | Collaborates |
+| Kubernetes Architect | GPU workload orchestration, distributed training scheduling, and ML serving infrastructure deployment on Kubernetes | Collaborates |
+| Security Architect | Ensure model artefact security, training data access governance, inference endpoint security, and AI supply chain integrity | Governed By |
+| MLOps Engineers | Platform tooling, pipeline patterns, and ML infrastructure implementation | Provides To |
+| data science and ML engineering teams | Platform adoption, experiment tracking standards, and model deployment best practices | Provides To |
 
 ## Key Technologies
 

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | AI Platform Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AI Platform Engineer builds and operates the organisation's AI/ML platform infrastructure, translating designs from the AI Platform Architect into production-grade implementations. This role provisions and maintains ML compute infrastructure, implements MLOps pipelines for model training and deployment, manages model registries, and supports data science and ML engineering teams with reliable, scalable platform tooling. Operating as an entry to mid-level practitioner, the AI Platform Engineer ensures that the AI platform is operationally stable, cost-efficient, and enables data scientists to move from experimentation to production with minimal friction.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of ML platform implementation, pipeline support, and infrastructure tasks to defined standards
+- **Experience Anchor:** 1-3 years in ML platform, MLOps, or infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** ML platform architecture and technology standards (Architect-owned); AI governance control design (AI Governance Engineer-owned, this role coordinates implementation); data pipeline architecture (Data Platform Architect-owned)
+- **Escalates To:** AI Platform Architect — complex design decisions
+- **Escalated To By:** Data Science / ML Engineering teams on experiment environment setup, pipeline debugging, and model deployment support
 
 ## Business Impact
 
@@ -76,14 +86,14 @@ The AI Platform Engineer builds and operates the organisation's AI/ML platform i
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AI Platform Architect: | Receives architecture design direction, reference implementations, and technology standards; escalates complex design decisions upward |
-| AI Governance Engineer: | Coordinates on embedding governance controls, audit logging, and bias testing hooks within ML pipelines and the model registry |
-| Data Platform Architect: | Aligns data ingestion and feature pipeline integration between the data platform and the ML platform |
-| Data Science / ML Engineering teams: | Primary customers of the platform; supports experiment environment setup, pipeline debugging, and model deployment |
-| DevOps Architect: | Aligns MLOps CI/CD pipelines with organisational DevOps toolchain standards and deployment gates |
-| Cloud Architects: | Coordinates on underlying compute, networking, and storage for ML infrastructure |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AI Platform Architect | Receives architecture design direction, reference implementations, and technology standards; escalates complex design decisions upward | Escalates To |
+| AI Governance Engineer | Coordinates on embedding governance controls, audit logging, and bias testing hooks within ML pipelines and the model registry | Collaborates |
+| Data Platform Architect | Aligns data ingestion and feature pipeline integration between the data platform and the ML platform | Collaborates |
+| Data Science / ML Engineering teams | Primary customers of the platform; supports experiment environment setup, pipeline debugging, and model deployment | Provides To |
+| DevOps Architect | Aligns MLOps CI/CD pipelines with organisational DevOps toolchain standards and deployment gates | Governed By |
+| Cloud Architects | Coordinates on underlying compute, networking, and storage for ML infrastructure | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/ai_governance/responsible_ai_engineer.md
+++ b/Roles/ai_governance/responsible_ai_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | AI Governance Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Responsible AI Engineer implements the technical tooling, testing processes, and compliance artefacts that support the organisation's AI governance framework. Where the AI Governance Architect defines policy and strategy, this role operationalises governance controls directly within AI development and MLOps pipelines. The Responsible AI Engineer runs bias and fairness evaluations, generates explainability outputs, produces model cards and compliance documentation, integrates governance tooling into CI/CD pipelines, and supports AI risk assessments with quantitative evidence and audit artefacts.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — embedding responsible AI checks and governance tooling into ML experimentation and deployment workflows
+- **Experience Anchor:** 3-5 years in AI/ML engineering with a responsible AI, ethics, or governance focus — operates independently within the AI Governance Architect's framework
+- **Out of Scope:** AI governance framework and policy design (AI Governance Architect-owned); ML platform infrastructure (AI Platform team-owned); AI regulatory legal interpretation (Legal and Compliance-owned)
+- **Escalates To:** AI Governance Architect — governance requirements interpretation and compliance gap findings
+- **Escalated To By:** Data Scientists and MLOps Engineers on responsible AI tooling and governance check integration
 
 ## Business Impact
 
@@ -78,13 +88,13 @@ The Responsible AI Engineer implements the technical tooling, testing processes,
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AI Governance Architect: | Receives governance requirements; escalates findings and compliance gaps |
-| Data Scientists: | Embeds governance checks into experimentation and training workflows |
-| MLOps Engineer: | Integrates governance tooling into CI/CD pipelines and model deployment gates |
-| Security Engineer: | Coordinates on AI-specific threat surface (prompt injection, model theft, adversarial examples) |
-| Legal and Compliance: | Provides technical evidence for AI regulatory assessments and audits |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AI Governance Architect | Receives governance requirements; escalates findings and compliance gaps | Escalates To |
+| Data Scientists | Embeds governance checks into experimentation and training workflows | Provides To |
+| MLOps Engineer | Integrates governance tooling into CI/CD pipelines and model deployment gates | Collaborates |
+| Security Engineer | Coordinates on AI-specific threat surface (prompt injection, model theft, adversarial examples) | Collaborates |
+| Legal and Compliance | Provides technical evidence for AI regulatory assessments and audits | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | Data Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data Engineer designs, builds, and maintains the data pipelines, transformations, and data models that deliver reliable, high-quality data to analytics, reporting, and machine learning consumers. This role works with cloud data platforms (Databricks, Snowflake, BigQuery, Azure Synapse), orchestration tools, and transformation frameworks to ingest data from diverse sources, apply medallion architecture patterns, and produce curated data products that the organisation can trust.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of data pipeline implementation and data model tasks to defined standards
+- **Experience Anchor:** 1-3 years in data engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Data pipeline architecture and design (Senior Engineers and the Architect-owned); CI/CD tooling standards (DataOps Specialists-owned); data governance policy definition (Data Governance-owned, this role applies its requirements)
+- **Escalates To:** Data Senior Engineer — design-level questions and implementation issues
+- **Escalated To By:** Data Scientists on feature engineering pipeline and curated dataset requests
 
 ## Business Impact
 
@@ -74,13 +84,13 @@ The Data Engineer designs, builds, and maintains the data pipelines, transformat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect: | Receive architectural direction; contribute feedback on implementation feasibility |
-| DataOps Specialists: | Follow CI/CD standards; request tooling and pipeline infrastructure support |
-| Analytics Engineers: | Collaborate on semantic layer and BI-facing data models |
-| Data Scientists: | Provide feature engineering pipelines and curated datasets |
-| Data Governance: | Apply cataloguing, lineage, and classification requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Receive architectural direction; contribute feedback on implementation feasibility | Consumes From |
+| DataOps Specialists | Follow CI/CD standards; request tooling and pipeline infrastructure support | Governed By |
+| Analytics Engineers | Collaborate on semantic layer and BI-facing data models | Collaborates |
+| Data Scientists | Provide feature engineering pipelines and curated datasets | Provides To |
+| Data Governance | Apply cataloguing, lineage, and classification requirements | Governed By |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data Engineering Product Owner owns the vision, roadmap, and delivery backlog for the organisation's data platform and data engineering capabilities. This role ensures the data platform investment delivers measurable business value - enabling analytics, BI, and ML use cases to be powered by reliable, timely, and trustworthy data. The Data Engineering PO bridges the CDO's data strategy with the technical delivery of the data engineering team, prioritising work that maximises data-driven business outcomes.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — data engineering backlog, delivery prioritisation, and roadmap alignment to enterprise data strategy
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Data platform architecture and technical constraints (Data Platform Architect-owned); pipeline reliability acceptance criteria detail (DataOps Specialists-owned); enterprise data strategy setting (CDO-owned, this role translates it into deliverables)
+- **Escalates To:** Data & AI Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** DataOps Specialists on acceptance criteria for pipeline reliability and CI/CD work
 
 ## Business Impact
 
@@ -71,14 +81,14 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect: | Align backlog with architecture roadmap and technical constraints |
-| CDO / Data Strategy: | Receive strategic data priorities and translate into engineering deliverables |
-| Analytics / BI Leads: | Capture and prioritise data consumption requirements |
-| Data Science / MLOps: | Align feature pipeline delivery with ML project roadmaps |
-| DataOps Specialists: | Provide clear acceptance criteria for pipeline reliability and CI/CD work |
-| Finance / FinOps: | Report and optimise data platform cost |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Align backlog with architecture roadmap and technical constraints | Consumes From |
+| CDO / Data Strategy | Receive strategic data priorities and translate into engineering deliverables | Consumes From |
+| Analytics / BI Leads | Capture and prioritise data consumption requirements | Consumes From |
+| Data Science / MLOps | Align feature pipeline delivery with ML project roadmaps | Collaborates |
+| DataOps Specialists | Provide clear acceptance criteria for pipeline reliability and CI/CD work | Provides To |
+| Finance / FinOps | Report and optimise data platform cost | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction on data mesh standards; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data Mesh Architect designs and governs the organisation's data mesh architecture — a sociotechnical approach to data management that moves away from centralised monolithic data platforms towards a domain-oriented, self-serve model where business domains own and publish their data as products. This role owns the data mesh governance framework, federated data product standards, data contract specifications, and the central infrastructure components (data product portal, federated catalogue, and interoperability layer) that allow domain teams to operate autonomously while maintaining enterprise-wide discoverability and interoperability. The Data Mesh Architect operates at the intersection of enterprise architecture, data engineering, and data governance.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — data mesh domain decomposition model, federated governance, and data product standards across the chapter
+- **Experience Anchor:** 8+ years in data architecture with demonstrated experience designing federated/domain-oriented data platforms — operates independently on domain-wide data mesh strategy decisions, as a peer counterpart to the Data Platform Architect rather than in a hierarchical relationship
+- **Out of Scope:** Underlying data platform infrastructure (Data Platform Architect-owned, this role aligns mesh requirements to it); enterprise capability domain boundaries (Enterprise Architect-owned, this role aligns mesh boundaries to it); enterprise-wide data governance policy (Data Management / Data Governance team-owned)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Business domain teams (Data Product Owners) on data product onboarding and governance guidance
 
 ## Business Impact
 
@@ -77,14 +87,14 @@ The Data Mesh Architect designs and governs the organisation's data mesh archite
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect: | Aligns data mesh self-serve infrastructure requirements with the underlying data platform architecture; agrees shared storage, compute, and governance tooling |
-| Enterprise Architect: | Aligns domain decomposition model with enterprise capability domains; ensures data mesh boundaries are consistent with application and business architecture |
-| AI Governance Architect: | Defines AI data product standards for ML training datasets, feature stores, and model output datasets published as data products |
-| Data Management / Data Governance team: | Integrates federated governance model with enterprise-wide data governance policy, data classification, and regulatory requirements |
-| Integration Architect: | Aligns data product output port patterns with enterprise integration and API standards for downstream consumption |
-| Business domain teams (Data Product Owners): | Partners with domain teams to design, review, and onboard data products to the mesh; provides governance guidance and self-serve tooling support |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Aligns data mesh self-serve infrastructure requirements with the underlying data platform architecture; agrees shared storage, compute, and governance tooling | Collaborates |
+| Enterprise Architect | Aligns domain decomposition model with enterprise capability domains; ensures data mesh boundaries are consistent with application and business architecture | Governed By |
+| AI Governance Architect | Defines AI data product standards for ML training datasets, feature stores, and model output datasets published as data products | Collaborates |
+| Data Management / Data Governance team | Integrates federated governance model with enterprise-wide data governance policy, data classification, and regulatory requirements | Governed By |
+| Integration Architect | Aligns data product output port patterns with enterprise integration and API standards for downstream consumption | Collaborates |
+| Business domain teams (Data Product Owners) | Partners with domain teams to design, review, and onboard data products to the mesh; provides governance guidance and self-serve tooling support | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Data Senior Engineers and Data Platform Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data Platform Architect designs and governs the organisation's enterprise data platform strategy, covering data ingestion, storage, transformation, and consumption layers across on-premises, cloud, and hybrid environments. This role defines the architecture for data lakehouse platforms, cloud data warehouses, streaming pipelines, and data mesh or data product patterns that enable analytics, machine learning, and operational data use cases at scale. The Architect ensures the data platform is secure, reliable, governed, and cost-efficient.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — data platform architecture, ingestion/storage/compute standards, and data platform technology selection across the chapter
+- **Experience Anchor:** 8+ years in data engineering or platform architecture with demonstrated architecture-level delivery — operates independently on domain-wide data platform architecture decisions, as a peer counterpart to the Data Mesh Architect rather than in a hierarchical relationship
+- **Out of Scope:** Data mesh domain decomposition and federated governance model (Data Mesh Architect-owned); AI/ML training and serving infrastructure (AI Platform Architect-owned, this role aligns data pipelines to it); data governance policy (CDO/Data Governance-owned)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Data Senior Engineers and Data Platform Engineers on architecture-level design exceptions
 
 ## Business Impact
 
@@ -94,14 +104,14 @@ The Data Platform Architect designs and governs the organisation's enterprise da
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CDO / Data Governance team: | Align platform architecture with data governance policies and data strategy |
-| MLOps / AI Platform Architect: | Design integration between data platform and ML training/serving infrastructure |
-| DataOps Specialist: | Provide architecture direction; receive operational feedback from platform operations |
-| Cloud Architects: | Align data platform architecture with cloud platform standards |
-| Analytics / BI teams: | Ensure data platform serves consumption layer performance requirements |
-| FinOps: | Provide data platform cost attribution models |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CDO / Data Governance team | Align platform architecture with data governance policies and data strategy | Governed By |
+| MLOps / AI Platform Architect | Design integration between data platform and ML training/serving infrastructure | Collaborates |
+| DataOps Specialist | Provide architecture direction; receive operational feedback from platform operations | Provides To |
+| Cloud Architects | Align data platform architecture with cloud platform standards | Collaborates |
+| Analytics / BI teams | Ensure data platform serves consumption layer performance requirements | Provides To |
+| FinOps | Provide data platform cost attribution models | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | Data Platform Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data Platform Engineer builds, maintains, and optimises the shared data platform infrastructure that all data engineering teams and data consumers rely upon. Operating as an entry to mid-level practitioner, this role implements data platform designs created by the Data Platform Architect — constructing and managing data lakes, lakehouses, ingestion pipelines, transformation frameworks, and data storage layers. Distinct from a domain-focused Data Engineer — who builds pipelines serving a specific business domain — the Data Platform Engineer focuses on the shared infrastructure layer that all data engineers and data consumers depend on. This role ensures the platform is reliable, performant, cost-efficient, and continuously improving.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of shared data platform infrastructure, onboarding support, and platform-layer incident response
+- **Experience Anchor:** 3-5 years in data platform or infrastructure engineering — operates independently within the Data Platform Architect's reference architecture
+- **Out of Scope:** Data platform architecture and technology standards (Architect-owned); domain-specific pipeline implementation (Data Engineers across domains-owned, this role provides shared infrastructure to them); DevOps toolchain standards (DevOps Architect-owned, this role aligns to them)
+- **Escalates To:** Data Platform Architect — complex design decisions and implementation feasibility questions
+- **Escalated To By:** Data Engineers across domains on platform onboarding and platform-layer issues
 
 ## Business Impact
 
@@ -77,14 +87,14 @@ The Data Platform Engineer builds, maintains, and optimises the shared data plat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect: | Receives architecture designs, technology standards, and implementation direction; escalates complex design decisions and provides implementation feasibility feedback |
-| DataOps Specialist: | Collaborates on pipeline reliability, data quality test integration, CI/CD pipeline implementation, and incident response for platform-layer failures |
-| Data Engineers across domains: | Primary platform customers; supports onboarding, resolves platform issues, and provides shared infrastructure services enabling domain data product delivery |
-| Cloud Architects: | Coordinates on underlying compute, networking, storage, and security configuration that underpins the data platform |
-| DevOps Architect: | Aligns data platform CI/CD pipelines with organisational DevOps toolchain, container registries, and deployment gates |
-| AI Platform Engineer: | Coordinates on data platform integration points for ML feature pipeline ingestion and training data access patterns |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Receives architecture designs, technology standards, and implementation direction; escalates complex design decisions and provides implementation feasibility feedback | Escalates To |
+| DataOps Specialist | Collaborates on pipeline reliability, data quality test integration, CI/CD pipeline implementation, and incident response for platform-layer failures | Collaborates |
+| Data Engineers across domains | Primary platform customers; supports onboarding, resolves platform issues, and provides shared infrastructure services enabling domain data product delivery | Provides To |
+| Cloud Architects | Coordinates on underlying compute, networking, storage, and security configuration that underpins the data platform | Collaborates |
+| DevOps Architect | Aligns data platform CI/CD pipelines with organisational DevOps toolchain, container registries, and deployment gates | Governed By |
+| AI Platform Engineer | Coordinates on data platform integration points for ML feature pipeline ingestion and training data access patterns | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/data_senior_engineer.md
+++ b/Roles/data_engineering/data_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | Data Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Data Senior Engineer leads complex data engineering initiatives, drives data platform standards adoption, and acts as a technical authority and escalation point within the data engineering team. This role owns design decisions for significant data domains or platform components, leads the development of reusable data frameworks and patterns, drives data quality maturity, and mentors data engineers. The Senior Data Engineer operates within a high degree of autonomy and contributes to the broader data platform architecture through hands-on technical leadership.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced data pipeline design and delivery within the Data Platform Architect's reference architecture
+- **Experience Anchor:** 5+ years in data engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Data platform architecture and technology standards (Architect-owned); pipeline reliability tooling and CI/CD standards (DataOps Specialist-owned, this role collaborates with it); semantic layer ownership (Analytics Engineers-owned, this role aligns to it)
+- **Escalates To:** Data Platform Architect — architecture-level questions and standards exceptions
+- **Escalated To By:** Data Engineers on complex pipeline design and implementation issues
 
 ## Business Impact
 
@@ -77,13 +87,13 @@ The Data Senior Engineer leads complex data engineering initiatives, drives data
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect: | Receive strategic direction; contribute implementation experience to architecture decisions |
-| DataOps Specialists: | Collaborate on pipeline reliability, testing, and observability |
-| Data Engineers: | Provide mentoring, code review, and design guidance |
-| Analytics Engineers: | Align on semantic layer requirements and data model design |
-| Data Scientists: | Provide feature engineering pipelines and curated, well-documented datasets |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Receive strategic direction; contribute implementation experience to architecture decisions | Escalates To |
+| DataOps Specialists | Collaborate on pipeline reliability, testing, and observability | Collaborates |
+| Data Engineers | Provide mentoring, code review, and design guidance | Provides To |
+| Analytics Engineers | Align on semantic layer requirements and data model design | Collaborates |
+| Data Scientists | Provide feature engineering pipelines and curated, well-documented datasets | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DataOps Specialist applies DevOps and agile engineering principles to data pipeline development, testing, and operations — bringing software engineering rigour to the data engineering lifecycle. This senior-level role owns data pipeline CI/CD, automated data quality testing frameworks, data pipeline observability and alerting, and incident management for data infrastructure failures. The DataOps Specialist bridges the gap between data engineering (build) and data operations (run), ensuring that pipelines are reliable, testable, observable, and continuously delivered. This role works closely with Data Platform Architects, data engineers across domains, DevOps, and ML platform teams to maintain a high standard of operational maturity for the organisation's data infrastructure.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — data pipeline CI/CD standards, quality testing integration, and pipeline observability across data engineering teams
+- **Experience Anchor:** 5+ years in DataOps, data engineering, or platform reliability with demonstrated independent delivery — operates independently within the Data Platform Architect's standards
+- **Out of Scope:** Data platform architecture and technology standards (Data Platform Architect-owned); data mesh governance framework design (Data Mesh Architect-owned, this role aligns pipeline standards to it); organisational DevOps toolchain standards (DevOps Architect-owned, this role aligns to them)
+- **Escalates To:** Data Platform Architect — pipeline architecture standards and design direction
+- **Escalated To By:** Data Engineers across domains on pipeline code reviews, quality testing guidance, and incident triage
 
 ## Business Impact
 
@@ -78,14 +88,14 @@ The DataOps Specialist applies DevOps and agile engineering principles to data p
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect: | Receives pipeline architecture standards and design direction; provides operational feedback on platform reliability and performance |
-| Data Mesh Architect: | Aligns data product pipeline CI/CD standards with the data mesh governance framework; ensures domain data product pipelines meet quality and SLA requirements |
-| DevOps Architect: | Aligns data pipeline CI/CD toolchain with organisational DevOps standards, shared runners, and deployment governance |
-| Observability Architect: | Integrates data pipeline monitoring, alerting, and incident data with the enterprise observability platform (Datadog, Grafana, etc.) |
-| AI Platform Architect: | Coordinates on ML feature engineering pipeline orchestration reliability and MLOps CI/CD alignment |
-| Data Engineers across domains: | Primary partners for pipeline code reviews, quality testing guidance, incident triage, and DataOps standards adoption |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Receives pipeline architecture standards and design direction; provides operational feedback on platform reliability and performance | Escalates To |
+| Data Mesh Architect | Aligns data product pipeline CI/CD standards with the data mesh governance framework; ensures domain data product pipelines meet quality and SLA requirements | Governed By |
+| DevOps Architect | Aligns data pipeline CI/CD toolchain with organisational DevOps standards, shared runners, and deployment governance | Governed By |
+| Observability Architect | Integrates data pipeline monitoring, alerting, and incident data with the enterprise observability platform (Datadog, Grafana, etc.) | Governed By |
+| AI Platform Architect | Coordinates on ML feature engineering pipeline orchestration reliability and MLOps CI/CD alignment | Collaborates |
+| Data Engineers across domains | Primary partners for pipeline code reviews, quality testing guidance, incident triage, and DataOps standards adoption | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Qumulo Storage Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Qumulo Storage Architect designs and oversees the implementation of enterprise storage solutions using Qumulo technology. This role ensures that the organization's file storage infrastructure delivers optimal performance, scalability, and data protection while meeting business requirements.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Qumulo unstructured storage platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in storage architecture with demonstrated Qumulo or scale-out NAS platform ownership — operates independently on domain-wide Qumulo platform architecture decisions
+- **Out of Scope:** Enterprise block/SAN storage architecture (Storage Architect-owned — a parallel, non-Qumulo storage ladder); server hardware procurement (Server Hardware Architect-owned, this role defines requirements for it); backup solution integration detail (Backup Solution Architects-owned, this role aligns to it)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Qumulo Storage Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -61,13 +71,13 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Architect | Hardware specifications for Qumulo nodes |
-| Cloud Platform Architects | Hybrid cloud storage implementations |
-| Database Architect | Storage requirements for database workloads |
-| Observability Architect | Storage monitoring solutions |
-| Backup Solution Architects | Data protection integration |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Architect | Hardware specifications for Qumulo nodes | Consumes From |
+| Cloud Platform Architects | Hybrid cloud storage implementations | Collaborates |
+| Database Architect | Storage requirements for database workloads | Provides To |
+| Observability Architect | Storage monitoring solutions | Governed By |
+| Backup Solution Architects | Data protection integration | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | Qumulo Storage Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Qumulo Storage Engineer is responsible for the implementation, configuration, maintenance, and optimization of the organization's Qumulo storage infrastructure. This role ensures high availability, performance, and reliability of file storage systems while supporting business applications and user needs.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Qumulo storage provisioning, connectivity, and support tasks to defined standards
+- **Experience Anchor:** 1-3 years in storage or infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Qumulo platform architecture and solution design (Senior Engineers and the Architect-owned); network connectivity troubleshooting beyond storage-side configuration (Network Engineers-owned); backup strategy definition (Backup Administrators-owned, this role coordinates with it)
+- **Escalates To:** Qumulo Storage Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** Application Teams on storage requirements
 
 ## Business Impact
 
@@ -143,16 +153,16 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Application Teams | Understand storage requirements |
-| Network Engineers | Connectivity issues |
-| Backup Administrators | Data protection strategies |
-| Cloud Engineers | Hybrid storage solutions |
-| System Administrators | Server access to storage |
-| Security Teams | Storage security configuration |
-| Storage Team Lead | Or **Infrastructure Manager** |
-| Virtualization Engineers | VM storage connectivity |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Application Teams | Understand storage requirements | Consumes From |
+| Network Engineers | Connectivity issues | Collaborates |
+| Backup Administrators | Data protection strategies | Collaborates |
+| Cloud Engineers | Hybrid storage solutions | Collaborates |
+| System Administrators | Server access to storage | Collaborates |
+| Security Teams | Storage security configuration | Governed By |
+| Qumulo Storage Senior Engineer | Escalate complex issues; receive implementation guidance | Escalates To |
+| Virtualization Engineers | VM storage connectivity | Collaborates |
 
 **Complementary Certifications:**
 

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Qumulo Storage Product Owner manages the development and lifecycle of the organization's Qumulo storage solutions. This role leads a team of storage architects and engineers, ensuring that Qumulo storage services meet business requirements, performance targets, and cost objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Qumulo storage platform backlog, procurement roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Qumulo technical architecture design (Qumulo Storage Architect-owned); backup solution strategy (Backup Solutions Product Owner-owned); data governance and compliance policy setting (data governance and compliance teams-owned)
+- **Escalates To:** Data & AI Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on storage requirements
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Backup Solutions Product Owner | Data protection strategies |
-| Qumulo Storage Architect | Technical strategy and design |
-| Application Product Owners | Storage requirements |
-| finance teams | Storage procurement and budgeting |
-| data governance and compliance teams | Data management policies |
-| IT leadership | Storage strategy and investment planning |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Backup Solutions Product Owner | Data protection strategies | Collaborates |
+| Qumulo Storage Architect | Technical strategy and design | Consumes From |
+| Application Product Owners | Storage requirements | Consumes From |
+| finance teams | Storage procurement and budgeting | Collaborates |
+| data governance and compliance teams | Data management policies | Governed By |
+| IT leadership | Storage strategy and investment planning | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | Qumulo Storage Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Qumulo Storage Senior Engineer leads the implementation and optimization of complex Qumulo storage solutions. This role provides technical leadership for storage deployments, migrations, and performance tuning while working closely with architects to translate storage designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Qumulo storage solution design and delivery within the Qumulo Storage Architect's reference architecture
+- **Experience Anchor:** 5+ years in storage engineering with demonstrated independent delivery on scale-out NAS platforms — operates independently within the Architect's reference architecture
+- **Out of Scope:** Qumulo platform architecture and technology standards (Architect-owned); hybrid cloud storage architecture (Cloud Senior Engineers-owned, this role coordinates with it); backup solution design (Backup Solution Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Qumulo Storage Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Qumulo Storage Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Qumulo Storage Architect | Solution design and implementation strategy |
-| Qumulo Storage Product Owner | Technical planning and roadmap execution |
-| Cloud Senior Engineers | Hybrid cloud storage solutions |
-| Backup Solution Senior Engineers | Integrated data protection |
-| Qumulo Storage Engineers | Technical implementation |
-| application teams | Complex storage requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Qumulo Storage Architect | Solution design and implementation strategy | Escalates To |
+| Qumulo Storage Product Owner | Technical planning and roadmap execution | Collaborates |
+| Cloud Senior Engineers | Hybrid cloud storage solutions | Collaborates |
+| Backup Solution Senior Engineers | Integrated data protection | Collaborates |
+| Qumulo Storage Engineers | Technical implementation | Provides To |
+| application teams | Complex storage requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Storage Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Storage Architect is responsible for designing and governing the organisation's enterprise storage strategy across on-premises, hybrid, and cloud environments. This role defines storage architecture patterns for block, file, and object storage, covering performance, capacity, resilience, data protection, and cost optimisation. Unlike vendor-specific storage specialists, the Storage Architect takes a platform-agnostic view across the full storage estate - from SAN/NAS infrastructure to cloud-native object storage and software-defined storage platforms.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — enterprise storage architecture, tiering strategy, and storage technology standards across the chapter
+- **Experience Anchor:** 8+ years in storage or infrastructure architecture with demonstrated architecture-level delivery — operates independently on domain-wide storage architecture decisions
+- **Out of Scope:** Backup, replication, and DR strategy detail (Data Protection Architect-owned, this role aligns to it); database workload performance tuning (Database Architects-owned, this role provisions storage tiers to meet it); storage procurement negotiation (FinOps/Finance-owned)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Storage Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -77,14 +87,14 @@ The Storage Architect is responsible for designing and governing the organisatio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Protection Architect: | Align storage architecture with backup, replication, and DR requirements |
-| Database Architects: | Ensure storage tiers and performance specifications meet database workload requirements |
-| Virtualisation Architects: | Design vSAN and hypervisor-attached storage solutions |
-| Cloud Architects: | Define hybrid and cloud-native storage integration patterns |
-| Kubernetes / Platform Engineers: | Define persistent volume standards and CSI driver governance |
-| FinOps / Finance: | Model and optimise storage cost across on-premises and cloud |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Protection Architect | Align storage architecture with backup, replication, and DR requirements | Collaborates |
+| Database Architects | Ensure storage tiers and performance specifications meet database workload requirements | Provides To |
+| Virtualisation Architects | Design vSAN and hypervisor-attached storage solutions | Collaborates |
+| Cloud Architects | Define hybrid and cloud-native storage integration patterns | Collaborates |
+| Kubernetes / Platform Engineers | Define persistent volume standards and CSI driver governance | Provides To |
+| FinOps / Finance | Model and optimise storage cost across on-premises and cloud | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | Storage Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Storage Engineer implements and maintains enterprise storage solutions across the organization. Working with the Storage Architect and Product Owner, this role ensures reliable, secure, and optimized storage environments supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of storage provisioning and connectivity tasks to defined standards
+- **Experience Anchor:** 1-3 years in storage or infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Storage architecture and solution design (Senior Engineers and the Architect-owned); backup infrastructure integration strategy (Backup Engineers-owned, this role coordinates with it); virtual machine storage design (Virtualization Engineers-owned, this role coordinates with it)
+- **Escalates To:** Storage Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on storage requirements and provisioning requests
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Storage Product Owner | Task prioritization |
-| Server Infrastructure Engineers | Storage connectivity |
-| Virtualization Engineers | Storage for virtual machines |
-| Backup Engineers | Backup storage integration |
-| Storage Architect | Implementation activities |
-| application teams | Storage requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Storage Product Owner | Task prioritization | Consumes From |
+| Server Infrastructure Engineers | Storage connectivity | Collaborates |
+| Virtualization Engineers | Storage for virtual machines | Provides To |
+| Backup Engineers | Backup storage integration | Collaborates |
+| Storage Architect | Implementation activities | Escalates To |
+| application teams | Storage requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Storage Product Owner manages the development and lifecycle of the organization's storage infrastructure services. This role leads a team of storage architects and engineers, ensuring that storage platforms meet business requirements, performance targets, and cost objectives while aligning with organizational data strategy.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — storage platform backlog, procurement roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Storage technical architecture design (Storage Architect-owned); backup solution strategy (Backup Solutions Product Owner-owned); data governance policy for storage compliance (data governance teams-owned)
+- **Escalates To:** Data & AI Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on storage requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Backup Solutions Product Owner | Data protection strategies |
-| Storage Architect | Technical strategy and design |
-| Application Product Owners | Storage requirements |
-| finance teams | Storage procurement and budgeting |
-| data governance teams | Storage compliance requirements |
-| IT leadership | Storage strategy and investment planning |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Backup Solutions Product Owner | Data protection strategies | Collaborates |
+| Storage Architect | Technical strategy and design | Consumes From |
+| Application Product Owners | Storage requirements | Consumes From |
+| finance teams | Storage procurement and budgeting | Collaborates |
+| data governance teams | Storage compliance requirements | Governed By |
+| IT leadership | Storage strategy and investment planning | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | Storage Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Storage Senior Engineer leads the implementation and optimization of complex enterprise storage solutions. This role provides technical leadership for storage deployments, migrations, and operations while working closely with architects to translate storage designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced storage solution design and delivery within the Storage Architect's reference architecture
+- **Experience Anchor:** 5+ years in storage engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Storage architecture and technology standards (Architect-owned); virtualisation platform design (Virtualization Senior Engineers-owned, this role provides storage to it); backup infrastructure design (Backup Senior Engineers-owned, this role provides storage to it)
+- **Escalates To:** Storage Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Storage Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Storage Architect | Solution design and implementation strategy |
-| Storage Product Owner | Technical planning and roadmap execution |
-| Virtualization Senior Engineers | Storage for virtual environments |
-| Database Senior Engineers | Storage for database systems |
-| Backup Senior Engineers | Storage for backup infrastructure |
-| Storage Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Storage Architect | Solution design and implementation strategy | Escalates To |
+| Storage Product Owner | Technical planning and roadmap execution | Collaborates |
+| Virtualization Senior Engineers | Storage for virtual environments | Provides To |
+| Database Senior Engineers | Storage for database systems | Provides To |
+| Backup Senior Engineers | Storage for backup infrastructure | Provides To |
+| Storage Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Database Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Database Architect designs comprehensive data management strategies and architectures for the organization. This role establishes the technical vision for database implementations, creating architectures that balance performance, scalability, security, and operational excellence while ensuring data integrity and availability.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — database platform architecture, technology selection, and data persistence standards across the chapter
+- **Experience Anchor:** 8+ years in database architecture or engineering with demonstrated architecture-level delivery — operates independently on domain-wide database architecture decisions
+- **Out of Scope:** Enterprise-wide data strategy (Enterprise Architects-owned, this role implements data persistence within it); application-level data access patterns (Application Architects-owned, this role provides persistence standards to them); database security control implementation (Security Architects-owned, this role aligns to it)
+- **Escalates To:** Data & AI Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Database Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Database Architect designs comprehensive data management strategies and arch
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Data strategy |
-| Security Architects | Database security design |
-| Application Architects | Data persistence |
-| Database Product Owner | Technical strategy |
-| Database Senior Engineers |  |
-| data governance teams | Compliance requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Data strategy | Governed By |
+| Security Architects | Database security design | Governed By |
+| Application Architects | Data persistence | Provides To |
+| Database Product Owner | Technical strategy | Collaborates |
+| Database Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| data governance teams | Compliance requirements | Governed By |
 
 ## Key Technologies
 

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | Database Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Database Engineer implements and maintains database systems across the organization. Working with the Database Architect and Product Owner, this role ensures reliable, secure, and optimized database environments supporting various business applications.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of database configuration and support tasks to defined standards
+- **Experience Anchor:** 1-3 years in database administration or engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Database architecture and solution design (Senior Engineers and the Architect-owned); server host configuration beyond database-side settings (Windows/Linux Server Engineers-owned); database monitoring tooling strategy (Observability Engineers-owned, this role coordinates with it)
+- **Escalates To:** Database Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on database requirements
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Database Engineer implements and maintains database systems across the organ
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Database Product Owner | Task prioritization |
-| Windows/Linux Server Engineers | Database host configuration |
-| Observability Engineers | Database monitoring |
-| Database Architect | Implementation activities |
-| application teams | Database requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Database Product Owner | Task prioritization | Consumes From |
+| Windows/Linux Server Engineers | Database host configuration | Collaborates |
+| Observability Engineers | Database monitoring | Collaborates |
+| Database Architect | Implementation activities | Escalates To |
+| application teams | Database requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Database Product Owner manages the portfolio of database platforms and data storage solutions across the organization. This role leads a team of database architects and engineers, ensuring that database services meet application requirements, performance standards, security policies, and cost objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — database platform backlog, standardisation roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Database technical architecture and design (Database Architect-owned); database-as-a-service platform selection (Cloud Platform Product Owners-owned, this role aligns to it); database security standards (Security teams-owned)
+- **Escalates To:** Data & AI Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on data requirements
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Database Product Owner manages the portfolio of database platforms and data 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Database Architect | Technical decisions and designs |
-| Application Product Owners | Data requirements |
-| Cloud Platform Product Owners | Database-as-a-service offerings |
-| Data Governance teams | Data management policies |
-| Security teams | Database security standards |
-| IT leadership | Database strategy and investment priorities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Database Architect | Technical decisions and designs | Consumes From |
+| Application Product Owners | Data requirements | Consumes From |
+| Cloud Platform Product Owners | Database-as-a-service offerings | Collaborates |
+| Data Governance teams | Data management policies | Governed By |
+| Security teams | Database security standards | Governed By |
+| IT leadership | Database strategy and investment priorities | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |
+| **Reports To** | Database Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Database Reliability Engineer focuses on ensuring the availability, performance, scalability, and reliability of database systems across the enterprise. This role applies Site Reliability Engineering principles to database operations, emphasizing automation, observability, and continuous improvement to database infrastructure.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — database reliability engineering, resilience implementation, and performance monitoring integration
+- **Experience Anchor:** 3-5 years in database or site reliability engineering — operates independently within the Database Architect's resilience design
+- **Out of Scope:** Database architecture and resilience design (Database Architects-owned, this role implements it); CI/CD toolchain standards (DevOps Engineers-owned, this role integrates with it); observability platform standards (Observability Engineers-owned, this role coordinates with it)
+- **Escalates To:** Database Senior Engineer — implementation-level reliability questions
+- **Escalated To By:** application teams on database performance issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Database Senior Engineers | Implementation |
-| Observability Engineers | Monitoring implementation |
-| DevOps Engineers | CI/CD integration |
-| Database Product Owner | Reliability metrics |
-| Database Architects | Resilience design |
-| application teams | Database performance |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Database Senior Engineers | Implementation | Escalates To |
+| Observability Engineers | Monitoring implementation | Collaborates |
+| DevOps Engineers | CI/CD integration | Collaborates |
+| Database Product Owner | Reliability metrics | Provides To |
+| Database Architects | Resilience design | Consumes From |
+| application teams | Database performance | Provides To |
 
 ## Key Technologies
 

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Data & AI Chapter Lead |
+| **Direct Reports** | Database Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Database Senior Engineer leads the implementation and optimization of complex database environments. This role provides technical leadership for database deployments, migrations, and performance tuning while working closely with architects to translate database designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced database solution design and delivery within the Database Architect's reference architecture
+- **Experience Anchor:** 5+ years in database engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Database platform architecture and technology standards (Architect-owned); cloud database service selection (Cloud Senior Engineers-owned, this role coordinates with it); reliability engineering tooling strategy (Database Reliability Engineer-owned, this role coordinates with it)
+- **Escalates To:** Database Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Database Engineers on complex database technology issues
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Database Senior Engineer leads the implementation and optimization of comple
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Database Architect | Solution design and implementation strategy |
-| Database Product Owner | Technical planning and roadmap execution |
-| Cloud Senior Engineers | Cloud database services |
-| Senior Engineers | From other platforms on integrated solutions |
-| Database Engineers | Complex database technologies |
-| application teams | Complex data requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Database Architect | Solution design and implementation strategy | Escalates To |
+| Database Product Owner | Technical planning and roadmap execution | Collaborates |
+| Cloud Senior Engineers | Cloud database services | Collaborates |
+| Senior Engineers from other platforms | Integrated solutions | Collaborates |
+| Database Engineers | Complex database technologies | Provides To |
+| application teams | Complex data requirements | Provides To |
 
 ## Key Technologies
 


### PR DESCRIPTION
## Summary

Batch 5/7 of #5: backfills **Reports To**, **Direct Reports**, **Role Scope & Boundaries**, and **Interaction Mode** across all 27 files in the Data & AI chapter still on the old template (AI Governance, Data Engineering, Data Management, Database Management), per `docs/role_template.md`. Closes #87.

- **AI Governance (7 files):** `ai_governance_architect/senior_engineer/engineer/product_owner`, `ai_platform_architect/engineer`, `responsible_ai_engineer`.
- **Data Engineering (7 files):** `data_platform_architect`, `data_mesh_architect`, `data_senior_engineer`, `data_engineer`, `data_platform_engineer`, `data_engineering_product_owner`, `dataops_specialist`.
- **Data Management (8 files):** Storage ladder (`storage_architect/senior_engineer/engineer/product_owner`) and the parallel Qumulo Storage ladder (`qumulo_storage_architect/senior_engineer/engineer/product_owner`). `data_governance_lead.md` and `data_privacy_officer.md` were already on the modern template from an earlier batch and are untouched.
- **Database Management (5 files):** `database_architect/senior_engineer/engineer/product_owner`, `database_reliability_engineer`.

## Reporting model

Standard IC ladder, consistent with batches 2-4: Engineer → Senior Engineer; Senior Engineer and Product Owner → **Data & AI Chapter Lead**. Three Architect pairs are modeled as peers rather than a hierarchy, grounded in each pair's own interactions-table text describing the other as its counterpart rather than its manager — both report to the Chapter Lead:

- **AI Governance Architect / AI Platform Architect**
- **Data Platform Architect / Data Mesh Architect**
- **Storage Architect / Qumulo Storage Architect** — parallel ladders (enterprise block/SAN storage vs. Qumulo scale-out NAS), not a hierarchy

Three Engineer-grade specialists with no dedicated Senior Engineer tier of their own report to their nearest Architect: **AI Platform Engineer** → AI Platform Architect, **Data Platform Engineer** → Data Platform Architect, **Responsible AI Engineer** → AI Governance Architect (mirrors the Developer Experience Engineer / Platform Reliability Engineer pattern from batch 4). **Database Reliability Engineer**, by contrast, does have a natural Senior Engineer peer in its own domain and reports to Database Senior Engineer.

## Other fixes bundled in

- `qumulo_storage_engineer.md`'s interactions table had a malformed row — `| Storage Team Lead | Or **Infrastructure Manager** |` — referencing role titles that don't exist anywhere else in the catalog (likely a markdown-wrapping artifact). Replaced it with the standard escalation row to Qumulo Storage Senior Engineer, consistent with every other Engineer-level file's table.

## Verification

- `npm run validate` — 220 files checked, 0 errors, 0 warnings, 0 duplicate titles.
- `npm test` — 91/91 passing.
- `npx markdownlint-cli2` on all 29 touched files (27 changed + 2 already-modern files in the same glob) — 0 issues.
- Cross-file directional consistency spot-checked (Reports To / Direct Reports pairs match on both sides across all four domains).

## Test plan

- [x] `npm run validate`
- [x] `npm test`
- [x] `npx markdownlint-cli2` on touched files
- [ ] CI green on both matrix legs

Closes #87.