### PR TITLE
feat: backfill Reports To / Scope / Interaction Mode for Security & Identity chapter (#88, batch 6/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
+  Mode backfilled for the Security & Identity chapter (#88, batch 6/7:
+  36 of 219 files — the domain's 2 governance specialists, GRC Risk
+  Compliance Analyst and Business Continuity/DR Manager, were already on
+  the modern template).** Security, Security Cross-Platform, Security &
+  Identity, Data Protection, and Directory Services all follow the
+  standard IC-ladder pattern: Engineer reports to Senior Engineer, Senior
+  Engineer and Product Owner report to the Security & Identity Chapter
+  Lead. Storage-style parallel ladders (Commvault vs. SimpliVity backup)
+  each report straight to the Chapter Lead rather than to each other, same
+  as the Storage/Qumulo Storage pattern from batch 5. Six Engineer- or
+  Senior-Engineer-grade specialists with no dedicated tier of their own
+  report to their nearest Architect or Senior Engineer: DevSecOps Engineer
+  → DevSecOps Architect, Security Automation Engineer → Security
+  Cross-Platform Senior Engineer, Cloud Security Posture Manager →
+  escalates to Security Cross-Platform Architect, Identity Governance
+  Specialist → escalates to Identity Management Architect, Privileged
+  Access Management Engineer → PAM Architect (no PAM Senior Engineer tier
+  exists), and Backup Reliability Engineer → "Commvault Senior Engineer or
+  SimpliVity Backup Senior Engineer, depending on platform assignment"
+  (mirroring the DevOps chapter's Automation Framework Engineer pattern).
+  Fixed a malformed interactions-table row in `commvault_product_owner.md`
+  ("IT Operations Manager | Or **Infrastructure Director**", referencing
+  roles that don't exist in the catalog) the same way as the
+  `qumulo_storage_engineer.md` fix in batch 5.
+- **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
   Mode backfilled for the Data & AI chapter (#87, batch 5/7: 27 of 219
   files — Data Management's 2 governance specialists, Data Governance
   Lead and Data Privacy Officer, were already on the modern template).**

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Commvault Senior Engineer or SimpliVity Backup Senior Engineer (depending on platform assignment) |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Backup Reliability Engineer focuses on ensuring the consistency, reliability, and effectiveness of backup systems across the enterprise. This role applies Site Reliability Engineering principles to backup operations, emphasizing automation, metrics, and continuous improvement to data protection infrastructure.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — backup infrastructure reliability engineering, resilience implementation, and performance monitoring integration
+- **Experience Anchor:** 3-5 years in backup or site reliability engineering — operates independently within the relevant Backup Architect's resilience design
+- **Out of Scope:** Backup platform architecture and resilience design (Backup Architects-owned, this role implements it); underlying storage reliability (Storage Engineers-owned, this role coordinates with it); CI/CD toolchain integration ownership (DevOps Engineers-owned, this role coordinates with it)
+- **Escalates To:** Commvault Senior Engineer or SimpliVity Backup Senior Engineer, depending on platform assignment — implementation-level reliability questions
+- **Escalated To By:** Risk Management on data protection assurance status
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Backup Senior Engineers | Implementation |
-| Observability Engineers | Monitoring implementation |
-| Storage Engineers | Storage reliability |
-| Backup Product Owner | Reliability metrics |
-| Risk Management | Data protection assurance |
-| Backup Architects | Resilience design |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Backup Senior Engineers | Implementation | Escalates To |
+| Observability Engineers | Monitoring implementation | Collaborates |
+| Storage Engineers | Storage reliability | Collaborates |
+| Backup Product Owner | Reliability metrics | Provides To |
+| Risk Management | Data protection assurance | Provides To |
+| Backup Architects | Resilience design | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Commvault Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Commvault Architect designs enterprise data protection strategies and solutions using Commvault technology. This role creates comprehensive backup, recovery, and data management architectures that ensure data availability, compliance, and business continuity while optimizing for performance and cost efficiency.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Commvault enterprise backup platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in backup/data protection architecture with demonstrated Commvault platform ownership — operates independently on domain-wide Commvault architecture decisions
+- **Out of Scope:** Underlying backup storage architecture (Storage Architect-owned, this role aligns backup strategy to it); SimpliVity hyperconverged backup architecture (SimpliVity Backup Architect-owned — a parallel, non-Commvault backup ladder); data retention regulatory interpretation (compliance teams-owned, this role implements requirements)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Commvault Senior Engineers on implementation approaches
 
 ## Business Impact
 
@@ -61,15 +71,15 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Storage Architect | Backup storage strategies |
-| Cloud Architects | Cloud-based data protection |
-| Security Architect | Data protection security |
-| Commvault Product Owner | Technical strategy |
-| Commvault Senior Engineers | Implementation approaches |
-| application architects | Application backup requirements |
-| compliance teams | Data retention requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Storage Architect | Backup storage strategies | Collaborates |
+| Cloud Architects | Cloud-based data protection | Collaborates |
+| Security Architect | Data protection security | Governed By |
+| Commvault Product Owner | Technical strategy | Collaborates |
+| Commvault Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| application architects | Application backup requirements | Provides To |
+| compliance teams | Data retention requirements | Governed By |
 
 ## Key Technologies
 

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Commvault Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Commvault Engineer implements and maintains backup and recovery systems using Commvault technology. Working with the Commvault Architect and Product Owner, this role ensures reliable data protection and recovery capabilities for the organization's systems and data.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Commvault backup configuration and agent deployment tasks to defined standards
+- **Experience Anchor:** 1-3 years in backup engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Commvault architecture and solution design (Senior Engineers and the Architect-owned); underlying database backup strategy (Database Engineers-owned, this role coordinates with it); backup storage configuration ownership (Storage Engineers-owned, this role coordinates with it)
+- **Escalates To:** Commvault Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on backup and recovery requests
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Commvault Product Owner | Task prioritization |
-| Server Engineers | Backup agent deployment |
-| Database Engineers | Database backup requirements |
-| Storage Engineers | Backup storage configuration |
-| Commvault Architect | Implementation activities |
-| application teams | Backup and recovery requests |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Commvault Product Owner | Task prioritization | Consumes From |
+| Server Engineers | Backup agent deployment | Collaborates |
+| Database Engineers | Database backup requirements | Collaborates |
+| Storage Engineers | Backup storage configuration | Collaborates |
+| Commvault Architect | Implementation activities | Escalates To |
+| application teams | Backup and recovery requests | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Commvault Product Owner is responsible for maximizing the value of the organization's Commvault data protection platform. This role defines and prioritizes the backlog of features, enhancements, and improvements for the Commvault environment, ensuring it meets business needs, compliance requirements, and operational efficiency goals.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Commvault platform backlog, recovery capability roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Commvault technical architecture (Commvault Architect-owned); recovery planning strategy (Business Continuity Managers-owned, this role aligns backlog to it); data protection compliance policy (Security Teams-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Commvault Engineers on implementation and operations status
 
 ## Business Impact
 
@@ -65,16 +75,16 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Application Owners | Backup requirements |
-| Infrastructure Teams | Commvault platform support |
-| Security Teams | Data protection compliance |
-| Business Continuity Managers | Recovery planning |
-| IT Operations Manager | Or **Infrastructure Director** |
-| Storage Team | Backup storage needs |
-| Cloud Teams | Cloud-based backup solutions |
-| Commvault Engineers | Implementation and operations |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Application Owners | Backup requirements | Consumes From |
+| Infrastructure Teams | Commvault platform support | Collaborates |
+| Security Teams | Data protection compliance | Governed By |
+| Business Continuity Managers | Recovery planning | Collaborates |
+| IT Operations Manager or Infrastructure Director | Infrastructure escalation for platform-level backup incidents | Collaborates |
+| Storage Team | Backup storage needs | Collaborates |
+| Cloud Teams | Cloud-based backup solutions | Collaborates |
+| Commvault Engineers | Implementation and operations | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | Commvault Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Commvault Senior Engineer leads the implementation and optimization of enterprise backup and recovery solutions using Commvault technology. This role provides technical leadership for complex Commvault deployments, migrations, and operations while working closely with architects to translate data protection strategies into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Commvault solution design and delivery within the Commvault Architect's reference architecture
+- **Experience Anchor:** 5+ years in backup engineering with demonstrated independent Commvault delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Commvault platform architecture and technology standards (Architect-owned); underlying storage integration architecture (Storage Senior Engineers-owned, this role coordinates with it); virtualisation platform design (Virtualization Senior Engineers-owned, this role coordinates VM backup strategies with it)
+- **Escalates To:** Commvault Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Commvault Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Commvault Architect | Solution design and implementation strategy |
-| Commvault Product Owner | Technical planning and roadmap execution |
-| Storage Senior Engineers | Backup storage integration |
-| Virtualization Senior Engineers | VM backup strategies |
-| Commvault Engineers | Technical implementation |
-| application teams | Complex backup requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Commvault Architect | Solution design and implementation strategy | Escalates To |
+| Commvault Product Owner | Technical planning and roadmap execution | Collaborates |
+| Storage Senior Engineers | Backup storage integration | Collaborates |
+| Virtualization Senior Engineers | VM backup strategies | Collaborates |
+| Commvault Engineers | Technical implementation | Provides To |
+| application teams | Complex backup requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors SimpliVity Backup Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The SimpliVity Backup Architect designs and oversees data protection strategies leveraging HPE SimpliVity's built-in backup and recovery capabilities. This role ensures optimal use of SimpliVity's native data protection features to meet the organization's requirements for data availability, compliance, and business continuity.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — SimpliVity hyperconverged backup platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in backup/data protection architecture with demonstrated hyperconverged infrastructure ownership — operates independently on domain-wide SimpliVity architecture decisions
+- **Out of Scope:** Enterprise Commvault backup architecture (Commvault Architect-owned — a parallel, non-SimpliVity backup ladder); VMware virtualisation platform architecture (VMware Architect-owned, this role designs VM backup strategies within it); database-level backup consistency (Database Architect-owned, this role coordinates with it)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** SimpliVity Backup Senior Engineers on implementation approaches
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| VMware Architect | Virtual machine backup strategies |
-| Commvault Architect | Integration with enterprise backup solutions |
-| Database Architect | Database backup strategies in SimpliVity |
-| Observability Architect | Backup monitoring |
-| compliance and security teams | Data protection requirements |
-| application architects | Backup requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| VMware Architect | Virtual machine backup strategies | Collaborates |
+| Commvault Architect | Integration with enterprise backup solutions | Collaborates |
+| Database Architect | Database backup strategies in SimpliVity | Collaborates |
+| Observability Architect | Backup monitoring | Consumes From |
+| compliance and security teams | Data protection requirements | Governed By |
+| application architects | Backup requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | SimpliVity Backup Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The SimpliVity Backup Engineer implements and maintains backup and recovery operations using HPE SimpliVity's built-in capabilities. Working with the SimpliVity Backup Architect and Product Owner, this role ensures reliable data protection for workloads running on the SimpliVity platform.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of SimpliVity backup configuration and VM backup operation tasks to defined standards
+- **Experience Anchor:** 1-3 years in backup or virtualisation engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** SimpliVity architecture and solution design (Senior Engineers and the Architect-owned); VM-level backup operations ownership (VMware Engineers-owned, this role coordinates with it); backup monitoring tooling design (Observability Engineers-owned, this role implements monitoring within it)
+- **Escalates To:** SimpliVity Backup Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on backup and recovery requirements
 
 ## Business Impact
 
@@ -61,13 +71,13 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| SimpliVity Backup Product Owner | Task prioritization |
-| VMware Engineers | Virtual machine backup operations |
-| Observability Engineers | Backup monitoring implementation |
-| SimpliVity Backup Architect | Implementation activities |
-| application teams | Backup and recovery requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| SimpliVity Backup Product Owner | Task prioritization | Consumes From |
+| VMware Engineers | Virtual machine backup operations | Collaborates |
+| Observability Engineers | Backup monitoring implementation | Collaborates |
+| SimpliVity Backup Architect | Implementation activities | Escalates To |
+| application teams | Backup and recovery requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The SimpliVity Backup Product Owner manages the development and lifecycle of the organization's backup and recovery services based on HPE SimpliVity's built-in capabilities. This role leads a team focusing on SimpliVity data protection, ensuring services meet business requirements, compliance standards, and operational objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — SimpliVity platform backlog, recovery capability roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** SimpliVity technical architecture (SimpliVity Backup Architect-owned); virtualisation platform roadmap (VMware Product Owner-owned, this role aligns to it); data protection policy definition (compliance and security teams-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** application owners on recovery point/time objective requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| VMware Product Owner | Virtualization integration |
-| SimpliVity Backup Architect | Technical strategy |
-| compliance and security teams | Data protection policies |
-| Service Delivery Managers | Backup operations |
-| application owners | Recovery point/time objectives |
-| IT leadership | Data protection strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| VMware Product Owner | Virtualization integration | Collaborates |
+| SimpliVity Backup Architect | Technical strategy | Consumes From |
+| compliance and security teams | Data protection policies | Governed By |
+| Service Delivery Managers | Backup operations | Collaborates |
+| application owners | Recovery point/time objectives | Consumes From |
+| IT leadership | Data protection strategy and investments | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | SimpliVity Backup Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The SimpliVity Backup Senior Engineer leads the implementation and optimization of data protection solutions using HPE SimpliVity's built-in capabilities. This role provides technical leadership for complex SimpliVity backup deployments while working closely with architects to translate data protection strategies into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced SimpliVity backup solution design and delivery within the SimpliVity Backup Architect's reference architecture
+- **Experience Anchor:** 5+ years in backup engineering with demonstrated independent SimpliVity delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** SimpliVity platform architecture and technology standards (Architect-owned); advanced VMware virtualisation integration ownership (VMware Senior Engineers-owned, this role coordinates with it); broader enterprise backup strategy (Enterprise Backup Senior Engineers-owned, this role integrates with it)
+- **Escalates To:** SimpliVity Backup Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** SimpliVity Backup Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| SimpliVity Backup Architect | Solution design and implementation strategy |
-| SimpliVity Backup Product Owner | Technical planning and roadmap execution |
-| VMware Senior Engineers | Advanced virtualization integration |
-| Enterprise Backup Senior Engineers | Integration with broader backup strategy |
-| SimpliVity Backup Engineers | Technical implementation |
-| application teams | Complex recovery requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| SimpliVity Backup Architect | Solution design and implementation strategy | Escalates To |
+| SimpliVity Backup Product Owner | Technical planning and roadmap execution | Collaborates |
+| VMware Senior Engineers | Advanced virtualization integration | Collaborates |
+| Enterprise Backup Senior Engineers | Integration with broader backup strategy | Collaborates |
+| SimpliVity Backup Engineers | Technical implementation | Provides To |
+| application teams | Complex recovery requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Windows Active Directory Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Active Directory Architect designs AD structure, security models, and all Tier 0 infrastructure across the organization. This role provides technical leadership for domain controllers and all servers involved in directory services, which fall under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Active Directory and hybrid identity infrastructure architecture across the chapter
+- **Experience Anchor:** 8+ years in directory services or identity infrastructure architecture with demonstrated architecture-level delivery — operates independently on domain-wide AD architecture decisions
+- **Out of Scope:** Broader Windows Server infrastructure architecture (Windows Server Architect-owned, this role aligns AD architecture to it); identity governance and IAM strategy beyond directory infrastructure (Identity Management Architect-owned, this role integrates with it); authorization framework design (Access Management Architect-owned, this role coordinates with it)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Windows Active Directory Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Windows Active Directory Architect designs AD structure, security models, an
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Architect | Overall Windows infrastructure |
-| Identity Management Architect | Integrated identity solutions |
-| Access Management Architect | Authorization frameworks |
-| Security Architects | Directory security controls |
-| Cloud Platform Architects | Microsoft Entra ID and hybrid identity |
-| application architects | Authentication requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Architect | Overall Windows infrastructure | Collaborates |
+| Identity Management Architect | Integrated identity solutions | Collaborates |
+| Access Management Architect | Authorization frameworks | Collaborates |
+| Security Architects | Directory security controls | Governed By |
+| Cloud Platform Architects | Microsoft Entra ID and hybrid identity | Collaborates |
+| application architects | Authentication requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Windows Active Directory Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Active Directory Engineer maintains directory services and all Tier 0 Windows servers across the organization. This role has exclusive responsibility for implementing and maintaining domain controllers and all servers involved in directory services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Active Directory operations and authentication support tasks to defined standards
+- **Experience Anchor:** 1-3 years in directory services or Windows infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Active Directory architecture and solution design (Senior Engineers and the Architect-owned); broader Windows Server infrastructure ownership (Windows Server Engineers-owned, this role coordinates with it); identity provisioning beyond directory operations (Identity Management Engineers-owned, this role coordinates with it)
+- **Escalates To:** Windows Active Directory Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on authentication requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Active Directory Product Owner | Task prioritization |
-| Windows Server Engineers | Server infrastructure |
-| Identity Management Engineers | Identity integration |
-| Security Engineers | Directory security controls |
-| Windows Active Directory Architect | Implementation activities |
-| application teams | Authentication requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Active Directory Product Owner | Task prioritization | Consumes From |
+| Windows Server Engineers | Server infrastructure | Collaborates |
+| Identity Management Engineers | Identity integration | Collaborates |
+| Security Engineers | Directory security controls | Collaborates |
+| Windows Active Directory Architect | Implementation activities | Escalates To |
+| application teams | Authentication requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Active Directory Product Owner manages the service roadmap and planning for all Tier 0 infrastructure, including domain controllers and all servers involved in directory services, which fall under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Active Directory / directory services platform backlog, modernisation roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Active Directory technical architecture (Windows Active Directory Architect-owned); identity management roadmap (Identity Management Product Owner-owned, this role aligns to it); directory security policy (Security and Compliance teams-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on authentication requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Product Owner | Infrastructure requirements |
-| Identity Management Product Owner | Integrated identity strategy |
-| Windows Active Directory Architect | Technical strategy |
-| Security and Compliance teams | Directory security policies |
-| Application Product Owners | Authentication requirements |
-| IT leadership | Directory services strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Product Owner | Infrastructure requirements | Collaborates |
+| Identity Management Product Owner | Integrated identity strategy | Collaborates |
+| Windows Active Directory Architect | Technical strategy | Consumes From |
+| Security and Compliance teams | Directory security policies | Governed By |
+| Application Product Owners | Authentication requirements | Consumes From |
+| IT leadership | Directory services strategy and investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | Windows Active Directory Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure initiatives, including complex implementations and optimizations for domain controllers and all servers involved in directory services, which fall under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Active Directory solution design and delivery within the Windows Active Directory Architect's reference architecture
+- **Experience Anchor:** 5+ years in directory services engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Active Directory architecture and hybrid identity standards (Architect-owned); broader Windows Server infrastructure integration ownership (Windows Server Senior Engineers-owned, this role coordinates with it); directory security control design (Security Senior Engineers-owned, this role implements it)
+- **Escalates To:** Windows Active Directory Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Windows Active Directory Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Active Directory Architect | Solution design and implementation strategy |
-| Windows Active Directory Product Owner | Technical planning and roadmap execution |
-| Windows Server Senior Engineers | Infrastructure integration |
-| Security Senior Engineers | Directory security implementations |
-| Cloud Senior Engineers | Hybrid identity solutions |
-| Windows Active Directory Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Active Directory Architect | Solution design and implementation strategy | Escalates To |
+| Windows Active Directory Product Owner | Technical planning and roadmap execution | Collaborates |
+| Windows Server Senior Engineers | Infrastructure integration | Collaborates |
+| Security Senior Engineers | Directory security implementations | Collaborates |
+| Cloud Senior Engineers | Hybrid identity solutions | Collaborates |
+| Windows Active Directory Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security/devsecops_architect.md
+++ b/Roles/security/devsecops_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors the DevSecOps Engineer; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevSecOps Architect is responsible for designing and governing the strategy, frameworks, and tooling that embed security into every stage of the software development lifecycle (SDLC) and CI/CD pipeline. This role bridges the worlds of software engineering, DevOps platform engineering, and security - ensuring that security is shifted left and treated as a first-class engineering concern rather than a gate at the end of delivery. The DevSecOps Architect defines standards for code security, supply chain security, container security, secrets management, and infrastructure security as code, and ensures these are implemented consistently across all engineering teams.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — DevSecOps control framework, pipeline security architecture, and supply chain security standards across the chapter
+- **Experience Anchor:** 8+ years in security or DevOps architecture with demonstrated DevSecOps programme ownership — operates independently on domain-wide DevSecOps architecture decisions
+- **Out of Scope:** Enterprise security policy and risk framework (CISO/Security Architects-owned, this role aligns to it); DevOps CI/CD platform design (DevOps Architect-owned, this role embeds security into it); application-level secure coding practices (Software Engineers-owned, this role defines requirements)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** the DevSecOps Engineer on implementation blockers and findings
 
 ## Business Impact
 
@@ -77,13 +87,13 @@ The DevSecOps Architect is responsible for designing and governing the strategy,
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| CISO / Security Architects: | Align DevSecOps controls with enterprise security policy and risk framework |
-| DevOps Architect / Platform Engineering Architect: | Embed security into CI/CD platforms as first-class capabilities |
-| Software Engineers / Development Teams: | Define security requirements and provide enablement |
-| Solution Architects: | Ensure solution designs include security testing and supply chain considerations |
-| Compliance / Audit: | Provide evidence of security controls in the pipeline for regulatory requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| CISO / Security Architects | Align DevSecOps controls with enterprise security policy and risk framework | Governed By |
+| DevOps Architect / Platform Engineering Architect | Embed security into CI/CD platforms as first-class capabilities | Collaborates |
+| Software Engineers / Development Teams | Define security requirements and provide enablement | Provides To |
+| Solution Architects | Ensure solution designs include security testing and supply chain considerations | Provides To |
+| Compliance / Audit | Provide evidence of security controls in the pipeline for regulatory requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | DevSecOps Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The DevSecOps Engineer implements and maintains the security tooling, automation, and processes embedded within the organisation's software development pipelines and DevOps workflows. This role works hands-on with CI/CD systems to integrate SAST, SCA, DAST, container scanning, and secrets management capabilities, ensuring security checks are automated, actionable, and minimally disruptive to engineering velocity. The DevSecOps Engineer is a bridge between the security and engineering disciplines, enabling developer teams to ship securely.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of pipeline security tooling deployment and developer enablement tasks
+- **Experience Anchor:** 3-5 years in security or DevOps engineering with an application security focus — operates independently within the DevSecOps Architect's framework
+- **Out of Scope:** DevSecOps control framework and pipeline security architecture (Architect-owned); broader security incident response (Security Engineers-owned, this role escalates findings to it); DevOps platform toolchain standards (DevOps / Platform Engineers-owned, this role collaborates on it)
+- **Escalates To:** DevSecOps Architect — design direction and implementation blockers
+- **Escalated To By:** Software Engineers on security finding remediation guidance
 
 ## Business Impact
 
@@ -74,13 +84,13 @@ The DevSecOps Engineer implements and maintains the security tooling, automation
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevSecOps Architect: | Receive design direction; raise implementation blockers and findings |
-| DevOps / Platform Engineers: | Collaborate on pipeline integration and tooling deployment |
-| Software Engineers: | Guide and support developers in understanding and remediating security findings |
-| Security Engineers: | Escalate findings requiring broader security response |
-| Compliance: | Provide pipeline security evidence for audit requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevSecOps Architect | Receive design direction; raise implementation blockers and findings | Escalates To |
+| DevOps / Platform Engineers | Collaborate on pipeline integration and tooling deployment | Collaborates |
+| Software Engineers | Guide and support developers in understanding and remediating security findings | Provides To |
+| Security Engineers | Escalate findings requiring broader security response | Collaborates |
+| Compliance | Provide pipeline security evidence for audit requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Security Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Architect designs and implements security systems and frameworks that protect the organization's information assets and technology infrastructure. They establish security standards, patterns, and best practices while ensuring compliance with regulatory requirements and industry standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — enterprise security architecture, control frameworks, and security design standards across the chapter
+- **Experience Anchor:** 8+ years in security architecture or engineering with demonstrated architecture-level delivery — operates independently on domain-wide security architecture decisions
+- **Out of Scope:** Enterprise-wide architecture integration beyond security (Enterprise Architects-owned, this role provides security patterns into it); regulatory interpretation (Compliance Managers-owned, this role implements requirements); security investment prioritisation (Security Product Owner-owned)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Security Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -163,16 +173,16 @@ The Security Architect designs and implements security systems and frameworks th
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Security integration in overall architecture |
-| Solution Architects | Security patterns and controls |
-| Security Engineers | Implementation of security designs |
-| Compliance Managers | Regulatory requirements |
-| Development Teams | Secure coding practices |
-| Security Operations | Architectural insights and design guidance for security operations |
-| Risk Management | Security risk assessments |
-| Product Owners | Security requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Security integration in overall architecture | Collaborates |
+| Solution Architects | Security patterns and controls | Provides To |
+| Security Engineers | Implementation of security designs | Provides To |
+| Compliance Managers | Regulatory requirements | Governed By |
+| Development Teams | Secure coding practices | Provides To |
+| Security Operations | Architectural insights and design guidance for security operations | Provides To |
+| Risk Management | Security risk assessments | Governed By |
+| Product Owners | Security requirements | Provides To |
 
 **Complementary Certifications:**
 

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Security Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Engineer implements and maintains security controls and technologies across the organization's IT infrastructure. Working with Security Architects and Senior Engineers, this role ensures the effective deployment of security solutions that protect systems, data, and users while supporting business requirements.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of security control implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in security engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Security architecture and solution design (Senior Engineers and the Architect-owned); network-level security control ownership (Network Engineers-owned, this role coordinates with it); identity access control design (Identity Engineers-owned, this role coordinates with it)
+- **Escalates To:** Security Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on security implementation requests
 
 ## Business Impact
 
@@ -62,14 +72,14 @@ The Security Engineer implements and maintains security controls and technologie
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Security Product Owner | Task prioritization |
-| Network Engineers | Security controls |
-| System Administrators | Endpoint security |
-| Identity Engineers | Access controls |
-| Security Senior Engineers |  |
-| application teams | Security implementations |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security Product Owner | Task prioritization | Consumes From |
+| Network Engineers | Security controls | Collaborates |
+| System Administrators | Endpoint security | Collaborates |
+| Identity Engineers | Access controls | Collaborates |
+| Security Senior Engineers | Escalate complex issues; receive implementation guidance | Escalates To |
+| application teams | Security implementations | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Product Owner manages the development and lifecycle of the organization's security services portfolio. This role leads a team of security architects and engineers, ensuring that security capabilities meet business requirements, risk management objectives, and compliance needs while aligning with the overall security strategy.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — security programme backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with security domain exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Security architecture and technical design (Security Architect-owned); regulatory compliance interpretation (Compliance-owned); enterprise risk appetite setting (Risk Management-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** IT teams on security implementation prioritisation
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Security Product Owner manages the development and lifecycle of the organiza
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Risk Management | Risk prioritization |
-| Compliance | Regulatory requirements |
-| Security Architect | Technical strategy |
-| Business Unit leaders | Security requirements |
-| IT teams | Security implementation |
-| executive leadership | Security investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Risk Management | Risk prioritization | Governed By |
+| Compliance | Regulatory requirements | Governed By |
+| Security Architect | Technical strategy | Consumes From |
+| Business Unit leaders | Security requirements | Consumes From |
+| IT teams | Security implementation | Provides To |
+| executive leadership | Security investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | Security Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Senior Engineer leads the implementation and optimization of complex security solutions across the organization. This role provides technical leadership for security deployments, operations, and incident response while working closely with architects to translate security designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced security solution design and delivery within the Security Architect's reference architecture
+- **Experience Anchor:** 5+ years in security engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Security architecture and control framework design (Architect-owned); incident response process ownership (Incident Response-owned, this role coordinates on security events); network security infrastructure design (Network Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Security Architect — solution design exceptions
+- **Escalated To By:** Security Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Security Senior Engineer leads the implementation and optimization of comple
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Security Architect | Solution design |
-| Security Product Owner | Technical planning |
-| Network Senior Engineers | Security infrastructure |
-| Cloud Senior Engineers | Cloud security |
-| Incident Response | Security events |
-| Security Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security Architect | Solution design | Escalates To |
+| Security Product Owner | Technical planning | Collaborates |
+| Network Senior Engineers | Security infrastructure | Collaborates |
+| Cloud Senior Engineers | Cloud security | Collaborates |
+| Incident Response | Security events | Collaborates |
+| Security Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -5,6 +5,8 @@
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Cloud Security Posture Manager implements and operates Cloud Security Posture Management (CSPM) across all cloud platforms — Azure, AWS, and GCP. This role continuously monitors cloud environments for misconfigurations, policy violations, and compliance drift, operating CSPM tooling that provides unified visibility across the organisation's multi-cloud estate. The Cloud Security Posture Manager manages cloud security benchmarks (CIS, NIST CSF, IEC 62443, ISO 27001), tracks compliance posture, and drives structured remediation workflows in partnership with cloud platform teams — ensuring that cloud configurations remain aligned to the organisation's security policy framework and regulatory obligations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — cloud security posture management (CSPM) tooling, runtime detection policy, and multi-cloud misconfiguration remediation
+- **Experience Anchor:** 5+ years in cloud security engineering with demonstrated CSPM/cloud posture ownership — operates independently within the Security Cross-Platform Architect's standards
+- **Out of Scope:** Cross-platform security standards design (Security Cross-Platform Architect-owned); pipeline-time policy-as-code rule design (DevSecOps engineers-owned, this role aligns runtime detection to it); cloud landing zone architecture (Cloud Architects-owned, this role triages findings within it)
+- **Escalates To:** Security Cross-Platform Architect — architectural-level misconfigurations and posture standard definitions
+- **Escalated To By:** Azure, AWS, and GCP Cloud Architects on misconfiguration remediation within their cloud estates
 
 ## Business Impact
 
@@ -73,17 +83,17 @@ The Cloud Security Posture Manager implements and operates Cloud Security Postur
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Architect | Shift-left CSPM integration — surfacing equivalent configuration checks within CI/CD pipelines and IaC scanning tooling |
-| DevSecOps engineers | Shift-left CSPM integration — surfacing equivalent configuration checks within CI/CD pipelines and IaC scanning tooling |
-| Infrastructure Automation Architect | Ensure compliance-as-code policies in IaC pipelines align with and complement CSPM runtime detection policies |
-| Compliance and Risk team | Provide CSPM findings, benchmark scores, and remediation evidence for regulatory compliance reporting, risk register updates, and audit preparation |
-| FinOps team | Review CSPM tooling costs, evaluate coverage efficiency, and ensure CSPM platform licensing is optimised across the multi-cloud estate |
-| Kubernetes Architect | Platform engineers to address Kubernetes-specific CSPM findings and CIS Kubernetes Benchmark compliance gaps |
-| Security Cross-Platform Architect | Security posture standard definitions and receives escalation guidance for architectural-level misconfigurations |
-| Security Architect | — operates within the security policy framework and escalates findings that exceed risk tolerance thresholds or require policy changes |
-| Azure Cloud Architect | **AWS Cloud Architect**, and **GCP Cloud Architect** to triage and drive remediation of misconfigurations within their respective cloud estates |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Architect | Shift-left CSPM integration — surfacing equivalent configuration checks within CI/CD pipelines and IaC scanning tooling | Collaborates |
+| DevSecOps engineers | Shift-left CSPM integration — surfacing equivalent configuration checks within CI/CD pipelines and IaC scanning tooling | Collaborates |
+| Infrastructure Automation Architect | Ensure compliance-as-code policies in IaC pipelines align with and complement CSPM runtime detection policies | Collaborates |
+| Compliance and Risk team | Provide CSPM findings, benchmark scores, and remediation evidence for regulatory compliance reporting, risk register updates, and audit preparation | Provides To |
+| FinOps team | Review CSPM tooling costs, evaluate coverage efficiency, and ensure CSPM platform licensing is optimised across the multi-cloud estate | Collaborates |
+| Kubernetes Architect | Platform engineers to address Kubernetes-specific CSPM findings and CIS Kubernetes Benchmark compliance gaps | Collaborates |
+| Security Cross-Platform Architect | Security posture standard definitions and receives escalation guidance for architectural-level misconfigurations | Escalates To |
+| Security Architect | Operates within the security policy framework and escalates findings that exceed risk tolerance thresholds or require policy changes | Governed By |
+| Azure, AWS, and GCP Cloud Architects | Triage and drive remediation of misconfigurations within their respective cloud estates | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Security Cross-Platform Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Automation Engineer builds and maintains the automated security tooling, pipelines, and integrations that allow security controls to operate at pipeline speed across the software development lifecycle. This role treats security as code — authoring policy-as-code engines (OPA, Kyverno), embedding SAST, DAST, and SCA tooling into CI/CD pipelines, implementing SOAR playbooks for automated threat response, and constructing automated compliance evidence collection workflows. Rather than relying on manual security reviews, the Security Automation Engineer designs the automation layer that enforces security controls continuously, at scale, and with measurable outcomes — making the security function a reliable, low-friction part of the engineering organisation rather than a bottleneck.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — security automation tooling, evidence collection pipelines, and pipeline-speed control enforcement
+- **Experience Anchor:** 3-5 years in security or automation engineering — operates independently within the Security Architect's control framework
+- **Out of Scope:** Cross-platform security standards (Security Cross-Platform Senior Engineer and Architect-owned); security control framework design (Security Architect-owned, this role implements automated enforcement of it); shared automation platform architecture (Automation Framework Engineer-owned, this role consumes it)
+- **Escalates To:** Security Cross-Platform Senior Engineer — complex automation implementation issues
+- **Escalated To By:** development teams on security gate findings and false positive tuning
 
 ## Business Impact
 
@@ -81,16 +91,16 @@ The Security Automation Engineer builds and maintains the automated security too
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Cloud Security Posture Manager | Align runtime CSPM detection with pipeline-time policy-as-code rules — ensuring consistent coverage between shift-left and runtime security layers |
-| Developer Experience Engineer | Integrate security tooling into the developer-facing toolchain in a low-friction, actionable manner — minimising developer toil while maintaining security coverage |
-| Automation Framework Engineer | Leverage shared automation infrastructure (pipeline templates, scripting libraries, orchestration platforms) for security automation workloads |
-| Compliance and Risk team | Understand evidence requirements for ISO 27001, SOC 2, and other frameworks — designing automated evidence collection pipelines to satisfy audit obligations |
-| Security Architect | — implements automation that enforces the organisation's security control framework at pipeline speed |
-| DevOps Architect | Embedding security tooling into shared CI/CD pipeline templates, golden-path tooling, and infrastructure automation — ensuring security gates are a first-class component of the delivery platform |
-| development teams | Triage security gate findings, explain remediation requirements, and tune false positive rates — maintaining developer trust in automated security tooling |
-| platform and SRE teams | Runtime security tooling (Falco) deployment, alert routing, and operational runbook management |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Cloud Security Posture Manager | Align runtime CSPM detection with pipeline-time policy-as-code rules — ensuring consistent coverage between shift-left and runtime security layers | Collaborates |
+| Developer Experience Engineer | Integrate security tooling into the developer-facing toolchain in a low-friction, actionable manner — minimising developer toil while maintaining security coverage | Collaborates |
+| Automation Framework Engineer | Leverage shared automation infrastructure (pipeline templates, scripting libraries, orchestration platforms) for security automation workloads | Consumes From |
+| Compliance and Risk team | Understand evidence requirements for ISO 27001, SOC 2, and other frameworks — designing automated evidence collection pipelines to satisfy audit obligations | Consumes From |
+| Security Architect | Implements automation that enforces the organisation's security control framework at pipeline speed | Governed By |
+| DevOps Architect | Embedding security tooling into shared CI/CD pipeline templates, golden-path tooling, and infrastructure automation — ensuring security gates are a first-class component of the delivery platform | Governed By |
+| development teams | Triage security gate findings, explain remediation requirements, and tune false positive rates — maintaining developer trust in automated security tooling | Provides To |
+| platform and SRE teams | Runtime security tooling (Falco) deployment, alert routing, and operational runbook management | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/security_cross_platform/security_cross_platform_architect.md
+++ b/Roles/security_cross_platform/security_cross_platform_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Security Cross-Platform Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Cross-Platform Architect designs and develops comprehensive security frameworks, standards, and architectures that span multiple technology domains. This role ensures consistent security controls and governance across all infrastructure platforms including on-premises servers, cloud environments, container platforms, and virtualization infrastructure.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — cross-platform security standards ensuring consistent controls across domain-specific security architectures
+- **Experience Anchor:** 8+ years in security architecture with demonstrated cross-platform or multi-domain security ownership — operates independently on domain-wide cross-platform security decisions
+- **Out of Scope:** Domain-specific security control implementation detail (domain-specific architects-owned, this role sets cross-cutting standards); enterprise security strategy setting (Security & Identity teams-owned, this role aligns to it); infrastructure onboarding process design (Enterprise Infrastructure Onboarding team-owned, this role embeds controls into it)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Security Cross-Platform Senior Engineers on technical design and implementation questions
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Security Cross-Platform Architect designs and develops comprehensive securit
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| domain-specific architects | Security standards are implemented consistently |
-| Security & Identity teams | Align on enterprise security strategy |
-| Enterprise Infrastructure Onboarding team | Embed security controls in onboarding processes |
-| DevOps teams | Integrate security into pipelines across multiple platforms |
-| senior leadership | Cross-platform security risks and mitigation strategies |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| domain-specific architects | Security standards are implemented consistently | Governed By |
+| Security & Identity teams | Align on enterprise security strategy | Governed By |
+| Enterprise Infrastructure Onboarding team | Embed security controls in onboarding processes | Provides To |
+| DevOps teams | Integrate security into pipelines across multiple platforms | Provides To |
+| senior leadership | Cross-platform security risks and mitigation strategies | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Security Cross-Platform Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Cross-Platform Engineer implements and maintains security controls across multiple technology domains. This role ensures the consistent application of security measures in various environments including Windows, Linux, cloud platforms, and container infrastructure, supporting the organization's overall security posture.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of cross-platform security control implementation tasks
+- **Experience Anchor:** 1-3 years in security engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Cross-platform security standards (Senior Engineers and the Architect-owned); domain-specific security architecture (domain architects-owned, this role receives technical input from them); security incident response ownership (security operations-owned, this role coordinates with it)
+- **Escalates To:** Security Cross-Platform Senior Engineer — complex implementations
+- **Escalated To By:** operations teams on security maintenance across multiple domains
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Security Cross-Platform Engineer implements and maintains security controls 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| domain-specific Engineers | Implement consistent security controls |
-| Security Cross-Platform Senior Engineers | Complex implementations |
-| operations teams | Multiple domains on security maintenance |
-| security operations | Monitoring and incident response |
-| domain architects with technical input | Security implementations |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| domain-specific Engineers | Implement consistent security controls | Collaborates |
+| Security Cross-Platform Senior Engineers | Complex implementations | Escalates To |
+| operations teams | Multiple domains on security maintenance | Provides To |
+| security operations | Monitoring and incident response | Collaborates |
+| domain architects | Provide technical input on security implementations | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Cross-Platform Product Owner manages the portfolio of security services and capabilities that span multiple technology domains. This role ensures that security requirements are prioritized and implemented consistently across all platforms, balancing security needs with operational efficiency and user experience.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — cross-platform security programme backlog and roadmap alignment across domain-specific product roadmaps
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with security domain exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Cross-platform security architecture (Security Cross-Platform Architect-owned); domain-specific product roadmap ownership (domain-specific Product Owners-owned, this role aligns cross-cutting priorities with them); regulatory compliance interpretation (security compliance teams-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** project managers on cross-platform security implementations
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Security Cross-Platform Product Owner manages the portfolio of security serv
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Security Cross-Platform Architect | Align product roadmap with architectural vision |
-| domain-specific Product Owners | Security features are prioritized in their roadmaps |
-| business stakeholders | Understand security requirements that span multiple domains |
-| security compliance teams | Regulatory requirements are addressed across platforms |
-| project managers | Cross-platform security implementations |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security Cross-Platform Architect | Align product roadmap with architectural vision | Consumes From |
+| domain-specific Product Owners | Security features are prioritized in their roadmaps | Collaborates |
+| business stakeholders | Understand security requirements that span multiple domains | Consumes From |
+| security compliance teams | Regulatory requirements are addressed across platforms | Governed By |
+| project managers | Cross-platform security implementations | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | Security Cross-Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Security Cross-Platform Senior Engineer leads the technical implementation of security controls and solutions that span multiple technology domains. This role designs, implements, and optimizes complex security mechanisms that work consistently across diverse environments including on-premises servers, cloud platforms, container ecosystems, and virtualization infrastructure.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced cross-platform security implementation within the Security Cross-Platform Architect's standards
+- **Experience Anchor:** 5+ years in security engineering with demonstrated cross-platform delivery — operates independently within the Architect's standards
+- **Out of Scope:** Cross-platform security standards design (Architect-owned); domain-specific security implementation detail (domain-specific Senior Engineers-owned, this role ensures consistency across them); security observability platform design (monitoring teams-owned, this role implements observability within it)
+- **Escalates To:** Security Cross-Platform Architect — technical design and implementation exceptions
+- **Escalated To By:** Security Cross-Platform Engineers on complex implementations
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Security Cross-Platform Senior Engineer leads the technical implementation o
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| domain-specific Senior Engineers | Implement consistent security controls |
-| Security Cross-Platform Architect | Technical design and implementation |
-| DevOps teams | Integrate security into CI/CD pipelines across platforms |
-| monitoring teams | Implement cross-platform security observability |
-| Mentors Security Cross-Platform Engineers | Complex implementations |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| domain-specific Senior Engineers | Implement consistent security controls | Governed By |
+| Security Cross-Platform Architect | Technical design and implementation | Escalates To |
+| DevOps teams | Integrate security into CI/CD pipelines across platforms | Collaborates |
+| monitoring teams | Implement cross-platform security observability | Collaborates |
+| Security Cross-Platform Engineers | Mentors on complex implementations | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Access Management Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Access Management Architect designs and oversees the organization's access management strategy and solutions. This role ensures secure, efficient, and appropriate access to systems and data while maintaining compliance with security policies and regulatory requirements.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — access management (authorization) architecture, RBAC/ABAC models, and access governance standards across the chapter
+- **Experience Anchor:** 8+ years in access management or identity architecture with demonstrated architecture-level delivery — operates independently on domain-wide access architecture decisions
+- **Out of Scope:** Identity (authentication) management architecture (Identity Management Architect-owned, this role integrates with it); access monitoring tooling design (Observability Architect-owned, this role consumes it); enterprise access governance policy (compliance and risk management-owned, this role implements it)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Access Management Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Access Management Architect designs and oversees the organization's access m
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Security Architects | Access security controls |
-| Cloud Platform Architects | Cloud access management |
-| Observability Architect | Access monitoring |
-| Identity Management Architect | Integrated IAM solutions |
-| compliance and risk management | Access governance |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security Architects | Access security controls | Governed By |
+| Cloud Platform Architects | Cloud access management | Collaborates |
+| Observability Architect | Access monitoring | Consumes From |
+| Identity Management Architect | Integrated IAM solutions | Collaborates |
+| compliance and risk management | Access governance | Governed By |
 
 ## Key Technologies
 

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Access Management Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Access Management Engineer implements and maintains access management systems across the organization. Working with the Access Management Architect and Product Owner, this role ensures secure, efficient, and appropriate access to systems and data for users and applications.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of access provisioning and control configuration tasks to defined standards
+- **Experience Anchor:** 1-3 years in access management or identity engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Access management architecture and solution design (Senior Engineers and the Architect-owned); identity (authentication) provisioning (Identity Management Engineers-owned, this role integrates with it); broader security control implementation (Security Engineers-owned, this role coordinates with it)
+- **Escalates To:** Access Management Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on access requirements
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Access Management Engineer implements and maintains access management system
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Access Management Product Owner | Task prioritization |
-| Identity Management Engineers | Integrated IAM solutions |
-| Security Engineers | Access security controls |
-| Access Management Architect | Implementation activities |
-| application teams | Access requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Access Management Product Owner | Task prioritization | Consumes From |
+| Identity Management Engineers | Integrated IAM solutions | Collaborates |
+| Security Engineers | Access security controls | Collaborates |
+| Access Management Architect | Implementation activities | Escalates To |
+| application teams | Access requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Access Management Product Owner manages the development and lifecycle of the organization's access management solutions. This role leads a team of access management architects and engineers, ensuring secure and efficient access to systems and data while meeting business requirements and compliance standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — access management platform backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Access management technical architecture (Access Management Architect-owned); identity (authentication) roadmap (Identity Management Product Owner-owned, this role aligns to it); access policy definition (Security and Compliance teams-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** business unit representatives on access needs
 
 ## Business Impact
 
@@ -96,14 +106,14 @@ The Access Management Product Owner manages the development and lifecycle of the
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Identity Management Product Owner | Integrated IAM strategy |
-| Access Management Architect | Technical strategy |
-| Security and Compliance teams | Access policies |
-| Application Product Owners | Application access requirements |
-| business unit representatives | Access needs |
-| IT leadership | Access management strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Identity Management Product Owner | Integrated IAM strategy | Collaborates |
+| Access Management Architect | Technical strategy | Consumes From |
+| Security and Compliance teams | Access policies | Governed By |
+| Application Product Owners | Application access requirements | Consumes From |
+| business unit representatives | Access needs | Consumes From |
+| IT leadership | Access management strategy and investments | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | Access Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Access Management Senior Engineer leads the implementation and optimization of enterprise access management solutions. This role provides technical leadership for access control systems while working closely with architects to translate access strategies into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced access management solution design and delivery within the Access Management Architect's reference architecture
+- **Experience Anchor:** 5+ years in access management engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Access management architecture and standards (Architect-owned); identity (authentication) management implementation (Identity Management Senior Engineers-owned, this role integrates with it); advanced security control design (Security Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Access Management Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Access Management Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Access Management Senior Engineer leads the implementation and optimization 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Access Management Architect | Solution design and implementation strategy |
-| Access Management Product Owner | Technical planning and roadmap execution |
-| Identity Management Senior Engineers | Integrated IAM solutions |
-| Security Senior Engineers | Advanced access security controls |
-| Access Management Engineers | Technical implementation |
-| application architects | Complex access requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Access Management Architect | Solution design and implementation strategy | Escalates To |
+| Access Management Product Owner | Technical planning and roadmap execution | Collaborates |
+| Identity Management Senior Engineers | Integrated IAM solutions | Collaborates |
+| Security Senior Engineers | Advanced access security controls | Collaborates |
+| Access Management Engineers | Technical implementation | Provides To |
+| application architects | Complex access requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Identity and Access Governance Specialist owns the Identity Governance and Administration (IGA) function across the organisation — the operational and technical layer that answers the question: who has what access, and is it appropriate? This role is distinct from the Identity Management Senior Engineer (which focuses on authentication protocols, federation, and SSO): the Identity and Access Governance Specialist focuses on the governance layer — designing and operating access certification campaigns, entitlement management catalogues, role mining and RBAC/ABAC engineering, Joiner/Mover/Leaver (JML) lifecycle automation, and Segregation of Duties (SoD) enforcement. The Specialist operates IGA platforms (SailPoint IdentityNow/IIQ, Saviynt, Omada Identity, Microsoft Entra ID Governance) and integrates them with HR systems (Workday, SAP) to drive fully automated, auditable, and compliant identity lifecycle processes at enterprise scale.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — identity governance and administration (IGA) platform operations, access certification, and segregation-of-duties (SoD) compliance
+- **Experience Anchor:** 5+ years in identity governance with demonstrated IGA platform ownership — operates independently within the Identity Management Architect's framework
+- **Out of Scope:** Enterprise identity architecture (Identity Management Architect-owned, this role operates IGA platforms within it); broader security control framework (Security Architect-owned, this role aligns SoD policy to it); privileged account vaulting operations (PAM Architect and Engineer-owned, this role coordinates certification scope with them)
+- **Escalates To:** Identity Management Architect — platform or design decisions requiring architectural guidance
+- **Escalated To By:** application owners on entitlement modelling and certification configuration
 
 ## Business Impact
 
@@ -81,17 +91,17 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Security Architect | SoD policy alignment with the broader security control framework, risk acceptance processes for SoD exceptions, and audit preparation for identity governance controls |
-| application owners | The enterprise to onboard applications into the IGA platform, design entitlement models and role structures, and maintain application-specific certification and SoD configurations |
-| Compliance and Risk team | Identity governance evidence, access certification results, and SoD compliance reports in support of ISO 27001, SOC 2, SOX, and regulatory assessments |
-| Internal and external audit teams | Identity governance evidence, access certification results, and SoD compliance reports in support of ISO 27001, SOC 2, SOX, and regulatory assessments |
-| Access Management Senior Engineer | Identity engineering team on entitlement provisioning integration — ensuring IGA-driven provisioning events are correctly executed at the application and directory layer |
-| CyberArk Identity | Or equivalent identity governance tooling to ensure that identity lifecycle events from the IGA platform are reflected in privileged account and vault membership management |
-| Identity Management Architect | — operates IGA platforms within the enterprise identity architecture framework and escalates platform or design decisions requiring architectural guidance |
-| Privileged Access Management (PAM) Architect and Engineer | Ensure privileged account entitlements are included in IGA certification scope, SoD analysis, and JML deprovisioning workflows — maintaining a unified governance view across standard and privileged identities |
-| HR systems teams | (Workday, SAP HRIS owners) to maintain JML integration reliability — managing attribute mapping updates, HR event trigger configurations, and data quality issues that affect automated provisioning |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security Architect | SoD policy alignment with the broader security control framework, risk acceptance processes for SoD exceptions, and audit preparation for identity governance controls | Governed By |
+| application owners | Onboard applications into the IGA platform, design entitlement models and role structures, and maintain application-specific certification and SoD configurations | Collaborates |
+| Compliance and Risk team | Identity governance evidence, access certification results, and SoD compliance reports in support of ISO 27001, SOC 2, SOX, and regulatory assessments | Provides To |
+| Internal and external audit teams | Identity governance evidence, access certification results, and SoD compliance reports in support of ISO 27001, SOC 2, SOX, and regulatory assessments | Provides To |
+| Access Management Senior Engineer | Coordinate with the identity engineering team on entitlement provisioning integration — ensuring IGA-driven provisioning events are correctly executed at the application and directory layer | Collaborates |
+| CyberArk Identity (or equivalent) | Ensure identity lifecycle events from the IGA platform are reflected in privileged account and vault membership management | Collaborates |
+| Identity Management Architect | Operates IGA platforms within the enterprise identity architecture framework and escalates platform or design decisions requiring architectural guidance | Escalates To |
+| Privileged Access Management (PAM) Architect and Engineer | Ensure privileged account entitlements are included in IGA certification scope, SoD analysis, and JML deprovisioning workflows — maintaining a unified governance view across standard and privileged identities | Collaborates |
+| HR systems teams (Workday, SAP HRIS owners) | Maintain JML integration reliability — managing attribute mapping updates, HR event trigger configurations, and data quality issues that affect automated provisioning | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Identity Management Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Identity Management Architect designs and oversees the organization's identity management strategy and solutions. This role focuses on creating a secure, scalable, and efficient identity infrastructure that supports authentication, lifecycle management, and identity governance across the enterprise.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — identity management architecture, directory services strategy, and hybrid identity standards across the chapter
+- **Experience Anchor:** 8+ years in identity architecture with demonstrated architecture-level delivery — operates independently on domain-wide identity architecture decisions
+- **Out of Scope:** Access management (authorization) architecture (Access Management Architect-owned, this role integrates identity with it); Active Directory infrastructure operations (Windows Server Architect-owned, this role aligns to it); application-level identity integration detail (application architects-owned, this role provides standards to them)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Identity Management Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Identity Management Architect designs and oversees the organization's identi
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Cloud Platform Architects | Cloud identity strategies |
-| Security Architects | Identity security controls |
-| Windows Server Architect | Active Directory architecture |
-| Access Management Architect | Integrated IAM solutions |
-| application architects | Application identity integration |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Cloud Platform Architects | Cloud identity strategies | Collaborates |
+| Security Architects | Identity security controls | Governed By |
+| Windows Server Architect | Active Directory architecture | Collaborates |
+| Access Management Architect | Integrated IAM solutions | Collaborates |
+| application architects | Application identity integration | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Identity Management Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Identity Management Engineer implements and maintains identity management systems across the organization. Working with the Identity Management Architect and Product Owner, this role ensures secure, efficient, and well-managed identity services for all users and applications.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of identity provisioning and directory operations tasks to defined standards
+- **Experience Anchor:** 1-3 years in identity or directory engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Identity management architecture and solution design (Senior Engineers and the Architect-owned); access management (authorization) implementation (Access Management Engineers-owned, this role integrates with it); Windows Server infrastructure operations (Windows Server Engineers-owned, this role coordinates with it)
+- **Escalates To:** Identity Management Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on identity integration requests
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Identity Management Engineer implements and maintains identity management sy
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Identity Management Product Owner | Task prioritization |
-| Access Management Engineers | Integrated IAM solutions |
-| Windows Server Engineers | Active Directory operations |
-| Identity Management Architect | Implementation activities |
-| application teams | Identity integration |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Identity Management Product Owner | Task prioritization | Consumes From |
+| Access Management Engineers | Integrated IAM solutions | Collaborates |
+| Windows Server Engineers | Active Directory operations | Collaborates |
+| Identity Management Architect | Implementation activities | Escalates To |
+| application teams | Identity integration | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Identity Management Product Owner manages the development and lifecycle of the organization's identity management solutions. This role leads a team of identity architects and engineers, ensuring that identity services meet security requirements, user needs, and operational objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — identity management platform backlog, modernisation roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Identity management technical architecture (Identity Management Architect-owned); access management (authorization) roadmap (Access Management Product Owner-owned, this role aligns to it); identity policy definition (security and compliance teams-owned)
+- **Escalates To:** Security & Identity Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** HR and business unit representatives on identity lifecycle process needs
 
 ## Business Impact
 
@@ -99,14 +109,14 @@ The Identity Management Product Owner manages the development and lifecycle of t
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Access Management Product Owner | Integrated IAM strategy |
-| Identity Management Architect | Technical strategy |
-| security and compliance teams | Identity policies |
-| Application Product Owners | Application identity requirements |
-| HR and business unit representatives | Identity lifecycle processes |
-| IT leadership | Identity management strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Access Management Product Owner | Integrated IAM strategy | Collaborates |
+| Identity Management Architect | Technical strategy | Consumes From |
+| security and compliance teams | Identity policies | Governed By |
+| Application Product Owners | Application identity requirements | Consumes From |
+| HR and business unit representatives | Identity lifecycle processes | Consumes From |
+| IT leadership | Identity management strategy and investments | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | Identity Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Identity Management Senior Engineer leads the implementation and optimization of enterprise identity management solutions. This role provides technical leadership for identity systems while working closely with architects to translate identity strategies into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced identity solution design and delivery within the Identity Management Architect's reference architecture
+- **Experience Anchor:** 5+ years in identity engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Identity management architecture and standards (Architect-owned); access management (authorization) implementation (Access Management Senior Engineers-owned, this role integrates with it); cloud identity service selection (Cloud Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Identity Management Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Identity Management Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Identity Management Architect | Solution design and implementation strategy |
-| Identity Management Product Owner | Technical planning and roadmap execution |
-| Access Management Senior Engineers | Integrated IAM solutions |
-| Cloud Senior Engineers | Cloud identity solutions |
-| Identity Management Engineers | Technical implementation |
-| application architects | Complex identity requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Identity Management Architect | Solution design and implementation strategy | Escalates To |
+| Identity Management Product Owner | Technical planning and roadmap execution | Collaborates |
+| Access Management Senior Engineers | Integrated IAM solutions | Collaborates |
+| Cloud Senior Engineers | Cloud identity solutions | Collaborates |
+| Identity Management Engineers | Technical implementation | Provides To |
+| application architects | Complex identity requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/privileged_access_management_architect.md
+++ b/Roles/security_identity/privileged_access_management_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |
+| **Reports To** | Security & Identity Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors the Privileged Access Management Engineer; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Privileged Access Management (PAM) Architect designs, governs, and evolves the organisation's strategy and technical architecture for securing privileged credentials, accounts, and access paths across on-premises, cloud, and hybrid environments. Privileged access - administrative accounts, service accounts, API keys, and secrets - represents the highest-value attack surface in any organisation. This role ensures that privileged access is vaulted, just-in-time, audited, and aligned to Zero Trust principles, preventing lateral movement and credential-based attacks.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — privileged access management (PAM) architecture, vaulting strategy, and just-in-time access patterns across the chapter
+- **Experience Anchor:** 8+ years in PAM or identity security architecture with demonstrated architecture-level delivery — operates independently on domain-wide PAM architecture decisions
+- **Out of Scope:** Standard identity lifecycle management (Identity Management Architect-owned, this role coordinates PIM/governance integration with it); enterprise security risk framework (Security Architect / CISO-owned, this role aligns PAM strategy to it); cloud landing zone design (Cloud Architects-owned, this role defines privileged access patterns within it)
+- **Escalates To:** Security & Identity Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** the Privileged Access Management Engineer on design-level issues and platform limitations
 
 ## Business Impact
 
@@ -76,14 +86,14 @@ The Privileged Access Management (PAM) Architect designs, governs, and evolves t
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Identity Management Architect: | Coordinate on Entra ID PIM, access governance, and identity lifecycle integration |
-| Security Architect / CISO: | Align PAM strategy with enterprise security architecture and risk management |
-| Cloud Architects (Azure, AWS, GCP): | Define cloud-native privileged access patterns and JIT models |
-| IT Operations / Sysadmins: | Drive on-boarding of server and infrastructure privileged accounts |
-| Database Administrators: | On-board database privileged credentials to PAM vaulting |
-| Compliance / Audit: | Provide PAM control evidence and attestation for regulatory requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Identity Management Architect | Coordinate on Entra ID PIM, access governance, and identity lifecycle integration | Collaborates |
+| Security Architect / CISO | Align PAM strategy with enterprise security architecture and risk management | Governed By |
+| Cloud Architects (Azure, AWS, GCP) | Define cloud-native privileged access patterns and JIT models | Collaborates |
+| IT Operations / Sysadmins | Drive on-boarding of server and infrastructure privileged accounts | Provides To |
+| Database Administrators | On-board database privileged credentials to PAM vaulting | Provides To |
+| Compliance / Audit | Provide PAM control evidence and attestation for regulatory requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/security_identity/privileged_access_management_engineer.md
+++ b/Roles/security_identity/privileged_access_management_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |
+| **Reports To** | Privileged Access Management Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Privileged Access Management (PAM) Engineer implements, operates, and maintains the organisation's PAM platform and associated privileged access controls. This role is responsible for on-boarding privileged accounts to vaulting solutions, configuring session management, maintaining platform health, and supporting IT operational teams in adopting JIT and zero-standing-privilege workflows. The PAM Engineer is a hands-on specialist who ensures the PAM platform is reliable, correctly configured, and actively covering the organisation's privileged attack surface.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of PAM onboarding, vaulting operations, and access support tasks
+- **Experience Anchor:** 3-5 years in PAM or identity security engineering — operates independently within the PAM Architect's reference architecture
+- **Out of Scope:** PAM architecture and vaulting strategy (Architect-owned); standard identity lifecycle provisioning (Identity Engineers-owned, this role coordinates with it); broader security incident investigation (Security Operations-owned, this role shares audit logs and alerts with it)
+- **Escalates To:** Privileged Access Management Architect — design-level issues and platform limitations
+- **Escalated To By:** IT Operations / System Administrators on PAM access support and on-boarding requests
 
 ## Business Impact
 
@@ -74,13 +84,13 @@ The Privileged Access Management (PAM) Engineer implements, operates, and mainta
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| PAM Architect: | Receive architecture direction; escalate design-level issues and platform limitations |
-| IT Operations / System Administrators: | Provide PAM access support and on-boarding assistance |
-| Security Operations: | Share audit logs and alert on privileged access anomalies |
-| Compliance / Audit: | Produce access reports and attestation evidence |
-| Identity Engineers: | Coordinate on Entra ID PIM and access lifecycle alignment |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| PAM Architect | Receive architecture direction; escalate design-level issues and platform limitations | Escalates To |
+| IT Operations / System Administrators | Provide PAM access support and on-boarding assistance | Provides To |
+| Security Operations | Share audit logs and alert on privileged access anomalies | Collaborates |
+| Compliance / Audit | Produce access reports and attestation evidence | Provides To |
+| Identity Engineers | Coordinate on Entra ID PIM and access lifecycle alignment | Collaborates |
 
 ## Key Technologies
 


### PR DESCRIPTION
## Summary

Batch 6/7 of #5: backfills **Reports To**, **Direct Reports**, **Role Scope & Boundaries**, and **Interaction Mode** across all 36 files in the Security & Identity chapter still on the old template (Security, Security Cross-Platform, Security & Identity, Data Protection, Directory Services), per `docs/role_template.md`. Closes #88.

- **Security (6 files):** `security_architect/senior_engineer/engineer/product_owner`, `devsecops_architect/engineer`.
- **Security Cross-Platform (6 files):** `security_cross_platform_architect/senior_engineer/engineer/product_owner`, `cloud_security_posture_manager`, `security_automation_engineer`.
- **Security & Identity (11 files):** Identity Management ladder (4), Access Management ladder (4), `identity_governance_specialist`, `privileged_access_management_architect/engineer`.
- **Data Protection (9 files):** Commvault ladder (4), SimpliVity Backup ladder (4), `backup_reliability_engineer`. `business_continuity_disaster_recovery_manager.md` was already on the modern template and is untouched.
- **Directory Services (4 files):** `windows_active_directory_architect/senior_engineer/engineer/product_owner`.

## Reporting model

Standard IC ladder, consistent with batches 2-5: Engineer → Senior Engineer; Senior Engineer and Product Owner → **Security & Identity Chapter Lead**. Two backup-platform ladders (Commvault vs. SimpliVity) each report straight to the Chapter Lead rather than to one another, the same parallel-ladder pattern as Storage/Qumulo Storage in batch 5.

Six Engineer- or Senior-Engineer-grade roles have no dedicated tier of their own within their sub-domain, so each reports to (or escalates to) its nearest Architect or Senior Engineer:

- **DevSecOps Engineer** → DevSecOps Architect (no DevSecOps Senior Engineer tier)
- **Security Automation Engineer** → Security Cross-Platform Senior Engineer
- **Cloud Security Posture Manager** (Senior Engineer grade, standalone) → escalates to Security Cross-Platform Architect
- **Identity Governance Specialist** (Senior Engineer grade, standalone) → escalates to Identity Management Architect, per its own text ("operates IGA platforms within the enterprise identity architecture framework")
- **Privileged Access Management Engineer** → PAM Architect (no PAM Senior Engineer tier)
- **Backup Reliability Engineer** → "Commvault Senior Engineer or SimpliVity Backup Senior Engineer, depending on platform assignment" — mirrors the DevOps chapter's Automation Framework Engineer pattern from batch 4

## Other fixes bundled in

- `commvault_product_owner.md`'s interactions table had a malformed row — `| IT Operations Manager | Or **Infrastructure Director** |` — referencing role titles that don't exist anywhere else in the catalog (the same markdown-wrapping artifact fixed in `qumulo_storage_engineer.md` during batch 5). Replaced it with a coherent row describing infrastructure escalation for platform-level backup incidents.

## Verification

- `npm run validate` — 220 files checked, 0 errors, 0 warnings, 0 duplicate titles.
- `npm test` — 91/91 passing.
- `npx markdownlint-cli2` on all 36 touched files — 0 issues.
- Cross-file directional consistency spot-checked (Reports To / Direct Reports pairs match on both sides, including the six specialist-role exceptions above).

## Test plan

- [x] `npm run validate`
- [x] `npm test`
- [x] `npx markdownlint-cli2` on touched files
- [ ] CI green on both matrix legs

Closes #88.