### PR TITLE
feat: backfill Reports To / Scope / Interaction Mode for Cloud, Platform & Infrastructure chapter (#89, batch 7/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
+  Mode backfilled for the Cloud, Platform & Infrastructure chapter (#89,
+  batch 7/7 — the final batch: 77 of 219 files, completing #5).** Cloud
+  Platforms, Kubernetes, Modern Infrastructure, Virtualisation (VMware,
+  Hyper-V, Nutanix), Specialised Computing (HPC), Server Hardware
+  (vendor-agnostic and HPE), Server OS (Linux and Windows), Network, and
+  FinOps all follow the standard IC-ladder pattern: Engineer reports to
+  Senior Engineer, Senior Engineer and Product Owner report to the Cloud,
+  Platform & Infrastructure Chapter Lead. Kubernetes and one Hyper-V file
+  had the variant "Relationships & Collaboration" heading renamed to the
+  canonical "Interactions with Other Roles" (mirroring the #7 fix, same as
+  batch 4). Two grounded structural exceptions:
+  - **Cloud Platforms has an explicit three-tier hierarchy above the
+    standard architect ladder**, stated directly in its own role-overview
+    text: the Cloud Principal Architect "operates below the Technical Area
+    Lead (TAL)" and reports there directly rather than to the Chapter
+    Lead; the Cloud Lead Architect "bridges the gap" between the Principal
+    Architect's strategy and the AWS/Azure/GCP Cloud Architects' designs
+    and reports to the Principal Architect. The three platform Architects
+    themselves still report to the Chapter Lead like every other domain,
+    but escalate cross-platform problems to the Cloud Lead Architect
+    rather than straight to the Chapter Lead.
+  - **Network Automation Architect is a peer to Network Architect**, per
+    its own text ("automation extends and operationalises network
+    designs" rather than replacing them) — both report to the Chapter
+    Lead, mirroring the API Strategy/API Platform peer pattern from
+    batch 4.
+  Six further structural notes: Site Reliability Engineer/Senior Engineer
+  has no Architect tier of its own in the catalog, so the Senior Engineer
+  reports to the Chapter Lead directly and escalates to the Platform
+  Engineering Architect (its closest real architectural relationship);
+  GenAI Platform Engineer and MLOps Engineer both report to the GenAI
+  Platform Architect (MLOps has no dedicated architect of its own); Chaos
+  Engineer reports to the Site Reliability Senior Engineer. FinOps's
+  interactions tables were fully restructured — the pre-existing content
+  used a degraded "Reports to | X" / blank-role-cell pseudo-row format
+  unlike every other domain's proper two-column table, including several
+  rows with a literally empty Role cell — into the standard three-column
+  format grounded in the same raw material. Fixed a malformed row in
+  `hpc_architect.md` ("Facilitates knowledge sharing and documentation |
+  All HPC stakeholders", with Role and Nature reversed) and merged a
+  duplicate pair of rows in `hpc_engineer.md` describing the same
+  researcher-training relationship twice.
+- **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
   Mode backfilled for the Security & Identity chapter (#88, batch 6/7:
   36 of 219 files — the domain's 2 governance specialists, GRC Risk
   Compliance Analyst and Business Continuity/DR Manager, were already on

--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | FinOps Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Cloud Cost Optimization Engineer is responsible for the hands-on implementation of cost reduction measures across the cloud estate, translating FinOps strategy into tangible savings through reserved instance and savings plan management, rightsizing, idle resource cleanup, spot instance adoption, and tagging enforcement. This role operates at the intersection of cloud engineering and financial accountability, working directly with cloud platforms and FinOps tooling to reduce waste, improve coverage, and ensure cost-aware resource utilisation across AWS, Azure, and GCP.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — cloud resource tagging, anomaly resolution, and rightsizing implementation tasks
+- **Experience Anchor:** 3-5 years in cloud engineering or FinOps with a cost optimisation focus — operates independently within the FinOps Senior Engineer's standards
+- **Out of Scope:** FinOps architecture and cost governance standards (FinOps Architect-owned); cloud platform engineering implementation (Cloud Platform Engineers-owned, this role coordinates rightsizing with it); pipeline design ownership (DevOps Engineers-owned, this role coordinates with it)
+- **Escalates To:** FinOps Senior Engineer — cost optimisation implementation questions
+- **Escalated To By:** application owners on tagging, anomaly resolution, and rightsizing support
 
 ## Business Impact
 
@@ -72,11 +82,14 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to | FinOps Senior Engineer or FinOps Manager |
-| | Cloud Platform Engineers, DevOps Engineers, FinOps Senior Engineer |
-| Collaborates with | Application owners, Finance business partners, and platform tooling teams on tagging, anomaly resolution, and rightsizing initiatives |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| FinOps Senior Engineer | Receives task prioritisation and technical guidance | Escalates To |
+| Cloud Platform Engineers | Coordinates on resource tagging, anomaly resolution, and rightsizing implementation | Collaborates |
+| DevOps Engineers | Coordinates cost-efficient deployment practices | Collaborates |
+| Application owners | Supports tagging, anomaly resolution, and rightsizing initiatives | Provides To |
+| Finance business partners | Provides cost optimisation data for reporting | Provides To |
+| platform tooling teams | Coordinates on FinOps tooling integration | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -5,6 +5,8 @@
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | FinOps Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Cloud Economics Analyst is the business-facing analytical capability within the FinOps practice, responsible for translating raw cloud spend data into actionable financial intelligence that informs budgeting, forecasting, and investment decisions. This role specialises in unit economics modelling, showback and chargeback reporting, budget variance analysis, TCO modelling, and make-vs-buy analysis, working closely with finance teams, product owners, and business unit leaders to ensure cloud costs are understood, attributed accurately, and optimised from a commercial perspective.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — cloud unit economics analysis, billing allocation accuracy, and commitment/contract data analysis
+- **Experience Anchor:** 3-5 years in FinOps, financial analysis, or cloud engineering with a financial/economics focus — operates independently within the FinOps Senior Engineer's standards
+- **Out of Scope:** FinOps architecture and cost governance standards (FinOps Architect-owned); billing pipeline engineering implementation (data engineering teams-owned, this role consumes it); tagging and rightsizing implementation (Cloud Cost Optimization Engineer-owned, this role analyses the resulting economics)
+- **Escalates To:** FinOps Senior Engineer — cost economics questions
+- **Escalated To By:** business unit finance leads on unit economics reporting needs
 
 ## Business Impact
 
@@ -73,11 +83,15 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to | FinOps Manager or Finance Operations Manager |
-| | FinOps Senior Engineer, FinOps Architect, Finance business partners, business unit finance leads |
-| Collaborates with | Cloud Platform Engineers (for tagging and allocation accuracy), product owners (for unit economics inputs), procurement teams (for commitment and contract data), and data engineering teams (for billing pipeline support) |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| FinOps Senior Engineer | Receives task prioritisation and technical guidance | Escalates To |
+| FinOps Architect | Consumes cost governance standards for economics analysis | Consumes From |
+| Finance business partners and business unit finance leads | Provides unit economics analysis and reporting | Provides To |
+| Cloud Platform Engineers | Coordinates for tagging and allocation accuracy | Collaborates |
+| product owners | Provides unit economics inputs | Provides To |
+| procurement teams | Consumes commitment and contract data | Consumes From |
+| data engineering teams | Coordinates on billing pipeline support | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors FinOps Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -14,6 +16,14 @@
 The FinOps Architect designs and implements cloud financial management strategies, governance frameworks, and cost optimization architectures across the organization. This role bridges financial management practices with cloud technology to ensure optimal resource utilization and cost efficiency.
 
 See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.md) — the tagging, budgeting, and chargeback standards this role works within.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — cloud financial management architecture, cost governance standards, and FinOps tooling strategy across the chapter
+- **Experience Anchor:** 8+ years in cloud financial management or infrastructure architecture with demonstrated architecture-level delivery — operates independently on domain-wide FinOps architecture decisions
+- **Out of Scope:** Cloud platform-specific architecture (Cloud Platform Architects-owned, this role partners with it on cost-efficient design); enterprise architecture strategy (Enterprise Architecture team-owned, this role aligns to it); individual cost optimisation execution (Cloud Cost Optimization Engineer-owned, this role guides it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** FinOps Senior Engineers on cost governance standards questions
 
 ## Business Impact
 
@@ -75,13 +85,15 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to | Chief Technology Officer or VP of Cloud Operations |
-| | : Cloud Platform Architects, Financial Controllers, IT Directors |
-| Partners with | Enterprise Architecture team, Cloud Center of Excellence |
-| Advises | Executive leadership on cloud economics and optimization |
-| Guides | Cloud engineering teams on cost-efficient architectures |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Cloud Platform Architects | Partners on cost-efficient cloud architecture design | Collaborates |
+| Financial Controllers | Aligns cloud spend reporting with enterprise financial controls | Collaborates |
+| IT Directors | Provides cloud economics input to infrastructure investment decisions | Provides To |
+| Enterprise Architecture team | Ensures FinOps standards align with enterprise architecture governance | Governed By |
+| Cloud Center of Excellence | Partners on cloud governance and best practice adoption | Collaborates |
+| Executive leadership | Advises on cloud economics and optimization strategy | Provides To |
+| Cloud engineering teams | Guides teams on cost-efficient architectures | Provides To |
 
 ## Key Technologies & Platforms
 

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | FinOps Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -14,6 +16,14 @@
 The FinOps Engineer implements and maintains cloud cost monitoring, reporting, and optimization solutions. This role applies technical expertise to operationalize FinOps practices, ensuring effective day-to-day management of cloud costs and supporting the organization's cloud financial management goals.
 
 See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.md) — the tagging, budgeting, and chargeback standards this role works within.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of cost tracking, tagging, and optimisation implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in cloud financial management or FinOps engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** FinOps architecture and cost governance standards (Senior Engineers and the Architect-owned); cloud platform engineering implementation (Cloud Platform Engineers-owned, this role coordinates cost data with it); billing negotiation with cloud service providers (FinOps Senior Engineer/Architect-owned, this role supports it)
+- **Escalates To:** FinOps Senior Engineer — cost optimisation implementation questions
+- **Escalated To By:** business units and project teams on cost optimisation support
 
 ## Business Impact
 
@@ -75,13 +85,15 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to | FinOps Manager or Cloud Cost Management Lead |
-| | : FinOps Senior Engineers, Cloud Platform Engineers, Finance Teams |
-| Collaborates with | DevOps teams, Application owners, Cloud Center of Excellence |
-| Supports | Business units and project teams on cost optimization |
-| Partners with | Cloud service providers on billing and optimization |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| FinOps Senior Engineers | Receives task prioritisation and technical guidance | Escalates To |
+| Cloud Platform Engineers | Coordinates on cloud resource cost data | Collaborates |
+| Finance Teams | Provides cost data for financial reporting | Provides To |
+| DevOps teams | Collaborates on cost-efficient deployment practices | Collaborates |
+| Application owners | Supports on cost optimisation opportunities | Provides To |
+| Cloud Center of Excellence | Partners on cost optimisation best practices | Collaborates |
+| Cloud service providers | Partners on billing and optimization | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The FinOps Product Owner manages the backlog of cloud cost optimization initiatives, drives cloud financial accountability, and ensures business alignment. This role champions the FinOps practice within the organization, ensuring that cloud spending delivers maximum business value and that stakeholders understand their cloud economics.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — FinOps platform backlog, cost governance roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with cloud financial management exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** FinOps technical architecture (FinOps Architect-owned); cloud engineering implementation (Cloud Engineers-owned, this role aligns backlog to it); enterprise financial controls (Financial Controllers-owned, this role coordinates reporting with them)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Business Unit Leaders on cost governance and reporting needs
 
 ## Business Impact
 
@@ -72,11 +82,13 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to | Cloud Services Director or Head of Cloud Center of Excellence |
-| | : FinOps Architect, Cloud Engineers, Business Unit Leaders, Financial Controllers |
-| Manages | FinOps product backlog and stakeholder relationships |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| FinOps Architect | Consumes technical strategy to shape backlog and roadmap priorities | Consumes From |
+| Cloud Engineers | Provides delivery direction and prioritisation for cost optimisation work | Provides To |
+| Business Unit Leaders | Gathers cost governance and reporting requirements | Consumes From |
+| Financial Controllers | Coordinates cloud spend reporting with enterprise financial processes | Collaborates |
+| Cloud Services Director | Manages the FinOps product backlog and stakeholder relationships | Escalates To |
 
 ## Key Focus Areas
 

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | FinOps Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The FinOps Senior Engineer leads complex cloud financial optimization projects, develops sophisticated automation solutions, and provides technical leadership for the FinOps practice. This role applies advanced technical expertise to optimize cloud costs at scale, implement innovative solutions, and mentor other team members.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced cost optimisation and FinOps tooling delivery within the FinOps Architect's reference architecture
+- **Experience Anchor:** 5+ years in cloud financial management engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** FinOps architecture and cost governance standards (Architect-owned); cloud platform engineering implementation (Cloud Platform Senior Engineers-owned, this role coordinates cost data with it); backlog prioritisation (FinOps Product Owner-owned, this role provides technical input to it)
+- **Escalates To:** FinOps Architect — cost governance standards exceptions
+- **Escalated To By:** FinOps Engineers on cost optimisation implementation questions
 
 ## Business Impact
 
@@ -73,10 +83,11 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Reports to | FinOps Manager or Cloud Operations Manager |
-| | : FinOps Architect, Cloud Platform Senior Engineers, FinOps Product Owner |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| FinOps Architect | Receives cost governance standards and architecture direction | Escalates To |
+| Cloud Platform Senior Engineers | Coordinates on cloud resource cost data and optimisation opportunities | Collaborates |
+| FinOps Product Owner | Provides technical input to backlog and roadmap prioritisation | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors AWS Cloud Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AWS Cloud Platform Architect designs, implements, and governs cloud solutions on Amazon Web Services. This role is responsible for creating secure, scalable, and cost-efficient AWS environments that meet business requirements and technical standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — AWS platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in AWS or cloud architecture with demonstrated architecture-level delivery — operates independently on domain-wide AWS architecture decisions within the Cloud Lead Architect's cross-platform standards
+- **Out of Scope:** Cross-platform architecture consistency (Cloud Lead Architect-owned, this role escalates cross-platform problems to it); underlying compute/OS configuration (Linux Server Architect-owned, this role aligns to it); container orchestration architecture (Kubernetes Architect-owned, this role coordinates EKS with it)
+- **Escalates To:** Cloud Lead Architect — complex cross-platform cloud problems
+- **Escalated To By:** AWS Cloud Senior Engineers on solution design questions
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Linux Server Architect | EC2 deployments and AMI standards |
-| Kubernetes Architect | EKS implementations |
-| Database Architect | RDS and other AWS database services |
-| Observability Architect | CloudWatch and observability solutions |
-| Azure Cloud Platform Architect | Multi-cloud strategies |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Linux Server Architect | EC2 deployments and AMI standards | Collaborates |
+| Kubernetes Architect | EKS implementations | Collaborates |
+| Database Architect | RDS and other AWS database services | Collaborates |
+| Observability Architect | CloudWatch and observability solutions | Collaborates |
+| Azure Cloud Platform Architect | Multi-cloud strategies | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | AWS Cloud Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AWS Cloud Engineer implements and maintains cloud resources and services in Amazon Web Services. Working with the AWS Cloud Platform Architect and Product Owner, this role ensures reliable, secure, and optimized AWS environments supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of AWS resource provisioning and implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in AWS or cloud engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** AWS architecture and solution design (Senior Engineers and the Architect-owned); underlying Linux instance configuration ownership (Linux Server Engineers-owned, this role coordinates with it); CI/CD pipeline design (DevOps Engineers-owned, this role integrates with it)
+- **Escalates To:** AWS Cloud Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on AWS resource requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AWS Cloud Product Owner | Task prioritization |
-| Linux Server Engineers | Cloud instances |
-| DevOps Engineers | CI/CD integration |
-| Observability Engineers | AWS monitoring |
-| AWS Cloud Platform Architect | Implementation activities |
-| application teams | AWS resource requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AWS Cloud Product Owner | Task prioritization | Consumes From |
+| Linux Server Engineers | Cloud instances | Collaborates |
+| DevOps Engineers | CI/CD integration | Collaborates |
+| Observability Engineers | AWS monitoring | Collaborates |
+| AWS Cloud Platform Architect | Implementation activities | Escalates To |
+| application teams | AWS resource requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AWS Cloud Platform Product Owner manages the organization's Amazon Web Services portfolio and adoption roadmap. This role leads a team of AWS architects and engineers, ensuring that AWS cloud services deliver maximum business value while maintaining security, compliance, and cost efficiency.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — AWS platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** AWS technical architecture (AWS Cloud Platform Architect-owned); underlying database service strategy (Database Product Owner-owned, this role aligns to it); AWS control implementation detail (Security and Compliance teams-owned)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on platform requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Linux Server Product Owner | Amazon EC2 standards |
-| Database Product Owner | AWS database services strategy |
-| AWS Cloud Platform Architect | Technical strategy |
-| Application Product Owners | Platform requirements |
-| Security and Compliance teams | AWS controls |
-| IT leadership | Cloud investment strategies and priorities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Linux Server Product Owner | Amazon EC2 standards | Collaborates |
+| Database Product Owner | AWS database services strategy | Collaborates |
+| AWS Cloud Platform Architect | Technical strategy | Consumes From |
+| Application Product Owners | Platform requirements | Consumes From |
+| Security and Compliance teams | AWS controls | Governed By |
+| IT leadership | Cloud investment strategies and priorities | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | AWS Cloud Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The AWS Cloud Senior Engineer leads the implementation and optimization of complex Amazon Web Services solutions. This role provides technical leadership for AWS deployments, migrations, and operations while working closely with architects to translate cloud designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced AWS solution design and delivery within the AWS Cloud Architect's reference architecture
+- **Experience Anchor:** 5+ years in AWS engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** AWS platform architecture and technology standards (Architect-owned); underlying Linux host configuration (Linux Senior Engineers-owned, this role coordinates with it); EKS cluster architecture (Kubernetes Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** AWS Cloud Architect — solution design exceptions
+- **Escalated To By:** AWS Cloud Engineers on AWS services and best practices
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| AWS Cloud Platform Architect | Solution design and implementation strategy |
-| AWS Cloud Product Owner | Technical planning and roadmap execution |
-| Linux Senior Engineers | Cloud infrastructure |
-| Kubernetes Senior Engineers | EKS implementations |
-| Security Engineers | Cloud security controls |
-| AWS Cloud Engineers | AWS services and best practices |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| AWS Cloud Platform Architect | Solution design and implementation strategy | Escalates To |
+| AWS Cloud Product Owner | Technical planning and roadmap execution | Collaborates |
+| Linux Senior Engineers | Cloud infrastructure | Collaborates |
+| Kubernetes Senior Engineers | EKS implementations | Collaborates |
+| Security Engineers | Cloud security controls | Governed By |
+| AWS Cloud Engineers | AWS services and best practices | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Azure Cloud Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Azure Cloud Platform Architect designs, implements, and governs cloud solutions using Microsoft Azure. This role is responsible for creating a secure, scalable, and cost-effective cloud environment that aligns with business objectives and technical requirements.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Azure platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in Azure or cloud architecture with demonstrated architecture-level delivery — operates independently on domain-wide Azure architecture decisions within the Cloud Lead Architect's cross-platform standards
+- **Out of Scope:** Cross-platform architecture consistency (Cloud Lead Architect-owned, this role escalates cross-platform problems to it); Windows Server / hybrid identity infrastructure (Windows Server Architect-owned, this role aligns Entra ID to it); AKS cluster architecture (Kubernetes Architect-owned, this role coordinates with it)
+- **Escalates To:** Cloud Lead Architect — complex cross-platform cloud problems
+- **Escalated To By:** Azure Cloud Senior Engineers on solution design questions
 
 ## Business Impact
 
@@ -80,13 +90,13 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Architect | Microsoft Entra ID and hybrid services |
-| Kubernetes Architect | Azure Kubernetes Service implementations |
-| Database Architect | Azure database services |
-| Observability Architect | Azure Monitor and Log Analytics |
-| AWS Cloud Platform Architect | Multi-cloud strategies |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Architect | Microsoft Entra ID and hybrid services | Collaborates |
+| Kubernetes Architect | Azure Kubernetes Service implementations | Collaborates |
+| Database Architect | Azure database services | Collaborates |
+| Observability Architect | Azure Monitor and Log Analytics | Collaborates |
+| AWS Cloud Platform Architect | Multi-cloud strategies | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Azure Cloud Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Azure Cloud Engineer implements and maintains cloud resources and services in Microsoft Azure. Working with the Azure Cloud Platform Architect and Product Owner, this role ensures reliable, secure, and optimized Azure environments supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Azure resource provisioning and implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in Azure or cloud engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Azure architecture and solution design (Senior Engineers and the Architect-owned); underlying Windows Server hybrid services ownership (Windows Server Engineers-owned, this role coordinates with it); AKS implementation ownership (Kubernetes Engineers-owned, this role coordinates with it)
+- **Escalates To:** Azure Cloud Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on Azure resource requirements
 
 ## Business Impact
 
@@ -61,13 +71,13 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Azure Cloud Product Owner | Task prioritization |
-| Windows Server Engineers | Azure hybrid services |
-| Kubernetes Engineers | Azure Kubernetes Service |
-| Observability Engineers | Azure monitoring |
-| Azure Cloud Platform Architect | Implementation activities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Azure Cloud Product Owner | Task prioritization | Consumes From |
+| Windows Server Engineers | Azure hybrid services | Collaborates |
+| Kubernetes Engineers | Azure Kubernetes Service | Collaborates |
+| Observability Engineers | Azure monitoring | Collaborates |
+| Azure Cloud Platform Architect | Implementation activities | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Azure Cloud Platform Product Owner manages the organization's Azure cloud services portfolio and adoption strategy. This role leads a team of Azure architects and engineers, ensuring that Azure-based services deliver business value while maintaining security, compliance, and cost efficiency.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Azure platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Azure technical architecture (Azure Cloud Platform Architect-owned); hybrid Windows Server roadmap (Windows Server Product Owner-owned, this role aligns to it); AKS strategy (Kubernetes Product Owner-owned, this role aligns to it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on platform requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Product Owner | Hybrid cloud scenarios |
-| Kubernetes Product Owner | Azure Kubernetes Service strategy |
-| Azure Cloud Platform Architect | Technical decisions |
-| Application Product Owners | Platform requirements |
-| Security and Compliance teams | Cloud controls |
-| IT leadership | Cloud strategy and investment priorities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Product Owner | Hybrid cloud scenarios | Collaborates |
+| Kubernetes Product Owner | Azure Kubernetes Service strategy | Collaborates |
+| Azure Cloud Platform Architect | Technical decisions | Consumes From |
+| Application Product Owners | Platform requirements | Consumes From |
+| Security and Compliance teams | Cloud controls | Governed By |
+| IT leadership | Cloud strategy and investment priorities | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Azure Cloud Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Azure Cloud Senior Engineer leads the implementation and optimization of complex Azure cloud solutions. This role provides technical leadership for Azure deployments, migrations, and operations while working closely with architects to translate cloud designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Azure solution design and delivery within the Azure Cloud Architect's reference architecture
+- **Experience Anchor:** 5+ years in Azure engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Azure platform architecture and technology standards (Architect-owned); underlying Windows host configuration (Windows Senior Engineers-owned, this role coordinates with it); AKS cluster architecture (Kubernetes Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Azure Cloud Architect — solution design exceptions
+- **Escalated To By:** Azure Cloud Engineers on Azure services and best practices
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Azure Cloud Platform Architect | Solution design and implementation strategy |
-| Azure Cloud Product Owner | Technical planning and roadmap execution |
-| Windows Senior Engineers | Hybrid cloud solutions |
-| Kubernetes Senior Engineers | AKS implementations |
-| Security Engineers | Cloud security controls |
-| Azure Cloud Engineers | Azure services and best practices |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Azure Cloud Platform Architect | Solution design and implementation strategy | Escalates To |
+| Azure Cloud Product Owner | Technical planning and roadmap execution | Collaborates |
+| Windows Senior Engineers | Hybrid cloud solutions | Collaborates |
+| Kubernetes Senior Engineers | AKS implementations | Collaborates |
+| Security Engineers | Cloud security controls | Governed By |
+| Azure Cloud Engineers | Azure services and best practices | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Lead Architect |
+| **Reports To** | Cloud Principal Architect |
+| **Direct Reports** | None (provides technical oversight and mentorship to the AWS, Azure, and GCP Cloud Architects; formal line management sits with the Cloud, Platform & Infrastructure Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Cloud Lead Architect provides technical leadership across a cluster of cloud platform architects (Azure, AWS, GCP). This role bridges the gap between the cross-organizational cloud strategy set by the Principal Cloud Architect and the platform-specific designs delivered by individual platform architects. The Cloud Lead Architect ensures architectural coherence, governs design quality, and acts as the primary escalation point for complex cross-platform cloud problems.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-platform — architectural coherence and design quality across the AWS, Azure, and GCP Cloud Architects
+- **Experience Anchor:** 10+ years in cloud architecture with demonstrated cross-platform technical leadership — bridges the Principal Cloud Architect's strategy and the platform architects' designs, acting as primary escalation point for complex cross-platform problems
+- **Out of Scope:** Multi-year multi-cloud strategy setting (Cloud Principal Architect-owned, this role executes the platform-level guidance it translates); platform-specific implementation detail (AWS/Azure/GCP Cloud Architects-owned); formal line management of the platform architects (Cloud, Platform & Infrastructure Chapter Lead-owned)
+- **Escalates To:** Cloud Principal Architect — cross-organisational strategy questions
+- **Escalated To By:** AWS, Azure, and GCP Cloud Architects on complex cross-platform cloud problems
 
 ## Business Impact
 
@@ -63,14 +73,14 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Principal Cloud Architect | Translates it into platform-level guidance |
-| Azure, AWS, and GCP Cloud Architects | Coordinates and provides technical oversight |
-| Technical Area Lead (TAL) | Priorities, escalations, and cross-domain technical decisions |
-| Enterprise Architecture Senior Engineer | Ensure cloud patterns are captured in the EA repository |
-| Security and Compliance Architects | Ensure cross-platform security posture consistency |
-| FinOps | Ensure cost governance standards are applied consistently across all cloud platforms |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Principal Cloud Architect | Translates strategic direction into platform-level guidance | Escalates To |
+| Azure, AWS, and GCP Cloud Architects | Coordinates and provides technical oversight | Provides To |
+| Technical Area Lead (TAL) | Priorities, escalations, and cross-domain technical decisions | Collaborates |
+| Enterprise Architecture Senior Engineer | Ensure cloud patterns are captured in the EA repository | Collaborates |
+| Security and Compliance Architects | Ensure cross-platform security posture consistency | Governed By |
+| FinOps | Ensure cost governance standards are applied consistently across all cloud platforms | Governed By |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Principal Architect |
+| **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
+| **Direct Reports** | None (sets multi-cloud strategy; the Cloud Lead Architect and platform architects execute against it) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Cloud Principal Architect is the organization's foremost individual contributor for cloud technology strategy. Operating below the Technical Area Lead (TAL), this role shapes the multi-year, multi-cloud architecture vision and translates it into a coherent strategy that the Lead Cloud Architect and platform architects execute against. The Principal Cloud Architect sets the standard for how cloud technology is adopted, governed, and evolved across the organization — influencing decisions at the intersection of business strategy, engineering capability, and cloud innovation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Enterprise-wide — multi-year, multi-cloud architecture strategy and standards across the organisation
+- **Experience Anchor:** 12+ years in cloud architecture with demonstrated organisation-wide strategic ownership — operates independently below the TAL, shaping strategy the Cloud Lead Architect and platform architects execute against
+- **Out of Scope:** Day-to-day platform-specific architecture decisions (Cloud Lead Architect and platform Architects-owned); chapter-level people management of domain architects and senior engineers (Cloud, Platform & Infrastructure Chapter Lead-owned); business unit budget allocation (PAL/Finance-owned)
+- **Escalates To:** Technical Area Lead (TAL) — strategic direction and cross-chapter alignment
+- **Escalated To By:** Cloud Lead Architect on cross-platform strategy questions and architecture governance escalations
 
 ## Business Impact
 
@@ -64,15 +74,15 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Technical Area Lead (TAL) | Cloud technology strategy, roadmap alignment, and governance |
-| Cloud Lead Architect | Provides strategic direction and oversight |
-| PAL | Alignment between cloud investment and business outcomes |
-| Enterprise Architecture Senior Engineer | Ensure cloud strategy is reflected in the EA repository and roadmap |
-| Security and Compliance Architects | Cloud-wide security posture and policy |
-| FinOps | Cloud spend strategy, commitment optimization, and multi-year cost modelling |
-| cloud service provider advisory programs | Technical communities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Technical Area Lead (TAL) | Cloud technology strategy, roadmap alignment, and governance | Escalates To |
+| Cloud Lead Architect | Provides strategic direction and oversight | Provides To |
+| PAL | Alignment between cloud investment and business outcomes | Collaborates |
+| Enterprise Architecture Senior Engineer | Ensure cloud strategy is reflected in the EA repository and roadmap | Collaborates |
+| Security and Compliance Architects | Cloud-wide security posture and policy | Governed By |
+| FinOps | Cloud spend strategy, commitment optimization, and multi-year cost modelling | Collaborates |
+| cloud service provider advisory programs | Technical communities | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors GCP Cloud Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Google Cloud Architect designs comprehensive cloud solutions using Google Cloud Platform (GCP) services. This role establishes the technical vision for GCP implementations, creating architectures that balance performance, cost, security, and operational excellence while aligning with business objectives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — GCP platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in GCP or cloud architecture with demonstrated architecture-level delivery — operates independently on domain-wide GCP architecture decisions within the Cloud Lead Architect's cross-platform standards
+- **Out of Scope:** Cross-platform architecture consistency (Cloud Lead Architect-owned, this role escalates cross-platform problems to it); enterprise architecture strategic alignment (Enterprise Architects-owned, this role aligns to it); GKE cluster architecture (Kubernetes Architect-owned, this role coordinates with it)
+- **Escalates To:** Cloud Lead Architect — complex cross-platform cloud problems
+- **Escalated To By:** GCP Cloud Senior Engineers on solution design questions
 
 ## Business Impact
 
@@ -62,14 +72,14 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Strategic alignment |
-| Security Architects | GCP security design |
-| Network Architects | Cloud connectivity |
-| GCP Cloud Product Owner | Technical strategy |
-| GCP Cloud Senior Engineers |  |
-| application architects | Cloud migration |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Strategic alignment | Governed By |
+| Security Architects | GCP security design | Governed By |
+| Network Architects | Cloud connectivity | Collaborates |
+| GCP Cloud Product Owner | Technical strategy | Collaborates |
+| GCP Cloud Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| application architects | Cloud migration | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | GCP Cloud Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Google Cloud Engineer implements and maintains cloud resources and services in Google Cloud Platform (GCP). Working with the GCP Cloud Architect and Product Owner, this role ensures reliable, secure, and optimized GCP environments supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of GCP resource provisioning and implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in GCP or cloud engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** GCP architecture and solution design (Senior Engineers and the Architect-owned); underlying Linux instance configuration ownership (Linux Server Engineers-owned, this role coordinates with it); CI/CD pipeline design (DevOps Engineers-owned, this role integrates with it)
+- **Escalates To:** GCP Cloud Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on GCP resource requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| GCP Cloud Product Owner | Task prioritization |
-| Linux Server Engineers | Cloud instances |
-| DevOps Engineers | CI/CD integration |
-| Observability Engineers | GCP monitoring |
-| GCP Cloud Architect | Implementation activities |
-| application teams | GCP resource requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| GCP Cloud Product Owner | Task prioritization | Consumes From |
+| Linux Server Engineers | Cloud instances | Collaborates |
+| DevOps Engineers | CI/CD integration | Collaborates |
+| Observability Engineers | GCP monitoring | Collaborates |
+| GCP Cloud Architect | Implementation activities | Escalates To |
+| application teams | GCP resource requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Google Cloud Product Owner manages the development and lifecycle of the organization's Google Cloud Platform (GCP) services portfolio. This role leads a team of GCP architects and engineers, ensuring that cloud services meet business requirements, cost objectives, and operational standards while aligning with the organization's cloud strategy.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — GCP platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** GCP technical architecture (GCP Cloud Architect-owned); cloud cost governance strategy (FinOps Team-owned, this role aligns to it); GCP compliance control implementation (security teams-owned)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on cloud requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| FinOps Team | Cloud cost management |
-| GCP Cloud Architect | Technical strategy |
-| Application Product Owners | Cloud requirements |
-| security teams | Cloud compliance requirements |
-| application teams | GCP service adoption |
-| IT leadership | Cloud strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| FinOps Team | Cloud cost management | Collaborates |
+| GCP Cloud Architect | Technical strategy | Consumes From |
+| Application Product Owners | Cloud requirements | Consumes From |
+| security teams | Cloud compliance requirements | Governed By |
+| application teams | GCP service adoption | Provides To |
+| IT leadership | Cloud strategy and investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | GCP Cloud Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Google Cloud Senior Engineer leads the implementation and optimization of complex Google Cloud Platform (GCP) solutions. This role provides technical leadership for GCP deployments, migrations, and operations while working closely with architects to translate cloud designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced GCP solution design and delivery within the GCP Cloud Architect's reference architecture
+- **Experience Anchor:** 5+ years in GCP engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** GCP platform architecture and technology standards (Architect-owned); underlying Linux host configuration (Linux Senior Engineers-owned, this role coordinates with it); GKE cluster architecture (Kubernetes Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** GCP Cloud Architect — solution design exceptions
+- **Escalated To By:** GCP Cloud Engineers on GCP services and best practices
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| GCP Cloud Architect | Solution design and implementation strategy |
-| GCP Cloud Product Owner | Technical planning and roadmap execution |
-| Linux Senior Engineers | Cloud infrastructure |
-| Kubernetes Senior Engineers | GKE implementations |
-| Security Engineers | Cloud security controls |
-| GCP Cloud Engineers | GCP services and best practices |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| GCP Cloud Architect | Solution design and implementation strategy | Escalates To |
+| GCP Cloud Product Owner | Technical planning and roadmap execution | Collaborates |
+| Linux Senior Engineers | Cloud infrastructure | Collaborates |
+| Kubernetes Senior Engineers | GKE implementations | Collaborates |
+| Security Engineers | Cloud security controls | Governed By |
+| GCP Cloud Engineers | GCP services and best practices | Provides To |
 
 ## Key Technologies
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Kubernetes Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Kubernetes Architect is responsible for designing and evolving container orchestration strategies that support modern application architectures. This role establishes the technical direction, standards, and best practices for Kubernetes platforms across the organization.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Kubernetes platform architecture, cluster standards, and container orchestration strategy across the chapter
+- **Experience Anchor:** 8+ years in Kubernetes or container platform architecture with demonstrated architecture-level delivery — operates independently on domain-wide Kubernetes architecture decisions
+- **Out of Scope:** Cloud-managed Kubernetes service selection (Cloud Architects-owned, this role aligns cluster design to it); container security control implementation (Security Architects-owned, this role implements standards from it); CI/CD pipeline design beyond cluster integration (DevOps teams-owned, this role coordinates with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Kubernetes Engineers and Senior Engineers on technical guidance requests
 
 ## Business Impact
 
@@ -144,18 +154,18 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 - Cloud Native Transformation Leader
 - Distinguished Engineer
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Platform Architect | Kubernetes-based data orchestration, Apache Spark/Flink on Kubernetes, and ML pipeline infrastructure (Kubeflow, Ray) |
-| Integration Architect | Service mesh cross-domain integration patterns, east-west traffic governance, and inter-service API standards |
-| Kubernetes Product Owner | Strategy and roadmap |
-| Kubernetes Engineers and Senior Engineers | Technical guidance |
-| Security Architects | Container security standards |
-| Cloud Architects | Align with cloud platform strategies |
-| application teams | Containerization approaches |
-| DevOps teams | CI/CD integration with Kubernetes |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Platform Architect | Kubernetes-based data orchestration, Apache Spark/Flink on Kubernetes, and ML pipeline infrastructure (Kubeflow, Ray) | Collaborates |
+| Integration Architect | Service mesh cross-domain integration patterns, east-west traffic governance, and inter-service API standards | Collaborates |
+| Kubernetes Product Owner | Strategy and roadmap | Collaborates |
+| Kubernetes Engineers and Senior Engineers | Technical guidance | Provides To |
+| Security Architects | Container security standards | Governed By |
+| Cloud Architects | Align with cloud platform strategies | Collaborates |
+| application teams | Containerization approaches | Provides To |
+| DevOps teams | CI/CD integration with Kubernetes | Collaborates |
 
 ## Key Performance Indicators
 

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Kubernetes Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Kubernetes Engineer implements and maintains Kubernetes environments, ensuring stable, secure, and performant container orchestration platforms. This role is responsible for day-to-day operations, troubleshooting, and implementation of standard Kubernetes components and configurations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of container deployment and cluster operations tasks to defined standards
+- **Experience Anchor:** 1-3 years in Kubernetes or container engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Kubernetes architecture and cluster design (Senior Engineers and the Architect-owned); underlying infrastructure platform ownership (infrastructure teams-owned, this role coordinates with it); CI/CD pipeline design (CI/CD teams-owned, this role integrates deployments with it)
+- **Escalates To:** Kubernetes Senior Engineers and Architect — day-to-day guidance and direction
+- **Escalated To By:** application teams on containerized workload support
 
 ## Business Impact
 
@@ -68,15 +78,15 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 - **Working Knowledge required:** GitOps deployment tools (ArgoCD, Flux) for declarative workload delivery, Linux system administration and container OS fundamentals (cgroups, namespaces, systemd)
 - **Awareness level expected:** Service mesh concepts (Istio, Linkerd) for advanced traffic management and mTLS, Cloud-managed Kubernetes platforms (AKS, EKS, GKE) for cloud-specific deployment and operations
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| application teams | Containerized workloads |
-| infrastructure teams | Underlying platforms |
-| security teams | Container security implementations |
-| CI/CD teams | Deployment pipeline integration |
-| Kubernetes Senior Engineers and Architect | Day-to-day guidance and direction |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| application teams | Containerized workloads | Provides To |
+| infrastructure teams | Underlying platforms | Collaborates |
+| security teams | Container security implementations | Governed By |
+| CI/CD teams | Deployment pipeline integration | Collaborates |
+| Kubernetes Senior Engineers and Architect | Day-to-day guidance and direction | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Kubernetes Product Owner manages the container platform roadmap and service portfolio, ensuring the Kubernetes environment meets the needs of application teams and aligns with organizational goals. This role prioritizes platform enhancements, coordinates the implementation schedule, and serves as the business liaison for container initiatives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Kubernetes platform backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Kubernetes technical architecture (Kubernetes Architect-owned); enterprise architecture standards alignment (enterprise architecture-owned, this role aligns to it); cross-cloud Kubernetes service roadmap ownership (other Product Owners-owned, this role coordinates integration points with them)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** application teams on containerization requirements
 
 ## Business Impact
 
@@ -67,16 +77,16 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 - **Working Knowledge required:** Kubernetes governance tools (OPA, Kyverno, Gatekeeper) for informing policy product decisions, Cloud-managed Kubernetes services (AKS, EKS, GKE) from a service catalogue and cost perspective
 - **Awareness level expected:** Service mesh capabilities (Istio, Linkerd) for evaluating advanced platform feature roadmap items, FinOps tooling for Kubernetes cost visibility, namespace-level chargeback, and reserved capacity
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Kubernetes Architect | Platform strategy and design |
-| Kubernetes Engineers | Implementation priorities |
-| application teams | Understand containerization requirements |
-| enterprise architecture | Alignment with standards |
-| other Product Owners | Integration points |
-| IT leadership | Container platform value and metrics |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Kubernetes Architect | Platform strategy and design | Consumes From |
+| Kubernetes Engineers | Implementation priorities | Provides To |
+| application teams | Understand containerization requirements | Consumes From |
+| enterprise architecture | Alignment with standards | Governed By |
+| other Product Owners | Integration points | Collaborates |
+| IT leadership | Container platform value and metrics | Provides To |
 
 ## Key Performance Indicators
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Kubernetes Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Kubernetes Senior Engineer leads complex containerization initiatives and advanced implementations, providing technical leadership for container orchestration platforms. This role focuses on automation, platform optimization, and solving complex challenges in Kubernetes environments while mentoring other team members.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Kubernetes cluster design and delivery within the Kubernetes Architect's reference architecture
+- **Experience Anchor:** 5+ years in Kubernetes engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Kubernetes platform architecture and standards (Architect-owned); CI/CD pipeline design (DevOps teams-owned, this role integrates advanced pipeline patterns with it); container security policy definition (security teams-owned, this role implements controls)
+- **Escalates To:** Kubernetes Architect — platform design exceptions
+- **Escalated To By:** Kubernetes Engineers on technical matters
 
 ## Business Impact
 
@@ -69,15 +79,15 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 - **Working Knowledge required:** Infrastructure as Code (Terraform, Pulumi) for cluster provisioning and lifecycle management, Multi-cluster management platforms (Rancher, VMware Tanzu, Red Hat OpenShift)
 - **Awareness level expected:** eBPF-based networking and security (Cilium, Hubble, Tetragon) for next-generation cluster observability, WASM and container-native computing patterns for edge and serverless Kubernetes workloads
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Kubernetes Architect | Platform design decisions |
-| Kubernetes Engineers | Technical matters |
-| DevOps teams | Advanced pipeline integrations |
-| application architects | Container strategy |
-| security teams | Container security implementations |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Kubernetes Architect | Platform design decisions | Escalates To |
+| Kubernetes Engineers | Technical matters | Provides To |
+| DevOps teams | Advanced pipeline integrations | Collaborates |
+| application architects | Container strategy | Collaborates |
+| security teams | Container security implementations | Governed By |
 
 ## Key Performance Indicators
 

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Site Reliability Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Chaos Engineer designs, implements, and executes controlled failure experiments to proactively validate the resilience and reliability of distributed systems, cloud infrastructure, and microservices. Rather than waiting for production incidents to expose weaknesses, Chaos Engineering deliberately injects failures - network partitions, pod terminations, resource exhaustion, latency injection - to verify that systems behave as expected under failure conditions and that monitoring and alerting correctly detects them. This role operates at the intersection of SRE, platform engineering, and quality engineering.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — chaos engineering experiment design, fault injection tooling, and resilience validation
+- **Experience Anchor:** 3-5 years in site reliability or resilience engineering — operates independently within the SRE practice's SLO framework
+- **Out of Scope:** SLO framework and reliability strategy (Site Reliability Senior Engineer-owned, this role validates it through experiments); internal developer platform design (Platform Engineering-owned, this role integrates chaos tooling with it); monitoring platform architecture (Observability Engineers-owned, this role validates alerting through it)
+- **Escalates To:** Site Reliability Senior Engineer — SLO validation findings and incident readiness gaps
+- **Escalated To By:** Engineering Squads on chaos experiment scheduling and remediation guidance
 
 ## Business Impact
 
@@ -76,13 +86,13 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| SRE / Senior SRE: | Collaborate on SLO validation and incident readiness |
-| Platform Engineering: | Design chaos tooling integration with internal developer platforms |
-| Engineering Squads: | Run experiments on their services; communicate findings and guide remediation |
-| Observability Engineers: | Validate alerting and monitoring effectiveness during fault injection |
-| Security Engineers: | Ensure experiment tooling and processes meet security requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| SRE / Senior SRE | Collaborate on SLO validation and incident readiness | Escalates To |
+| Platform Engineering | Design chaos tooling integration with internal developer platforms | Collaborates |
+| Engineering Squads | Run experiments on their services; communicate findings and guide remediation | Provides To |
+| Observability Engineers | Validate alerting and monitoring effectiveness during fault injection | Collaborates |
+| Security Engineers | Ensure experiment tooling and processes meet security requirements | Governed By |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors the GenAI Platform Engineer; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-07 |
 
 ---
@@ -60,17 +62,16 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| MLOps Engineers | Pipeline implementation and model deployment |
-| Security Architects | AI security controls and LLM governance |
-| Cloud Platform Architects | (Azure, AWS, GCP) on AI service integration |
-| Platform Engineering Architect | IDP integration of AI tooling |
-| FinOps Architect | AI/LLM cost governance |
-| Enterprise Architects | AI platform strategy and roadmap |
-| Data Scientists | Platform capabilities and golden paths |
-| AI Engineers | Platform capabilities and golden paths |
-| AI Platform Architect (AI Governance) | Alignment between classical MLOps platform architecture and GenAI/LLM platform architecture |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| MLOps Engineers | Pipeline implementation and model deployment | Collaborates |
+| Security Architects | AI security controls and LLM governance | Governed By |
+| Cloud Platform Architects (Azure, AWS, GCP) | AI service integration | Collaborates |
+| Platform Engineering Architect | IDP integration of AI tooling | Collaborates |
+| FinOps Architect | AI/LLM cost governance | Governed By |
+| Enterprise Architects | AI platform strategy and roadmap | Governed By |
+| Data Scientists and AI Engineers | Platform capabilities and golden paths | Provides To |
+| AI Platform Architect (AI Governance) | Alignment between classical MLOps platform architecture and GenAI/LLM platform architecture | Collaborates |
 
 ## Key Technologies
 
@@ -117,6 +118,14 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 - Knowledge transfer and enablement effectiveness
 - Edge AI model deployment coverage: ≥80% of approved edge AI workloads served via standardised edge inference patterns
 - Edge inference latency: p95 inference latency within agreed SLA for latency-sensitive edge AI applications
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — GenAI/LLM platform architecture, AI service integration, and generative AI tooling strategy across the chapter
+- **Experience Anchor:** 8+ years in AI/ML or platform architecture with demonstrated GenAI platform ownership — operates independently on domain-wide GenAI platform architecture decisions
+- **Out of Scope:** Classical MLOps platform architecture (AI Platform Architect in AI Governance-owned, this role aligns GenAI platform design with it); AI governance and risk framework (Security Architects-owned, this role implements AI security controls and LLM governance from it); cloud AI service selection detail (Cloud Platform Architects-owned, this role integrates with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** the GenAI Platform Engineer on platform delivery questions
 
 ## Business Impact
 

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | GenAI Platform Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-07 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The GenAI Platform Engineer implements and maintains the infrastructure, tooling, and pipelines that enable engineering and data science teams to build, deploy, and operate AI and generative AI applications in production. This role focuses on the day-to-day delivery of reliable, secure, and cost-efficient AI infrastructure, including LLM serving, RAG pipelines, vector databases, agentic workflow infrastructure, and AI observability tooling. This role is distinct from the AI Platform Engineer in AI Governance, which builds and operates classical MLOps pipelines (feature stores, model training, model registries) — the GenAI Platform Engineer operates the infrastructure layer specific to large language models and agentic AI.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of GenAI/LLM platform implementation, pipeline integration, and IDP tooling tasks
+- **Experience Anchor:** 3-5 years in AI/ML or platform engineering — operates independently within the GenAI Platform Architect's reference architecture
+- **Out of Scope:** GenAI platform architecture and technology standards (Architect-owned); ML pipeline architecture (MLOps Engineers-owned, this role integrates with it); AI security control design (Security Engineers-owned, this role implements it)
+- **Escalates To:** GenAI Platform Architect — platform delivery decisions
+- **Escalated To By:** Data Scientists and AI Engineers on platform tooling support
 
 ## Business Impact
 
@@ -66,16 +76,15 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| MLOps Engineers | ML pipeline integration |
-| Data Scientists | Platform tooling |
-| AI Engineers | Platform tooling |
-| DevOps Engineers | CI/CD pipeline automation |
-| Security Engineers | AI security control implementation |
-| Cloud Engineers | Cloud AI service configuration |
-| Platform Engineering Engineers | IDP integration |
-| GenAI Platform Architect | Platform delivery |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| MLOps Engineers | ML pipeline integration | Collaborates |
+| Data Scientists and AI Engineers | Platform tooling | Provides To |
+| DevOps Engineers | CI/CD pipeline automation | Collaborates |
+| Security Engineers | AI security control implementation | Governed By |
+| Cloud Engineers | Cloud AI service configuration | Collaborates |
+| Platform Engineering Engineers | IDP integration | Collaborates |
+| GenAI Platform Architect | Platform delivery | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/infrastructure_automation_architect.md
+++ b/Roles/modern_infrastructure/infrastructure_automation_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Infrastructure Automation Architect designs and governs the organisation's end-to-end infrastructure automation strategy — spanning Infrastructure as Code (IaC), configuration management, event-driven automation, runbook automation, and self-healing infrastructure patterns. This role owns the automation standards, reusable module libraries, and automation governance frameworks that cloud and platform teams build upon, ensuring consistency, security, and operational efficiency across all infrastructure provisioning and management activities. The Infrastructure Automation Architect bridges the gap between infrastructure engineering and platform operations, establishing automation as a first-class engineering discipline across the organisation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — infrastructure-as-code (IaC) module standards, compliance-as-code, and automation architecture across the chapter
+- **Experience Anchor:** 8+ years in infrastructure automation or platform architecture with demonstrated IaC programme ownership — operates independently on domain-wide automation architecture decisions
+- **Out of Scope:** Cloud platform-specific service architecture (Azure/AWS/GCP Cloud Architects-owned, this role aligns automation standards to each); CI/CD pipeline platform design (DevOps Architect-owned, this role integrates IaC automation into it); observability signal design (Observability Architect-owned, this role builds remediation triggers from it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Infrastructure Engineers on IaC design pattern and module development questions
 
 ## Business Impact
 
@@ -75,17 +85,16 @@ The Infrastructure Automation Architect designs and governs the organisation's e
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Azure Cloud Architect | **AWS Cloud Architect**, and **GCP Cloud Architect** to define automation standards that align with each cloud platform's native capabilities and governance model |
-| DevOps Architect | CI/CD pipeline automation integration — ensuring IaC modules, compliance gates, and drift detection fit within delivery pipeline patterns |
-| Observability Architect | Design automated remediation triggers based on observability signals and to ensure automation activities produce appropriate audit telemetry |
-| ITSM Architect | Service management teams on runbook automation integration with ServiceNow Orchestration and change management workflows |
-| Kubernetes Architect | GitOps-based cluster automation, namespace provisioning patterns, and cluster lifecycle management automation |
-| Security Architect | Embed compliance-as-code controls and security guardrails into IaC module standards and automation pipelines |
-| Infrastructure Automation Senior Engineers | IaC design patterns and module development |
-| Infrastructure Engineers | IaC design patterns and module development |
-| FinOps team | Infracost integration, budget guardrails in IaC pipelines, and cost governance standards |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Azure, AWS, and GCP Cloud Architects | Define automation standards that align with each cloud platform's native capabilities and governance model | Collaborates |
+| DevOps Architect | CI/CD pipeline automation integration — ensuring IaC modules, compliance gates, and drift detection fit within delivery pipeline patterns | Collaborates |
+| Observability Architect | Design automated remediation triggers based on observability signals and to ensure automation activities produce appropriate audit telemetry | Collaborates |
+| ITSM Architect | Runbook automation integration with ServiceNow Orchestration and change management workflows | Collaborates |
+| Kubernetes Architect | GitOps-based cluster automation, namespace provisioning patterns, and cluster lifecycle management automation | Collaborates |
+| Security Architect | Embed compliance-as-code controls and security guardrails into IaC module standards and automation pipelines | Governed By |
+| Infrastructure Automation Senior Engineers and Infrastructure Engineers | IaC design patterns and module development | Provides To |
+| FinOps team | Infracost integration, budget guardrails in IaC pipelines, and cost governance standards | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | GenAI Platform Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The MLOps Engineer implements and maintains platforms and pipelines that enable data science and AI teams to efficiently develop, deploy, and operate machine learning and generative AI models in production. This role bridges the gap between data science, AI engineering, and operations, ensuring ML/LLM models are reliable, scalable, observable, and governed in production environments.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — ML pipeline automation, model deployment infrastructure, and cloud ML service integration
+- **Experience Anchor:** 3-5 years in MLOps or platform engineering — operates independently within the GenAI Platform Architect's reference architecture
+- **Out of Scope:** GenAI/LLM platform architecture (GenAI Platform Architect-owned); data pipeline architecture upstream of model training (Data Engineers-owned, this role integrates with it); infrastructure automation module governance (Platform Engineers-owned, this role integrates with it)
+- **Escalates To:** GenAI Platform Architect — ML pipeline platform decisions
+- **Escalated To By:** Data Scientists on model deployment requirements
 
 ## Business Impact
 
@@ -66,14 +76,14 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Data Engineers | Data pipeline integration |
-| DevOps Engineers | Infrastructure automation |
-| Platform Engineers | Platform integration |
-| Cloud Engineers | Cloud services for ML |
-| Application Teams | Model integration |
-| Data Scientists | Model deployment requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Data Engineers | Data pipeline integration | Collaborates |
+| DevOps Engineers | Infrastructure automation | Collaborates |
+| Platform Engineers | Platform integration | Collaborates |
+| Cloud Engineers | Cloud services for ML | Collaborates |
+| Application Teams | Model integration | Provides To |
+| Data Scientists | Model deployment requirements | Consumes From |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Observability Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Observability Architect designs and governs the organisation's full-stack observability strategy, covering metrics, distributed tracing, structured logging, alerting frameworks, and SLO/SLA design. This role owns the observability platform architecture and toolchain, ensuring that engineers, SREs, and operations teams have the signals they need to detect issues, investigate incidents, and meet reliability commitments. The Observability Architect sets organisation-wide instrumentation standards, governs telemetry pipelines, and drives observability culture across engineering teams operating across cloud-native, hybrid, and multi-cloud environments.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — observability platform architecture, telemetry pipeline standards, and SLO framework design across the chapter
+- **Experience Anchor:** 8+ years in observability or SRE architecture with demonstrated architecture-level delivery — operates independently on domain-wide observability architecture decisions
+- **Out of Scope:** Cloud-native monitoring service selection (Cloud Architects-owned, this role aligns platform design to it); security event monitoring policy (Security Architect-owned, this role integrates with SIEM per its requirements); CI/CD pipeline design (DevOps Architect-owned, this role integrates observability into it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Observability Senior Engineers and Engineers on platform implementation and instrumentation standards
 
 ## Business Impact
 
@@ -76,18 +86,16 @@ The Observability Architect designs and governs the organisation's full-stack ob
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Azure Cloud Architect | , **AWS Cloud Architect**, and **GCP Cloud Architect** to align observability platform with cloud-native monitoring services (Azure Monitor, CloudWatch, Cloud Operations Suite) |
-| Kubernetes Architect | Cluster observability, workload metrics collection, and service mesh telemetry design |
-| Site Reliability Engineers | SLO framework implementation, error budget policies, and incident detection engineering |
-| Senior Site Reliability Engineers | SLO framework implementation, error budget policies, and incident detection engineering |
-| Security Architect | Security event monitoring, telemetry pipeline access controls, and integration with SIEM platforms |
-| DevOps Architect | Observability integration within CI/CD pipelines (deployment tracking, release impact analysis, and pipeline performance metrics) |
-| Data Platform Architect | Telemetry data pipeline patterns and event streaming for observability data feeds |
-| Observability Product Owner | Platform roadmap prioritisation and capability investment decisions |
-| Observability Senior Engineers | Platform implementation and instrumentation standards |
-| Observability Engineers | Platform implementation and instrumentation standards |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Azure, AWS, and GCP Cloud Architects | Align observability platform with cloud-native monitoring services (Azure Monitor, CloudWatch, Cloud Operations Suite) | Collaborates |
+| Kubernetes Architect | Cluster observability, workload metrics collection, and service mesh telemetry design | Collaborates |
+| Site Reliability Engineers and Senior Engineers | SLO framework implementation, error budget policies, and incident detection engineering | Collaborates |
+| Security Architect | Security event monitoring, telemetry pipeline access controls, and integration with SIEM platforms | Governed By |
+| DevOps Architect | Observability integration within CI/CD pipelines (deployment tracking, release impact analysis, and pipeline performance metrics) | Collaborates |
+| Data Platform Architect | Telemetry data pipeline patterns and event streaming for observability data feeds | Collaborates |
+| Observability Product Owner | Platform roadmap prioritisation and capability investment decisions | Collaborates |
+| Observability Senior Engineers and Engineers | Platform implementation and instrumentation standards | Provides To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Observability Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Observability Engineer implements and maintains monitoring, logging, and tracing solutions that provide visibility into IT systems and applications. This role focuses on configuring observability tools, creating dashboards and alerts, and ensuring effective collection of telemetry data across the enterprise.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of monitoring implementation and alert integration tasks to defined standards
+- **Experience Anchor:** 1-3 years in observability or monitoring engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Observability architecture and platform design (Senior Engineers and the Architect-owned); underlying infrastructure platform ownership (infrastructure teams-owned, this role monitors it); operational alert response ownership (operations teams-owned, this role integrates alerting with it)
+- **Escalates To:** Senior Observability Engineers and Architect — day-to-day guidance and direction
+- **Escalated To By:** service desk on troubleshooting using monitoring data
 
 ## Business Impact
 
@@ -67,15 +77,15 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 - **Working Knowledge required:** Kubernetes monitoring stack (kube-state-metrics, node exporter, metrics-server), Alertmanager, PagerDuty, and OpsGenie for alert routing and on-call notification, Scripting and automation for monitoring configuration and dashboard-as-code
 - **Awareness level expected:** AI/ML-assisted anomaly detection capabilities in modern observability platforms, eBPF-based observability tooling and low-overhead profiling approaches
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| application teams | Monitoring implementation |
-| infrastructure teams | Platform monitoring |
-| operations teams | Alert integration |
-| service desk with monitoring data | Troubleshooting |
-| Senior Observability Engineers and Architect | Day-to-day guidance and direction |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| application teams | Monitoring implementation | Provides To |
+| infrastructure teams | Platform monitoring | Collaborates |
+| operations teams | Alert integration | Collaborates |
+| service desk | Troubleshooting using monitoring data | Provides To |
+| Senior Observability Engineers and Architect | Day-to-day guidance and direction | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Observability Product Owner manages the observability platform portfolio, defining requirements and priorities for monitoring, logging, and tracing services. This role ensures that observability platforms meet the needs of all stakeholders and align with business objectives for system reliability and performance visibility.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — observability platform backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Observability technical architecture (Observability Architect-owned); incident management process ownership (IT operations-owned, this role integrates roadmap with it); cross-service integration ownership (other Product Owners-owned, this role coordinates with them)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** application teams on monitoring requirements
 
 ## Business Impact
 
@@ -67,16 +77,16 @@ The Observability Product Owner manages the observability platform portfolio, de
 - **Working Knowledge required:** OpenTelemetry instrumentation concepts and team adoption patterns, Distributed tracing systems (Jaeger, Zipkin) and APM tool features, Time-series database concepts, cardinality management, and telemetry cost governance
 - **Awareness level expected:** AI-assisted root cause analysis and AIOps capabilities in observability platforms, eBPF-based observability and continuous profiling as emerging product features
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Observability Architect | Platform strategy |
-| Observability Engineers | Implementation priorities |
-| application teams | Understand monitoring requirements |
-| IT operations | Incident management integration |
-| other Product Owners | Service integration |
-| IT leadership | Observability platform value |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Observability Architect | Platform strategy | Consumes From |
+| Observability Engineers | Implementation priorities | Provides To |
+| application teams | Understand monitoring requirements | Consumes From |
+| IT operations | Incident management integration | Collaborates |
+| other Product Owners | Service integration | Collaborates |
+| IT leadership | Observability platform value | Provides To |
 
 ## Key Performance Indicators
 

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Observability Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Observability Senior Engineer leads advanced observability projects, focusing on complex implementations, platform optimization, and advanced analytics. This role develops sophisticated monitoring strategies, implements advanced observability patterns, and mentors team members while driving innovation in system visibility approaches.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced observability solution design and delivery within the Observability Architect's reference architecture
+- **Experience Anchor:** 5+ years in observability or monitoring engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Observability platform architecture and standards (Architect-owned); SRE SLO framework ownership (SRE and platform teams-owned, this role supports advanced monitoring for it); security monitoring policy definition (security teams-owned, this role implements patterns)
+- **Escalates To:** Observability Architect — platform design exceptions
+- **Escalated To By:** Observability Engineers on mentoring and technical guidance
 
 ## Business Impact
 
@@ -69,15 +79,15 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 - **Working Knowledge required:** AI/ML-based anomaly detection and intelligent alerting systems, Observability-as-code frameworks and IaC tooling for telemetry configuration, Real-time analytics platforms for high-cardinality telemetry data processing
 - **Awareness level expected:** eBPF-based continuous profiling tools (Parca, Pyroscope), OpenTelemetry emerging signals (profiling, events)
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Observability Architect | Platform design |
-| SRE and platform teams | Advanced monitoring |
-| application architects | Advanced instrumentation |
-| security teams | Security monitoring patterns |
-| Observability Engineers | Mentoring and technical guidance |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Observability Architect | Platform design | Escalates To |
+| SRE and platform teams | Advanced monitoring | Collaborates |
+| application architects | Advanced instrumentation | Collaborates |
+| security teams | Security monitoring patterns | Governed By |
+| Observability Engineers | Mentoring and technical guidance | Provides To |
 
 ## Key Performance Indicators
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Platform Engineering Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Platform Engineering Architect designs comprehensive internal developer platforms that enable application teams to efficiently build, deploy, and operate their services. This role establishes the technical vision for developer experience, creating architectures that balance self-service capabilities with governance and operational excellence.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — internal platform engineering architecture and infrastructure self-service standards across the chapter
+- **Experience Anchor:** 8+ years in platform engineering or infrastructure architecture with demonstrated architecture-level delivery — operates independently on domain-wide platform architecture decisions
+- **Out of Scope:** Cloud infrastructure provisioning architecture (Cloud Platform Architects-owned, this role integrates with it); CI/CD pipeline strategy (DevOps Architects-owned, this role aligns to it); security control design (Security Architects-owned, this role implements secure platform design from it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Platform Engineering Senior Engineers on solution design questions
 
 ## Business Impact
 
@@ -65,14 +75,14 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Cloud Platform Architects | Infrastructure integration |
-| DevOps Architects | CI/CD strategy |
-| Security Architects | Secure platform design |
-| Platform Engineering Product Owner | Technical strategy |
-| Platform Engineering Senior Engineers |  |
-| application architects | Platform requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Cloud Platform Architects | Infrastructure integration | Collaborates |
+| DevOps Architects | CI/CD strategy | Collaborates |
+| Security Architects | Secure platform design | Governed By |
+| Platform Engineering Product Owner | Technical strategy | Collaborates |
+| Platform Engineering Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| application architects | Platform requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Platform Engineering Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Platform Engineering Engineer implements and maintains internal developer platforms that enable application teams to efficiently build, deploy, and operate their services. This role focuses on creating self-service capabilities, automation, and tooling that improve the developer experience and accelerate software delivery.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of internal platform implementation tasks to defined standards
+- **Experience Anchor:** 1-3 years in platform engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Platform engineering architecture and solution design (Senior Engineers and the Architect-owned); CI/CD pipeline design (DevOps Engineers-owned, this role integrates with it); container platform implementation ownership (Kubernetes Engineers-owned, this role coordinates with it)
+- **Escalates To:** Platform Engineering Senior Engineers — design-level questions and complex implementation issues
+- **Escalated To By:** application developers on platform usage support
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Platform Engineering Product Owner | Task prioritization |
-| DevOps Engineers | Pipeline integration |
-| Kubernetes Engineers | Container platforms |
-| Cloud Engineers | Infrastructure services |
-| Platform Engineering Senior Engineers |  |
-| application developers | Platform usage |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Platform Engineering Product Owner | Task prioritization | Consumes From |
+| DevOps Engineers | Pipeline integration | Collaborates |
+| Kubernetes Engineers | Container platforms | Collaborates |
+| Cloud Engineers | Infrastructure services | Collaborates |
+| Platform Engineering Senior Engineers | Escalate complex issues; receive implementation guidance | Escalates To |
+| application developers | Platform usage | Provides To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Platform Engineering Product Owner manages the roadmap and development of internal developer platforms that enable application teams to build, deploy, and operate their services efficiently. This role leads a team of platform engineers, ensuring that the developer experience meets the needs of application teams while maintaining operational excellence.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — internal platform engineering backlog, roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Platform engineering technical architecture (Platform Engineering Architect-owned); CI/CD roadmap ownership (DevOps Product Owner-owned, this role aligns to it); cloud infrastructure service roadmap (Cloud Platform Product Owners-owned, this role coordinates with them)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** development team leaders on platform adoption support
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| DevOps Product Owner | CI/CD integration |
-| Cloud Platform Product Owners | Infrastructure services |
-| Platform Engineering Architect | Technical strategy |
-| Application Product Owners | Developer requirements |
-| development team leaders | Platform adoption |
-| IT leadership | Platform strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| DevOps Product Owner | CI/CD integration | Collaborates |
+| Cloud Platform Product Owners | Infrastructure services | Collaborates |
+| Platform Engineering Architect | Technical strategy | Consumes From |
+| Application Product Owners | Developer requirements | Consumes From |
+| development team leaders | Platform adoption | Provides To |
+| IT leadership | Platform strategy and investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Platform Engineering Senior Engineer leads the implementation and optimization of developer platforms that enable application teams to efficiently build, deploy, and operate their services. This role provides technical leadership for internal platform development while working closely with architects to create effective self-service capabilities.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced platform engineering solution design and delivery within the Platform Engineering Architect's reference architecture
+- **Experience Anchor:** 5+ years in platform engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Platform engineering architecture and standards (Architect-owned); DevOps pipeline design (DevOps Senior Engineers-owned, this role integrates with it); container platform architecture (Kubernetes Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Platform Engineering Architect — solution design exceptions
+- **Escalated To By:** Platform Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Platform Engineering Architect | Solution design |
-| Platform Engineering Product Owner | Technical planning |
-| DevOps Senior Engineers | Pipeline integration |
-| Kubernetes Senior Engineers | Container platforms |
-| Security Engineers | Platform security controls |
-| Platform Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Platform Engineering Architect | Solution design | Escalates To |
+| Platform Engineering Product Owner | Technical planning | Collaborates |
+| DevOps Senior Engineers | Pipeline integration | Collaborates |
+| Kubernetes Senior Engineers | Container platforms | Collaborates |
+| Security Engineers | Platform security controls | Governed By |
+| Platform Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Site Reliability Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and efficient systems through engineering practices applied to operations. This role bridges development and operations, designing solutions that improve system reliability, performance, and observability while reducing toil through automation.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of reliability engineering practices and incident response support tasks
+- **Experience Anchor:** 1-3 years in site reliability or infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Reliability strategy and SLO framework design (Site Reliability Senior Engineer and Platform Engineering Architect-owned); observability platform implementation (Observability Engineers-owned, this role coordinates monitoring with it); deployment pipeline architecture (DevOps Engineers-owned, this role coordinates reliability with it)
+- **Escalates To:** Site Reliability Senior Engineer — reliability design questions and complex implementation issues
+- **Escalated To By:** application teams on reliability engineering practices support
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Platform Engineering Architects | Reliability design patterns |
-| Observability Engineers | Monitoring implementation |
-| Cloud Platform Engineers | Cloud service reliability |
-| DevOps Engineers | Deployment pipeline reliability |
-| Security Engineers | Implementing secure reliable systems |
-| application teams | Reliability engineering practices |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Platform Engineering Architects | Reliability design patterns | Consumes From |
+| Observability Engineers | Monitoring implementation | Collaborates |
+| Cloud Platform Engineers | Cloud service reliability | Collaborates |
+| DevOps Engineers | Deployment pipeline reliability | Collaborates |
+| Security Engineers | Implementing secure reliable systems | Collaborates |
+| application teams | Reliability engineering practices | Provides To |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Site Reliability Senior Engineer (Senior SRE) leads the technical implementation of SRE practices across the organisation's production engineering teams. Building on hands-on SRE engineering experience, this role takes ownership of complex reliability projects, leads SLO/SLI design for critical services, mentors junior SREs, and drives forward the engineering practices around observability, incident management, capacity planning, and toil elimination. The Senior SRE operates with a high degree of autonomy and serves as a technical lead in cross-functional reliability initiatives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — reliability engineering practice, SLO design, and incident post-mortem methodology across engineering squads
+- **Experience Anchor:** 5+ years in site reliability engineering with demonstrated independent delivery — operates independently within the reliability strategy set by chapter architecture
+- **Out of Scope:** Platform engineering architecture (Platform Engineering Architect-owned, this role drives reliability requirements into it); observability platform design (Observability Engineers-owned, this role collaborates on telemetry pipeline design with it); availability-impacting security incident ownership (Security Operations-owned, this role coordinates with it)
+- **Escalates To:** Platform Engineering Architect — systemic reliability issues and platform-level design escalations
+- **Escalated To By:** the Site Reliability Engineer on implementation feedback and reliability practice questions
 
 ## Business Impact
 
@@ -78,13 +88,13 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| SRE Architect: | Receive reliability strategy direction; provide implementation feedback and escalate systemic reliability issues |
-| Engineering Squads: | Embed reliability practices; support SLO design and incident post-mortems |
-| Observability Engineers: | Collaborate on telemetry pipeline and dashboard design |
-| Platform Engineering: | Drive reliability requirements for internal developer platform capabilities |
-| Security Operations: | Coordinate on availability-impacting security incidents |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| SRE Architect (Platform Engineering Architect) | Receive reliability strategy direction; provide implementation feedback and escalate systemic reliability issues | Escalates To |
+| Engineering Squads | Embed reliability practices; support SLO design and incident post-mortems | Provides To |
+| Observability Engineers | Collaborate on telemetry pipeline and dashboard design | Collaborates |
+| Platform Engineering | Drive reliability requirements for internal developer platform capabilities | Provides To |
+| Security Operations | Coordinate on availability-impacting security incidents | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Network Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Network Architect designs comprehensive enterprise network strategies and architectures for the organization. This role establishes the technical vision for network infrastructure, creating architectures that balance performance, security, scalability, and reliability while aligning with business objectives and digital transformation initiatives.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — network architecture, connectivity standards, and hybrid network design across the chapter
+- **Experience Anchor:** 8+ years in network architecture with demonstrated architecture-level delivery — operates independently on domain-wide network architecture decisions
+- **Out of Scope:** Network automation tooling architecture (Network Automation Architect-owned — a peer role that extends and operationalises this role's designs); security control implementation (Security Architects-owned, this role implements security design from it); cloud connectivity service selection (Cloud Architects-owned, this role aligns hybrid connectivity to it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Network Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -63,14 +73,14 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Security Architects | Security design |
-| Cloud Architects | Hybrid connectivity |
-| Network Product Owner | Technical strategy |
-| Network Senior Engineers |  |
-| application architects | Network requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Security Architects | Security design | Governed By |
+| Cloud Architects | Hybrid connectivity | Collaborates |
+| Network Product Owner | Technical strategy | Collaborates |
+| Network Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| application architects | Network requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/network/network_automation_architect.md
+++ b/Roles/network/network_automation_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors the Network Automation Engineer; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Network Automation Architect designs and governs the strategy, tooling, and practices for automating network infrastructure provisioning, configuration, validation, and operations. As networks evolve from manually-configured hardware-centric models to software-defined, API-driven, and infrastructure-as-code approaches, this role leads the transition - defining the automation architecture across on-premises (campus, data centre), SD-WAN, and cloud networking. The Network Automation Architect bridges traditional network engineering with software and DevOps practices to enable faster, safer, and more consistent network-change delivery.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — network automation architecture, CI/CD for network changes, and infrastructure-as-code patterns across the chapter
+- **Experience Anchor:** 8+ years in network engineering or automation architecture with demonstrated architecture-level delivery — operates independently on domain-wide network automation decisions, as a peer counterpart to the Network Architect rather than in a hierarchical relationship
+- **Out of Scope:** Overall network platform architecture (Network Architect-owned, this role extends and operationalises its designs); cloud IaC standards beyond network automation (Cloud Architects-owned, this role aligns to them); ITSM change process ownership (Service Management-owned, this role integrates automated workflows with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** the Network Automation Engineer on automation strategy questions
 
 ## Business Impact
 
@@ -98,13 +108,13 @@ The Network Automation Architect designs and governs the strategy, tooling, and 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Network Architect: | Collaborate on overall network platform decisions; automation extends and operationalises network designs |
-| DevOps / Platform Engineering Architect: | Align network CI/CD with enterprise pipeline standards |
-| Cloud Architects: | Define cloud network automation patterns (Terraform VNets/VPCs) aligned with cloud platform IaC standards |
-| Security Engineers: | Automate network security policy enforcement and compliance validation |
-| Service Management: | Integrate automated network change workflows with ITSM change approval processes |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Network Architect | Collaborate on overall network platform decisions; automation extends and operationalises network designs | Collaborates |
+| DevOps / Platform Engineering Architect | Align network CI/CD with enterprise pipeline standards | Collaborates |
+| Cloud Architects | Define cloud network automation patterns (Terraform VNets/VPCs) aligned with cloud platform IaC standards | Collaborates |
+| Security Engineers | Automate network security policy enforcement and compliance validation | Governed By |
+| Service Management | Integrate automated network change workflows with ITSM change approval processes | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Network Automation Architect |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Network Automation Engineer specializes in developing and implementing automation solutions for network infrastructure. This role focuses on creating scripts, tools, and pipelines that enable efficient network configuration, deployment, and management while reducing manual effort and increasing consistency.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of network automation scripting, pipeline integration, and automated change tasks
+- **Experience Anchor:** 3-5 years in network engineering with an automation focus — operates independently within the Network Automation Architect's standards
+- **Out of Scope:** Network automation architecture (Network Automation Architect-owned); overall network platform architecture (Network Architects-owned, this role automates strategy set by it); security automation policy design (Security Engineers-owned, this role implements automated enforcement)
+- **Escalates To:** Network Automation Architect — automation strategy questions
+- **Escalated To By:** Network Engineers on automation implementation requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Network Automation Engineer specializes in developing and implementing autom
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Network Engineers | Implementation requirements |
-| DevOps Engineers | Pipeline integration |
-| Security Engineers | Security automation |
-| Network Product Owner | Automation capabilities |
-| Cloud Engineers | Hybrid network automation |
-| Network Architects | Automation strategy |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Network Engineers | Implementation requirements | Consumes From |
+| DevOps Engineers | Pipeline integration | Collaborates |
+| Security Engineers | Security automation | Collaborates |
+| Network Product Owner | Automation capabilities | Collaborates |
+| Cloud Engineers | Hybrid network automation | Collaborates |
+| Network Architects | Automation strategy | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Network Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Network Engineer implements and maintains enterprise network infrastructure across the organization. Working with the Network Architect and Product Owner, this role ensures reliable, secure, and optimized network connectivity supporting various business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of network connectivity and configuration tasks to defined standards
+- **Experience Anchor:** 1-3 years in network engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Network architecture and solution design (Senior Engineers and the Architect-owned); network security control implementation (Security Engineers-owned, this role coordinates with it); server connectivity ownership (Server Infrastructure Engineers-owned, this role coordinates with it)
+- **Escalates To:** Network Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** business units on network connectivity requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Network Product Owner | Task prioritization |
-| Security Engineers | Network security controls |
-| Server Infrastructure Engineers | Connectivity |
-| Cloud Engineers | Hybrid network integration |
-| Network Architect | Implementation activities |
-| business units | Network connectivity requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Network Product Owner | Task prioritization | Consumes From |
+| Security Engineers | Network security controls | Governed By |
+| Server Infrastructure Engineers | Connectivity | Collaborates |
+| Cloud Engineers | Hybrid network integration | Collaborates |
+| Network Architect | Implementation activities | Escalates To |
+| business units | Network connectivity requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Network Product Owner manages the development and lifecycle of the organization's network services portfolio. This role leads a team of network architects and engineers, ensuring that network services meet business requirements, performance targets, and security objectives while aligning with organizational strategy.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — network platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Network technical architecture (Network Architect-owned); security initiative ownership (Security Product Owner-owned, this role coordinates with it); hybrid cloud network roadmap ownership (Cloud teams-owned, this role coordinates with them)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** business units on network service needs
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Network Product Owner manages the development and lifecycle of the organizat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Security Product Owner | Network security initiatives |
-| Network Architect | Technical strategy and design |
-| Application Product Owners | Connectivity requirements |
-| Cloud teams | Hybrid network integration |
-| business units | Understand service needs |
-| IT leadership | Network strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Security Product Owner | Network security initiatives | Collaborates |
+| Network Architect | Technical strategy and design | Consumes From |
+| Application Product Owners | Connectivity requirements | Consumes From |
+| Cloud teams | Hybrid network integration | Collaborates |
+| business units | Understand service needs | Consumes From |
+| IT leadership | Network strategy and investments | Provides To |
 
 ## Key Technologies
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Network Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Network Senior Engineer leads the implementation and optimization of complex enterprise network solutions. This role provides technical leadership for network deployments, migrations, and operations while working closely with architects to translate network designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced network solution design and delivery within the Network Architect's reference architecture
+- **Experience Anchor:** 5+ years in network engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Network architecture and standards (Architect-owned); network security control ownership (Security Senior Engineers-owned, this role coordinates with it); virtual networking design ownership (Virtualization Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Network Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Network Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Network Senior Engineer leads the implementation and optimization of complex
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Network Architect | Solution design and implementation strategy |
-| Network Product Owner | Technical planning and roadmap execution |
-| Security Senior Engineers | Network security controls |
-| Cloud Senior Engineers | Cloud network integration |
-| Virtualization Senior Engineers | Virtual networking |
-| Network Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Network Architect | Solution design and implementation strategy | Escalates To |
+| Network Product Owner | Technical planning and roadmap execution | Collaborates |
+| Security Senior Engineers | Network security controls | Governed By |
+| Cloud Senior Engineers | Cloud network integration | Collaborates |
+| Virtualization Senior Engineers | Virtual networking | Collaborates |
+| Network Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Server Hardware Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Server Hardware Architect designs comprehensive server infrastructure strategies and architectures for the organization. This role establishes the technical vision for server hardware implementations, creating architectures that balance performance, scalability, efficiency, and reliability while aligning with business objectives and data center strategies.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — server hardware standards and technology roadmap across the chapter
+- **Experience Anchor:** 8+ years in server hardware or infrastructure architecture with demonstrated architecture-level delivery — operates independently on domain-wide hardware architecture decisions
+- **Out of Scope:** Enterprise-wide technology standards beyond hardware (Enterprise Architects-owned, this role aligns to it); data centre facility planning (Data Center Architects-owned, this role coordinates capacity strategy with it); HPE-specific hardware architecture (HPE Server Hardware Architect-owned — a parallel, vendor-specific hardware ladder)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Server Hardware Senior Engineers on implementation strategy questions
 
 ## Business Impact
 
@@ -80,14 +90,14 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Technology standards |
-| Data Center Architects | Infrastructure planning |
-| Infrastructure Directors | Capacity strategy |
-| Server Hardware Product Owner | Technical strategy |
-| Server Hardware Senior Engineers |  |
-| vendors | Hardware roadmaps and innovation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Technology standards | Governed By |
+| Data Center Architects | Infrastructure planning | Collaborates |
+| Infrastructure Directors | Capacity strategy | Collaborates |
+| Server Hardware Product Owner | Technical strategy | Collaborates |
+| Server Hardware Senior Engineers | Provide architectural direction and mentoring; receive implementation feedback | Provides To |
+| vendors | Hardware roadmaps and innovation | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Server Hardware Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Server Hardware Engineer implements and maintains the physical server infrastructure across the organization. Working with the Server Hardware Architect and Product Owner, this role ensures proper installation, configuration, and maintenance of server hardware to support business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of server hardware installation, deployment, and inventory tasks to defined standards
+- **Experience Anchor:** 1-3 years in server hardware or infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Server hardware architecture and solution design (Senior Engineers and the Architect-owned); OS installation ownership (Windows/Linux Server Engineers-owned, this role coordinates with it); vendor contract negotiation (procurement team-owned, this role coordinates receiving and inventory with it)
+- **Escalates To:** Server Hardware Architect — implementation activity questions
+- **Escalated To By:** data center facilities teams on physical infrastructure coordination
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Server Hardware Engineer implements and maintains the physical server infras
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Product Owner | Task prioritization |
-| Windows/Linux Server Engineers | OS installation needs |
-| Server Hardware Architect | Implementation activities |
-| data center facilities teams | Physical infrastructure |
-| procurement team | Hardware receiving and inventory |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Product Owner | Task prioritization | Consumes From |
+| Windows/Linux Server Engineers | OS installation needs | Collaborates |
+| Server Hardware Architect | Implementation activities | Escalates To |
+| data center facilities teams | Physical infrastructure | Collaborates |
+| procurement team | Hardware receiving and inventory | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Server Hardware Product Owner manages the lifecycle of physical server infrastructure across the organization. This role leads a team of hardware architects and engineers, ensuring that server hardware meets performance requirements, operational standards, and cost objectives while aligning with business needs.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — server hardware procurement backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Server hardware technical architecture (Server Hardware Architect-owned); data centre operations execution (Data Center Operations teams-owned, this role coordinates installation with it); vendor contract terms (Procurement-owned, this role coordinates selection with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** platform-specific Product Owners (Windows, Linux, HPC) on hardware requirements
 
 ## Business Impact
 
@@ -86,14 +96,14 @@ The Server Hardware Product Owner manages the lifecycle of physical server infra
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Architect | Specifications and designs |
-| platform-specific Product Owners (Windows, Linux, HPC) | Hardware requirements |
-| Data Center Operations teams | Installation and maintenance |
-| Finance | Capital expenditure planning and budgeting |
-| Procurement | Vendor selection and contract negotiations |
-| IT leadership | Infrastructure investment strategy |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Architect | Specifications and designs | Consumes From |
+| platform-specific Product Owners (Windows, Linux, HPC) | Hardware requirements | Collaborates |
+| Data Center Operations teams | Installation and maintenance | Collaborates |
+| Finance | Capital expenditure planning and budgeting | Collaborates |
+| Procurement | Vendor selection and contract negotiations | Collaborates |
+| IT leadership | Infrastructure investment strategy | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Server Hardware Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Server Hardware Senior Engineer leads the implementation and optimization of enterprise server hardware infrastructure. This role provides technical leadership for complex server deployments, hardware troubleshooting, and lifecycle management while working closely with architects to translate designs into physical implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced server hardware solution delivery within the Server Hardware Architect's reference architecture
+- **Experience Anchor:** 5+ years in server hardware engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Server hardware architecture and standards (Architect-owned); data centre operations facility management (data center operations-owned, this role coordinates infrastructure planning with it); OS-level platform configuration (platform Senior Engineers-owned, this role coordinates hardware requirements with them)
+- **Escalates To:** Server Hardware Architect — implementation strategy exceptions
+- **Escalated To By:** Server Hardware Engineers on complex technical challenges
 
 ## Business Impact
 
@@ -88,14 +98,14 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Architect | Implementation strategies |
-| Server Hardware Product Owner | Technical planning |
-| Senior Engineers | Platforms on hardware requirements |
-| Server Hardware Engineers | Complex technical challenges |
-| data center operations | Infrastructure planning |
-| vendor technical resources | Complex issues |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Architect | Implementation strategies | Escalates To |
+| Server Hardware Product Owner | Technical planning | Collaborates |
+| Senior Engineers from other platforms | Hardware requirements | Collaborates |
+| Server Hardware Engineers | Complex technical challenges | Provides To |
+| data center operations | Infrastructure planning | Collaborates |
+| vendor technical resources | Complex issues | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors HPE Server Hardware Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The HPE Server Hardware Architect designs and oversees the organization's server infrastructure based on Hewlett Packard Enterprise technologies. This role ensures the delivery of a reliable, performant, and cost-effective server platform that meets the organization's computing requirements.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — HPE server hardware standards and technology roadmap across the chapter
+- **Experience Anchor:** 8+ years in server hardware architecture with demonstrated HPE platform ownership — operates independently on domain-wide HPE hardware architecture decisions
+- **Out of Scope:** Vendor-agnostic server hardware architecture (Server Hardware Architect-owned — a parallel, non-HPE hardware ladder); OS-level configuration on the hardware (Windows and Linux Server Architects-owned, this role aligns hardware to it); virtualisation host design detail (VMware/Nutanix Architects-owned, this role provides hardware requirements to it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** HPE Server Hardware Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -90,14 +100,14 @@ The HPE Server Hardware Architect designs and oversees the organization's server
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows and Linux Server Architects | Align hardware with OS requirements |
-| VMware/Nutanix Architects | Virtualization host requirements |
-| Storage Architects | Server storage integration |
-| Network Architects | Server connectivity |
-| HPC Architects | High-performance computing solutions |
-| data center teams | Physical infrastructure planning |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows and Linux Server Architects | Align hardware with OS requirements | Collaborates |
+| VMware/Nutanix Architects | Virtualization host requirements | Provides To |
+| Storage Architects | Server storage integration | Collaborates |
+| Network Architects | Server connectivity | Collaborates |
+| HPC Architects | High-performance computing solutions | Collaborates |
+| data center teams | Physical infrastructure planning | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | HPE Server Hardware Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The HPE Server Hardware Engineer implements and maintains server infrastructure based on Hewlett Packard Enterprise technologies. Working with the HPE Server Hardware Architect and Product Owner, this role ensures reliable and properly configured server hardware supporting business applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of HPE server hardware installation and deployment tasks to defined standards
+- **Experience Anchor:** 1-3 years in server hardware engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** HPE hardware architecture and solution design (Senior Engineers and the Architect-owned); OS installation ownership (OS Engineers-owned, this role coordinates with it); vendor contract negotiation (procurement team-owned, this role coordinates receiving and inventory with it)
+- **Escalates To:** HPE Server Hardware Architect — implementation activity questions
+- **Escalated To By:** platform engineers on hardware-related issues
 
 ## Business Impact
 
@@ -102,14 +112,14 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| HPE Server Hardware Product Owner | Task prioritization |
-| OS Engineers | Operating system installation requirements |
-| HPE Server Hardware Architect | Implementation activities |
-| data center facilities teams | Physical infrastructure |
-| procurement team | Hardware receiving and inventory |
-| platform engineers | Hardware-related issues |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| HPE Server Hardware Product Owner | Task prioritization | Consumes From |
+| OS Engineers | Operating system installation requirements | Collaborates |
+| HPE Server Hardware Architect | Implementation activities | Escalates To |
+| data center facilities teams | Physical infrastructure | Collaborates |
+| procurement team | Hardware receiving and inventory | Collaborates |
+| platform engineers | Hardware-related issues | Provides To |
 
 ## Key Technologies
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The HPE Server Hardware Product Owner manages the development and lifecycle of the organization's server infrastructure based on Hewlett Packard Enterprise technologies. This role leads a team of server hardware architects and engineers, ensuring that server platforms meet business requirements, performance targets, and operational standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — HPE server hardware procurement backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** HPE hardware technical architecture (HPE Server Hardware Architect-owned); vendor-agnostic hardware roadmap (Server Hardware Product Owner-owned — a parallel, non-HPE hardware ladder); vendor contract terms (procurement teams-owned, this role coordinates negotiations with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** platform-specific Product Owners (Windows, Linux, VMware) on hardware requirements
 
 ## Business Impact
 
@@ -165,14 +175,14 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| HPE Server Hardware Architect | Technical strategy |
-| platform-specific Product Owners (Windows, Linux, VMware) | Hardware requirements |
-| procurement teams | Vendor negotiations and contracts |
-| finance teams | Capital expenditure planning |
-| business stakeholders | Computing service requirements |
-| IT leadership | Infrastructure strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| HPE Server Hardware Architect | Technical strategy | Consumes From |
+| platform-specific Product Owners (Windows, Linux, VMware) | Hardware requirements | Collaborates |
+| procurement teams | Vendor negotiations and contracts | Collaborates |
+| finance teams | Capital expenditure planning | Collaborates |
+| business stakeholders | Computing service requirements | Consumes From |
+| IT leadership | Infrastructure strategy and investments | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | HPE Server Hardware Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The HPE Server Hardware Senior Engineer leads the implementation and optimization of enterprise server infrastructure based on Hewlett Packard Enterprise technologies. This role provides technical leadership for complex server deployments, migrations, and operations while working closely with architects to translate server designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced HPE server hardware solution delivery within the HPE Server Hardware Architect's reference architecture
+- **Experience Anchor:** 5+ years in HPE server hardware engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** HPE hardware architecture and standards (Architect-owned); OS-hardware integration ownership (Platform Senior Engineers-owned, this role coordinates with it); virtualisation host optimisation ownership (Virtualization Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** HPE Server Hardware Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** HPE Server Hardware Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -157,14 +167,14 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| HPE Server Hardware Architect | Solution design and implementation strategy |
-| HPE Server Hardware Product Owner | Technical planning |
-| Virtualization Senior Engineers | Host optimization |
-| Platform Senior Engineers | OS-hardware integration |
-| HPE Server Hardware Engineers | Technical implementation |
-| vendor technical resources | Advanced issues and solutions |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| HPE Server Hardware Architect | Solution design and implementation strategy | Escalates To |
+| HPE Server Hardware Product Owner | Technical planning | Collaborates |
+| Virtualization Senior Engineers | Host optimization | Collaborates |
+| Platform Senior Engineers | OS-hardware integration | Collaborates |
+| HPE Server Hardware Engineers | Technical implementation | Provides To |
+| vendor technical resources | Advanced issues and solutions | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Linux Server Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Linux Server Architect designs and defines the strategic direction for the organization's Linux infrastructure. This role creates architectural blueprints, standards, and reference models for Linux environments, ensuring they meet business requirements for performance, scalability, reliability, and security while aligning with broader IT strategy and enterprise architecture principles.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Linux server platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in Linux systems architecture with demonstrated architecture-level delivery — operates independently on domain-wide Linux architecture decisions
+- **Out of Scope:** Windows Server architecture (Windows Server Architect-owned — a parallel, non-Linux OS ladder); server hardware specification (Server Hardware Architect-owned, this role consumes it); container platform architecture (Kubernetes Architect-owned via CI/CD Engineers, this role coordinates hosting with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Linux Server Engineers on implementation of architectural standards
 
 ## Business Impact
 
@@ -149,17 +159,17 @@ The Linux Server Architect designs and defines the strategic direction for the o
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Align Linux architecture with overall strategy |
-| Linux Server Engineers | Implementation of architectural standards |
-| Security Architects | Linux security design |
-| Cloud Architects | Hybrid Linux deployments |
-| Infrastructure Managers | Linux technology roadmaps |
-| Network Architects | Linux networking requirements |
-| Storage Architects | Linux storage solutions |
-| Application Architects | Linux platform requirements, OS constraints, and kernel-level design considerations |
-| DevOps Engineers | CI/CD pipeline integration |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Align Linux architecture with overall strategy | Governed By |
+| Linux Server Engineers | Implementation of architectural standards | Provides To |
+| Security Architects | Linux security design | Governed By |
+| Cloud Architects | Hybrid Linux deployments | Collaborates |
+| Infrastructure Managers | Linux technology roadmaps | Collaborates |
+| Network Architects | Linux networking requirements | Collaborates |
+| Storage Architects | Linux storage solutions | Collaborates |
+| Application Architects | Linux platform requirements, OS constraints, and kernel-level design considerations | Provides To |
+| DevOps Engineers | CI/CD pipeline integration | Collaborates |
 
 **Complementary Certifications:**
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Linux Server Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Linux Server Engineer implements and maintains Tier 1 Linux Server environments across the organization, excluding any Tier 0 infrastructure related to directory services which falls under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Linux server deployment and configuration tasks to defined standards
+- **Experience Anchor:** 1-3 years in Linux systems engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Linux architecture and solution design (Senior Engineers and the Architect-owned); server hardware deployment ownership (Server Hardware Engineers-owned, this role coordinates with it); container host configuration ownership (Kubernetes Engineers-owned, this role coordinates with it)
+- **Escalates To:** Linux Server Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** Database Engineers on Linux database host support
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Linux Server Product Owner | Task prioritization |
-| Server Hardware Engineers | Server deployments |
-| Kubernetes Engineers | Container host configuration |
-| Database Engineers | Linux database hosts |
-| Linux Server Architect | Implementation activities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Linux Server Product Owner | Task prioritization | Consumes From |
+| Server Hardware Engineers | Server deployments | Collaborates |
+| Kubernetes Engineers | Container host configuration | Collaborates |
+| Database Engineers | Linux database hosts | Provides To |
+| Linux Server Architect | Implementation activities | Escalates To |
 
 ## Key Technologies
 

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Linux Server Product Owner manages the product backlog and roadmap for all Tier 1 Linux Server platforms, excluding any Tier 0 infrastructure related to directory services which falls under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Linux server platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Linux technical architecture (Linux Server Architect-owned); cross-platform integration ownership (other Product Owners-owned, this role coordinates with them); hardening policy definition (Security teams-owned, this role implements compliance from it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Business Relationship Managers on business driver alignment
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Linux Server Architect | Technical strategy and design |
-| other Product Owners | Integrated solutions |
-| Security teams | Linux hardening and compliance |
-| Service Delivery Managers | Operational transitions |
-| Business Relationship Managers | Understand business drivers |
-| IT leadership | Strategic initiatives and investment decisions |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Linux Server Architect | Technical strategy and design | Consumes From |
+| other Product Owners | Integrated solutions | Collaborates |
+| Security teams | Linux hardening and compliance | Governed By |
+| Service Delivery Managers | Operational transitions | Collaborates |
+| Business Relationship Managers | Understand business drivers | Consumes From |
+| IT leadership | Strategic initiatives and investment decisions | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Linux Server Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Linux Server Senior Engineer leads complex implementations and optimizations for Tier 1 Linux Server environments, excluding any Tier 0 infrastructure related to directory services which falls under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Linux solution delivery within the Linux Server Architect's reference architecture
+- **Experience Anchor:** 5+ years in Linux systems engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Linux platform architecture and standards (Architect-owned); HPC-specific performance tuning ownership (HPC Senior Engineers-owned, this role coordinates with it); container hosting architecture (Kubernetes Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Linux Server Architect — solution design and implementation approach exceptions
+- **Escalated To By:** Linux Server Engineers on technical skills development
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Linux Server Architect | Solution design and implementation approaches |
-| Linux Server Product Owner | Technical planning and roadmap execution |
-| HPC Senior Engineers | Linux performance optimization |
-| Kubernetes Senior Engineers | Advanced container hosting |
-| Cloud Senior Engineers | Linux in cloud environments |
-| Linux Server Engineers | Technical skills development |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Linux Server Architect | Solution design and implementation approaches | Escalates To |
+| Linux Server Product Owner | Technical planning and roadmap execution | Collaborates |
+| HPC Senior Engineers | Linux performance optimization | Collaborates |
+| Kubernetes Senior Engineers | Advanced container hosting | Collaborates |
+| Cloud Senior Engineers | Linux in cloud environments | Collaborates |
+| Linux Server Engineers | Technical skills development | Provides To |
 
 ## Key Technologies
 

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Windows Server Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Server Architect designs and defines the strategic direction for the organization's Windows Server infrastructure. This role creates architectural blueprints, standards, and reference models for Windows environments, ensuring they meet business requirements for performance, scalability, reliability, and security while aligning with broader IT strategy and enterprise architecture.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Windows Server platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in Windows systems architecture with demonstrated architecture-level delivery — operates independently on domain-wide Windows architecture decisions
+- **Out of Scope:** Linux Server architecture (Linux Server Architect-owned — a parallel, non-Windows OS ladder); Active Directory identity architecture (Windows Active Directory Architect-owned, this role aligns to it); server hardware specification (Server Hardware Architect-owned, this role consumes it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Windows Server Engineers on implementation of architectural standards
 
 ## Business Impact
 
@@ -149,17 +159,17 @@ The Windows Server Architect designs and defines the strategic direction for the
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Enterprise Architects | Align Windows architecture with overall strategy |
-| Windows Server Engineers | Implementation of architectural standards |
-| Security Architects | Windows security design |
-| Cloud Architects | Hybrid Windows deployments |
-| Infrastructure Managers | Windows technology roadmaps |
-| Network Architects | Windows networking requirements |
-| Storage Architects | Windows storage solutions |
-| Application Architects | Windows platform requirements, OS constraints, and Group Policy/WinAPI design considerations |
-| Active Directory Engineers | Identity architecture |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architects | Align Windows architecture with overall strategy | Governed By |
+| Windows Server Engineers | Implementation of architectural standards | Provides To |
+| Security Architects | Windows security design | Governed By |
+| Cloud Architects | Hybrid Windows deployments | Collaborates |
+| Infrastructure Managers | Windows technology roadmaps | Collaborates |
+| Network Architects | Windows networking requirements | Collaborates |
+| Storage Architects | Windows storage solutions | Collaborates |
+| Application Architects | Windows platform requirements, OS constraints, and Group Policy/WinAPI design considerations | Provides To |
+| Active Directory Engineers | Identity architecture | Collaborates |
 
 **Complementary Certifications:**
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Windows Server Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Server Engineer implements and maintains Tier 1 Windows Server environments across the organization, excluding Tier 0 infrastructure (domain controllers and servers involved in directory services) which falls under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Windows server deployment and configuration tasks to defined standards
+- **Experience Anchor:** 1-3 years in Windows systems engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Windows architecture and solution design (Senior Engineers and the Architect-owned); server hardware deployment ownership (Server Hardware Engineers-owned, this role coordinates with it); monitoring platform implementation ownership (Observability Engineers-owned, this role coordinates with it)
+- **Escalates To:** Windows Server Architect — implementation detail questions
+- **Escalated To By:** other platform engineers on integration point coordination
 
 ## Business Impact
 
@@ -69,13 +79,13 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Product Owner | Task prioritization and delivery |
-| Server Hardware Engineers | Physical server deployments |
-| Observability Engineers | Monitoring implementation |
-| Windows Server Architect | Implementation details |
-| other platform engineers | Integration points |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Product Owner | Task prioritization and delivery | Consumes From |
+| Server Hardware Engineers | Physical server deployments | Collaborates |
+| Observability Engineers | Monitoring implementation | Collaborates |
+| Windows Server Architect | Implementation details | Escalates To |
+| other platform engineers | Integration points | Collaborates |
 
 ## Key Technologies
 

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Server Product Owner manages the product backlog and roadmap for all Tier 1 Windows Server platforms, excluding Tier 0 infrastructure (domain controllers and servers involved in directory services) which falls under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Windows Server platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Windows technical architecture (Windows Server Architect-owned); cross-platform initiative ownership (other Product Owners-owned, this role coordinates with them); compliance policy definition (Security teams-owned, this role implements vulnerability management from it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Business Relationship Managers on stakeholder needs
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Architect | Define technical direction |
-| other Product Owners | Cross-platform initiatives |
-| Security teams | Windows compliance and vulnerability management |
-| Service Delivery Managers | Operational handover |
-| Business Relationship Managers | Understand stakeholder needs |
-| IT leadership | Strategic roadmaps and investment planning |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Architect | Define technical direction | Consumes From |
+| other Product Owners | Cross-platform initiatives | Collaborates |
+| Security teams | Windows compliance and vulnerability management | Governed By |
+| Service Delivery Managers | Operational handover | Collaborates |
+| Business Relationship Managers | Understand stakeholder needs | Consumes From |
+| IT leadership | Strategic roadmaps and investment planning | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Windows Server Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Windows Server Senior Engineer leads complex implementations and optimizations for Tier 1 Windows Server environments, excluding Tier 0 infrastructure (domain controllers and servers involved in directory services) which falls under the exclusive responsibility of the Directory Services team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Windows solution delivery within the Windows Server Architect's reference architecture
+- **Experience Anchor:** 5+ years in Windows systems engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Windows platform architecture and standards (Architect-owned); Azure hybrid solution architecture (Azure Cloud Senior Engineers-owned, this role coordinates with it); cross-domain solution design ownership (Senior Engineers from other platforms-owned, this role coordinates with them)
+- **Escalates To:** Windows Server Architect — solution design and validation exceptions
+- **Escalated To By:** Windows Server Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Architect | Solution design and validation |
-| Windows Server Product Owner | Technical planning and roadmap execution |
-| Azure Cloud Senior Engineers | Hybrid solutions |
-| Security Engineers | Windows security implementation |
-| Senior Engineers | From other platforms on cross-domain solutions |
-| Windows Server Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Architect | Solution design and validation | Escalates To |
+| Windows Server Product Owner | Technical planning and roadmap execution | Collaborates |
+| Azure Cloud Senior Engineers | Hybrid solutions | Collaborates |
+| Security Engineers | Windows security implementation | Governed By |
+| Senior Engineers from other platforms | Cross-domain solutions | Collaborates |
+| Windows Server Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/specialized_computing/hpc_architect.md
+++ b/Roles/specialized_computing/hpc_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors HPC Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The High-Performance Computing (HPC) Architect leads the design, implementation, and evolution of advanced HPC environments for scientific, engineering, analytics, and large-scale AI/ML training workloads. This role focuses on maximizing performance, scalability, security, sustainability, and efficiency, and sets technical direction for GPU-accelerated AI infrastructure, LLM training clusters, and hybrid/cloud HPC. The HPC Architect ensures alignment with organizational goals including AI strategy and fosters a culture of continuous learning and cross-functional collaboration.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — high-performance computing architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in HPC or scientific computing architecture with demonstrated architecture-level delivery — operates independently on domain-wide HPC architecture decisions
+- **Out of Scope:** Underlying Linux OS architecture (Linux Server Architect-owned, this role aligns to it); cloud/hybrid HPC service selection (Cloud Platform Architects-owned, this role integrates with it); specialised HPC hardware procurement (Server Hardware Architect-owned, this role defines requirements for it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** HPC Senior Engineers on solution design, automation, and implementation strategy questions
 
 ## Business Impact
 
@@ -94,16 +104,16 @@ The High-Performance Computing (HPC) Architect leads the design, implementation,
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Linux Server Architect | OS and hybrid/cloud integration |
-| Cloud Platform Architects | OS and hybrid/cloud integration |
-| Database Architect | Data-intensive computing solutions |
-| Security Architects | Ensure compliance and data protection |
-| Observability Architect | HPC monitoring and analytics |
-| HPC Product Owner | Business stakeholders on HPC strategy |
-| Server Hardware Architect | Specialized HPC hardware |
-| Facilitates knowledge sharing and documentation | All HPC stakeholders |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Linux Server Architect | OS and hybrid/cloud integration | Collaborates |
+| Cloud Platform Architects | OS and hybrid/cloud integration | Collaborates |
+| Database Architect | Data-intensive computing solutions | Collaborates |
+| Security Architects | Ensure compliance and data protection | Governed By |
+| Observability Architect | HPC monitoring and analytics | Collaborates |
+| HPC Product Owner | Business stakeholders on HPC strategy | Collaborates |
+| Server Hardware Architect | Specialized HPC hardware | Consumes From |
+| All HPC stakeholders | Facilitates knowledge sharing and documentation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | HPC Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The HPC Engineer designs, implements, and maintains high-performance computing environments that support computationally intensive workloads. This role ensures that HPC clusters are secure, scalable, and efficient for scientific and engineering applications. The HPC Engineer works closely with the HPC Architect, Product Owner, and other stakeholders to automate operations, integrate new technologies, support users, and promote sustainable, cost-effective HPC operations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of HPC resource provisioning and support tasks to defined standards
+- **Experience Anchor:** 1-3 years in HPC or scientific computing engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** HPC architecture and solution design (Senior Engineers and the Architect-owned); underlying Linux OS automation ownership (Linux Server Engineers-owned, this role coordinates with it); specialised hardware upgrade ownership (Server Hardware Engineers-owned, this role coordinates with it)
+- **Escalates To:** HPC Architect — implementation and design activity questions
+- **Escalated To By:** researchers and engineers on HPC resource training and documentation needs
 
 ## Business Impact
 
@@ -77,16 +87,15 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| HPC Product Owner | Task prioritization and user requirements |
-| Linux Server Engineers | Base OS and automation |
-| Server Hardware Engineers | Specialized hardware and upgrades |
-| Security Engineers | Ensure compliance and data protection |
-| Cloud Engineers | Integrate cloud-based HPC resources |
-| HPC Architect | Implementation and design activities |
-| Provides training and documentation | Researchers and engineers using HPC resources |
-| researchers and engineers | HPC resources |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| HPC Product Owner | Task prioritization and user requirements | Consumes From |
+| Linux Server Engineers | Base OS and automation | Collaborates |
+| Server Hardware Engineers | Specialized hardware and upgrades | Collaborates |
+| Security Engineers | Ensure compliance and data protection | Governed By |
+| Cloud Engineers | Integrate cloud-based HPC resources | Collaborates |
+| HPC Architect | Implementation and design activities | Escalates To |
+| researchers and engineers | Provide training, documentation, and support for HPC resource usage | Provides To |
 
 ## Key Technologies
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The High-Performance Computing (HPC) Product Owner leads the development, delivery, and continuous improvement of HPC solutions that support the organization's computationally intensive workloads. This role drives the strategic vision for HPC, ensuring environments are innovative, scalable, secure, and aligned with research and business needs. The Product Owner champions user engagement, value delivery, and adoption of emerging HPC technologies, including cloud and hybrid solutions. The Product Owner also champions sustainability, diversity, and user advocacy, ensuring that HPC solutions are accessible and valuable to all stakeholders.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — HPC platform backlog, investment strategy, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with research computing exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** HPC technical architecture (HPC Architect-owned); server hardware procurement roadmap (Server Hardware Product Owner-owned, this role aligns to it); cloud integration compliance detail (Security Teams-owned)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Data Science and Research departments on evolving computational needs
 
 ## Business Impact
 
@@ -75,15 +85,15 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Product Owner | Infrastructure requirements and optimization |
-| Linux Server Product Owner | Infrastructure requirements and optimization |
-| Cloud Product Owners | Cloud integration and compliance |
-| Security Teams | Cloud integration and compliance |
-| HPC Architect | Platform design, technology adoption, and enhancement |
-| Data Science and Research departments | Understand evolving computational needs |
-| IT leadership | HPC investment strategy, business cases, and value delivery |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Product Owner | Infrastructure requirements and optimization | Collaborates |
+| Linux Server Product Owner | Infrastructure requirements and optimization | Collaborates |
+| Cloud Product Owners | Cloud integration and compliance | Collaborates |
+| Security Teams | Cloud integration and compliance | Governed By |
+| HPC Architect | Platform design, technology adoption, and enhancement | Consumes From |
+| Data Science and Research departments | Understand evolving computational needs | Consumes From |
+| IT leadership | HPC investment strategy, business cases, and value delivery | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | HPC Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The HPC Senior Engineer leads the technical implementation, automation, and optimization of high-performance computing environments. This role combines deep HPC expertise with technical leadership, driving innovation, security, and efficiency. The Senior Engineer works closely with researchers, architects, and engineers to deliver robust, scalable, and secure HPC solutions for complex workloads. The Senior Engineer also fosters a culture of innovation, continuous improvement, and inclusivity within the HPC team.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced HPC solution design and delivery within the HPC Architect's reference architecture
+- **Experience Anchor:** 5+ years in HPC or scientific computing engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** HPC platform architecture and standards (Architect-owned); server hardware upgrade ownership (Server Hardware Senior Engineers-owned, this role coordinates with it); cloud HPC integration ownership (Cloud Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** HPC Architect — solution design, automation, and implementation strategy exceptions
+- **Escalated To By:** HPC Engineers on complex technical challenges and best practices
 
 ## Business Impact
 
@@ -97,15 +107,15 @@ The HPC Senior Engineer leads the technical implementation, automation, and opti
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| HPC Architect | Solution design, automation, and implementation strategies |
-| HPC Product Owner | Technical planning, roadmap execution, and user requirements |
-| Server Hardware Senior Engineers | HPC infrastructure and upgrades |
-| Cloud Senior Engineers | Cloud and hybrid HPC solutions |
-| Security Engineers | Ensure compliance and data protection |
-| HPC Engineers | Complex technical challenges and best practices |
-| researchers | Optimize and automate computational workflows |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| HPC Architect | Solution design, automation, and implementation strategies | Escalates To |
+| HPC Product Owner | Technical planning, roadmap execution, and user requirements | Collaborates |
+| Server Hardware Senior Engineers | HPC infrastructure and upgrades | Collaborates |
+| Cloud Senior Engineers | Cloud and hybrid HPC solutions | Collaborates |
+| Security Engineers | Ensure compliance and data protection | Governed By |
+| HPC Engineers | Complex technical challenges and best practices | Provides To |
+| researchers | Optimize and automate computational workflows | Provides To |
 
 ## Key Technologies
 

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Hyper-V Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Hyper-V Architect is responsible for designing and overseeing the strategic implementation of Microsoft's virtualization technologies across the organization. This role drives technical standards, architecture patterns, and best practices for Hyper-V environments.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Hyper-V virtualisation platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in virtualisation architecture with demonstrated Hyper-V/Windows platform ownership — operates independently on domain-wide Hyper-V architecture decisions
+- **Out of Scope:** VMware or Nutanix virtualisation architecture (VMware/Nutanix Architects-owned — parallel, non-Hyper-V virtualisation ladders); Windows Server infrastructure architecture (Windows Server Teams-owned, this role collaborates on platform integration with it); Azure hybrid cloud integration detail (Cloud Teams-owned, this role integrates with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Hyper-V Senior Engineers on architecture design and standards development support
 
 ## Business Impact
 
@@ -74,15 +84,15 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Windows Server Teams | Collaboration on platform integration and architecture |
-| Storage Teams | Design of storage solutions for Hyper-V environments |
-| Network Teams | Design of network architecture for virtualized workloads |
-| Cloud Teams | Integration with Azure and hybrid cloud scenarios |
-| Security Teams | Implementation of security controls in virtualized environments |
-| Other Virtualization Teams | Cross-platform integration and migration strategies |
-| Product Owners | Strategic planning and roadmap development |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Windows Server Teams | Collaboration on platform integration and architecture | Collaborates |
+| Storage Teams | Design of storage solutions for Hyper-V environments | Collaborates |
+| Network Teams | Design of network architecture for virtualized workloads | Collaborates |
+| Cloud Teams | Integration with Azure and hybrid cloud scenarios | Collaborates |
+| Security Teams | Implementation of security controls in virtualized environments | Governed By |
+| Other Virtualization Teams | Cross-platform integration and migration strategies | Collaborates |
+| Product Owners | Strategic planning and roadmap development | Collaborates |
 
 ## Key Performance Indicators
 

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Hyper-V Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Hyper-V Engineer implements and maintains Microsoft virtualization environments, ensuring they operate efficiently and reliably to support business applications. This role focuses on day-to-day operations, deployments, and routine maintenance of Hyper-V infrastructure.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of VM provisioning and Hyper-V operations tasks to defined standards
+- **Experience Anchor:** 1-3 years in virtualisation or Windows infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Hyper-V architecture and solution design (Senior Engineers and the Architect-owned); OS-level Windows Server configuration ownership (Windows Server Teams-owned, this role coordinates with it); network configuration architecture (Network Teams-owned, this role implements configurations within it)
+- **Escalates To:** Hyper-V Senior Engineers — complex issues requiring escalation
+- **Escalated To By:** Service Desk on incidents and service requests
 
 ## Business Impact
 
@@ -74,17 +84,17 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 - **Working Knowledge required:** Software-Defined Networking and Hyper-V virtual switch configuration, Azure hybrid services integration for on-premises Hyper-V environments, Virtual Machine Queue (VMQ) and network performance settings
 - **Awareness level expected:** Azure Stack HCI cloud-managed Hyper-V features and capabilities, Windows Server 2025 virtualisation improvements and new Hyper-V features
 
-## Relationships & Collaboration
+## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Hyper-V Senior Engineers | Receiving guidance and escalating complex issues |
-| Windows Server Teams | Coordinating OS-level configurations and updates |
-| Storage Teams | Working with storage allocations and configurations |
-| Network Teams | Implementation of network configurations for VMs |
-| Service Desk | Responding to incidents and service requests |
-| Application Teams | Supporting VM provisioning for application needs |
-| Security Teams | Implementing security controls and responding to vulnerabilities |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Hyper-V Senior Engineers | Receiving guidance and escalating complex issues | Escalates To |
+| Windows Server Teams | Coordinating OS-level configurations and updates | Collaborates |
+| Storage Teams | Working with storage allocations and configurations | Collaborates |
+| Network Teams | Implementation of network configurations for VMs | Collaborates |
+| Service Desk | Responding to incidents and service requests | Provides To |
+| Application Teams | Supporting VM provisioning for application needs | Provides To |
+| Security Teams | Implementing security controls and responding to vulnerabilities | Governed By |
 
 ## Key Performance Indicators
 

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtualization platforms within the organization. This role balances business requirements with technical capabilities to ensure Hyper-V environments deliver value to stakeholders while maintaining operational excellence.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Hyper-V platform backlog, licensing roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Hyper-V technical architecture (Hyper-V Architect-owned); Windows Server platform roadmap (Windows Server Teams-owned, this role coordinates dependencies with it); service level definition beyond Hyper-V-specific commitments (Service Management-owned, this role coordinates with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Business Stakeholders on requirements and expectations
 
 ## Business Impact
 
@@ -76,15 +86,15 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Business Stakeholders | Understanding requirements and managing expectations |
-| Hyper-V Architect | Collaborating on technical strategy and architecture |
-| Hyper-V Engineering Teams | Providing direction on implementation priorities |
-| Windows Server Teams | Coordinating platform dependencies and roadmaps |
-| Procurement | Managing licensing and vendor relationships |
-| Finance Teams | Budget planning and cost management |
-| Service Management | Defining service levels and support models |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Business Stakeholders | Understanding requirements and managing expectations | Consumes From |
+| Hyper-V Architect | Collaborating on technical strategy and architecture | Consumes From |
+| Hyper-V Engineering Teams | Providing direction on implementation priorities | Provides To |
+| Windows Server Teams | Coordinating platform dependencies and roadmaps | Collaborates |
+| Procurement | Managing licensing and vendor relationships | Collaborates |
+| Finance Teams | Budget planning and cost management | Collaborates |
+| Service Management | Defining service levels and support models | Collaborates |
 
 ## Key Performance Indicators
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Hyper-V Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, develops automation solutions, and provides technical leadership for the virtualization team. This role focuses on optimization, advanced implementations, troubleshooting critical issues, and mentoring other team members.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Hyper-V solution design and delivery within the Hyper-V Architect's reference architecture
+- **Experience Anchor:** 5+ years in Hyper-V or Windows virtualisation engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Hyper-V platform architecture and standards (Architect-owned); advanced Windows Server configuration ownership (Windows Server Teams-owned, this role collaborates with it); complex network design ownership (Network Teams-owned, this role coordinates with it)
+- **Escalates To:** Hyper-V Architect — architecture design and standards development support
+- **Escalated To By:** Hyper-V Engineers on technical leadership and mentoring needs
 
 ## Business Impact
 
@@ -79,16 +89,16 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Hyper-V Architect | Supporting architecture design and standards development |
-| Hyper-V Product Owner | Providing technical input on roadmaps and feature prioritization |
-| Hyper-V Engineers | Mentoring and providing technical leadership |
-| Windows Server Teams | Collaborating on advanced Windows configurations |
-| Cloud Teams | Integration with Azure and hybrid scenarios |
-| Storage Teams | Advanced storage configurations and troubleshooting |
-| Network Teams | Complex network designs for virtualization |
-| Security Teams | Advanced security implementations for virtual environments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Hyper-V Architect | Supporting architecture design and standards development | Escalates To |
+| Hyper-V Product Owner | Providing technical input on roadmaps and feature prioritization | Collaborates |
+| Hyper-V Engineers | Mentoring and providing technical leadership | Provides To |
+| Windows Server Teams | Collaborating on advanced Windows configurations | Collaborates |
+| Cloud Teams | Integration with Azure and hybrid scenarios | Collaborates |
+| Storage Teams | Advanced storage configurations and troubleshooting | Collaborates |
+| Network Teams | Complex network designs for virtualization | Collaborates |
+| Security Teams | Advanced security implementations for virtual environments | Governed By |
 
 ## Key Performance Indicators
 

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors Nutanix Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Nutanix Architect designs and oversees the organization's hyperconverged infrastructure (HCI) based on Nutanix technology. This role ensures the delivery of a scalable, efficient, and resilient platform that meets business requirements for application hosting and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — Nutanix hyperconverged infrastructure architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in virtualisation or hyperconverged infrastructure architecture with demonstrated Nutanix ownership — operates independently on domain-wide Nutanix architecture decisions
+- **Out of Scope:** VMware or Hyper-V virtualisation architecture (VMware/Hyper-V Architects-owned — parallel, non-Nutanix virtualisation ladders); server hardware specification (Server Hardware Architect-owned, this role consumes it); database workload tuning detail (Database Architect-owned, this role optimises Nutanix for it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** Nutanix Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Architect | Hardware specifications for Nutanix nodes |
-| Database Architect | Database workload optimization on Nutanix |
-| Kubernetes Architect | Container solutions with Nutanix Karbon |
-| Backup Solutions Architect | Nutanix data protection strategies |
-| Cloud Platform Architects | Hybrid cloud solutions with Nutanix Xi |
-| application architects | Workload placement |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Architect | Hardware specifications for Nutanix nodes | Consumes From |
+| Database Architect | Database workload optimization on Nutanix | Collaborates |
+| Kubernetes Architect | Container solutions with Nutanix Karbon | Collaborates |
+| Backup Solutions Architect | Nutanix data protection strategies | Collaborates |
+| Cloud Platform Architects | Hybrid cloud solutions with Nutanix Xi | Collaborates |
+| application architects | Workload placement | Provides To |
 
 ## Key Technologies
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | Nutanix Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Nutanix Engineer implements and maintains hyperconverged infrastructure based on Nutanix technology. Working with the Nutanix Architect and Product Owner, this role ensures reliable, secure, and optimized Nutanix environments supporting various business workloads.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of Nutanix cluster provisioning and infrastructure tasks to defined standards
+- **Experience Anchor:** 1-3 years in Nutanix or hyperconverged infrastructure engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** Nutanix architecture and solution design (Senior Engineers and the Architect-owned); server hardware physical infrastructure ownership (Server Hardware Engineers-owned, this role coordinates with it); network connectivity design (Network Engineers-owned, this role coordinates with it)
+- **Escalates To:** Nutanix Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on infrastructure needs
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Nutanix Product Owner | Task prioritization |
-| Server Hardware Engineers | Physical infrastructure |
-| Network Engineers | Connectivity requirements |
-| Security Engineers | Infrastructure security |
-| Nutanix Architect | Implementation activities |
-| application teams | Infrastructure needs |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Nutanix Product Owner | Task prioritization | Consumes From |
+| Server Hardware Engineers | Physical infrastructure | Collaborates |
+| Network Engineers | Connectivity requirements | Collaborates |
+| Security Engineers | Infrastructure security | Governed By |
+| Nutanix Architect | Implementation activities | Escalates To |
+| application teams | Infrastructure needs | Provides To |
 
 ## Key Technologies
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Nutanix Product Owner manages the development and lifecycle of the organization's Nutanix hyperconverged infrastructure (HCI) solutions. This role leads a team of Nutanix architects and engineers, ensuring that hyperconverged services meet business requirements, performance targets, and operational standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — Nutanix platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Nutanix technical architecture (Nutanix Architect-owned); server hardware procurement roadmap (Server Hardware Product Owner-owned, this role aligns to it); operational service transition ownership (Service Delivery Managers-owned, this role coordinates with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on infrastructure requirements
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Product Owner | Nutanix hardware planning |
-| Nutanix Architect | Technical strategy and design |
-| Application Product Owners | Infrastructure requirements |
-| Service Delivery Managers | Operational transitions |
-| business stakeholders | Service requirements |
-| IT leadership | Hyperconverged strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Product Owner | Nutanix hardware planning | Collaborates |
+| Nutanix Architect | Technical strategy and design | Consumes From |
+| Application Product Owners | Infrastructure requirements | Consumes From |
+| Service Delivery Managers | Operational transitions | Collaborates |
+| business stakeholders | Service requirements | Consumes From |
+| IT leadership | Hyperconverged strategy and investments | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | Nutanix Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The Nutanix Senior Engineer leads the implementation and optimization of complex Nutanix hyperconverged solutions. This role provides technical leadership for Nutanix deployments, migrations, and operations while working closely with architects to translate HCI designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced Nutanix solution design and delivery within the Nutanix Architect's reference architecture
+- **Experience Anchor:** 5+ years in Nutanix or hyperconverged infrastructure engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** Nutanix platform architecture and standards (Architect-owned); database workload optimisation ownership (Database Senior Engineers-owned, this role coordinates with it); hybrid cloud integration ownership (Cloud Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** Nutanix Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** Nutanix Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -61,14 +71,14 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Nutanix Architect | Solution design and implementation strategy |
-| Nutanix Product Owner | Technical planning and roadmap execution |
-| Database Senior Engineers | Optimizing database workloads |
-| Security Senior Engineers | Infrastructure security controls |
-| Cloud Senior Engineers | Hybrid cloud integrations |
-| Nutanix Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Nutanix Architect | Solution design and implementation strategy | Escalates To |
+| Nutanix Product Owner | Technical planning and roadmap execution | Collaborates |
+| Database Senior Engineers | Optimizing database workloads | Collaborates |
+| Security Senior Engineers | Infrastructure security controls | Governed By |
+| Cloud Senior Engineers | Hybrid cloud integrations | Collaborates |
+| Nutanix Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (sets technical direction and mentors VMware Senior Engineers; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The VMware Architect designs and oversees the organization's virtualization infrastructure based on VMware technologies. This role ensures the delivery of a scalable, performant, and reliable virtualization platform supporting enterprise applications and services.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain-wide — VMware virtualisation platform architecture and technology standards across the chapter
+- **Experience Anchor:** 8+ years in virtualisation architecture with demonstrated architecture-level delivery — operates independently on domain-wide VMware architecture decisions
+- **Out of Scope:** Nutanix or Hyper-V virtualisation architecture (Nutanix/Hyper-V Architects-owned — parallel, non-VMware virtualisation ladders); server hardware specification (Server Hardware Architect-owned, this role consumes it); virtual storage detail implementation (Storage Architects-owned, this role coordinates with it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — chapter-wide priorities and cross-domain investment decisions
+- **Escalated To By:** VMware Senior Engineers on solution design and implementation strategy
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The VMware Architect designs and oversees the organization's virtualization infr
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Architect | Hardware specifications for VMware hosts |
-| Storage Architects | Virtual storage design |
-| Network Architects | Virtual networking solutions |
-| Cloud Platform Architects | Hybrid cloud integration |
-| Backup Solutions Architect | Virtualization backup strategies |
-| Security Architects | Virtual infrastructure security |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Architect | Hardware specifications for VMware hosts | Consumes From |
+| Storage Architects | Virtual storage design | Collaborates |
+| Network Architects | Virtual networking solutions | Collaborates |
+| Cloud Platform Architects | Hybrid cloud integration | Collaborates |
+| Backup Solutions Architect | Virtualization backup strategies | Collaborates |
+| Security Architects | Virtual infrastructure security | Governed By |
 
 ## Key Technologies
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
+| **Reports To** | VMware Senior Engineer |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The VMware Engineer implements and maintains virtualization infrastructure based on VMware technologies. Working with the VMware Architect and Product Owner, this role ensures reliable, secure, and optimized virtualization services supporting business applications and workloads.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of VM provisioning and datastore configuration tasks to defined standards
+- **Experience Anchor:** 1-3 years in virtualisation engineering — works under guidance, building toward independent delivery
+- **Out of Scope:** VMware architecture and solution design (Senior Engineers and the Architect-owned); server hardware host configuration ownership (Server Hardware Engineers-owned, this role coordinates with it); virtual network implementation ownership (Network Engineers-owned, this role coordinates with it)
+- **Escalates To:** VMware Senior Engineer — design-level questions and complex implementation issues
+- **Escalated To By:** application teams on VM requirements
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| VMware Product Owner | Task prioritization |
-| Server Hardware Engineers | Host configuration |
-| Storage Engineers | Datastore configuration |
-| Network Engineers | Virtual network implementation |
-| VMware Architect | Implementation activities |
-| application teams | VM requirements |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| VMware Product Owner | Task prioritization | Consumes From |
+| Server Hardware Engineers | Host configuration | Collaborates |
+| Storage Engineers | Datastore configuration | Collaborates |
+| Network Engineers | Virtual network implementation | Collaborates |
+| VMware Architect | Implementation activities | Escalates To |
+| application teams | VM requirements | Provides To |
 
 ## Key Technologies
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The VMware Product Owner manages the development and lifecycle of the organization's VMware-based virtualization solutions. This role leads a team of VMware architects and engineers, ensuring that virtualization services meet business requirements, performance targets, and operational standards.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — VMware platform backlog, investment roadmap, and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management — operates independently on backlog and roadmap decisions
+- **Out of Scope:** VMware technical architecture (VMware Architect-owned); host infrastructure procurement roadmap (Server Hardware Product Owner-owned, this role aligns to it); virtual storage service roadmap (Storage Product Owner-owned, this role aligns to it)
+- **Escalates To:** Cloud, Platform & Infrastructure Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Application Product Owners on virtualization requirements
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| Server Hardware Product Owner | Host infrastructure |
-| Storage Product Owner | Virtual storage services |
-| VMware Architect | Technical strategy and design |
-| Application Product Owners | Virtualization requirements |
-| business stakeholders | Virtualization service delivery |
-| IT leadership | Virtualization strategy and investments |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Server Hardware Product Owner | Host infrastructure | Collaborates |
+| Storage Product Owner | Virtual storage services | Collaborates |
+| VMware Architect | Technical strategy and design | Consumes From |
+| Application Product Owners | Virtualization requirements | Consumes From |
+| business stakeholders | Virtualization service delivery | Provides To |
+| IT leadership | Virtualization strategy and investments | Provides To |
 
 ## Key Focus Areas
 

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -5,6 +5,8 @@
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |
+| **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
+| **Direct Reports** | VMware Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -12,6 +14,14 @@
 ## Role Overview
 
 The VMware Senior Engineer leads the implementation and optimization of complex VMware virtualization solutions. This role provides technical leadership for virtualization deployments, migrations, and operations while working closely with architects to translate virtualization designs into effective implementations.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — advanced VMware solution design and delivery within the VMware Architect's reference architecture
+- **Experience Anchor:** 5+ years in VMware engineering with demonstrated independent delivery — operates independently within the Architect's reference architecture
+- **Out of Scope:** VMware platform architecture and standards (Architect-owned); advanced storage virtualisation ownership (Storage Senior Engineers-owned, this role coordinates with it); complex virtual networking design (Network Senior Engineers-owned, this role coordinates with it)
+- **Escalates To:** VMware Architect — solution design and implementation strategy exceptions
+- **Escalated To By:** VMware Engineers on technical implementation issues
 
 ## Business Impact
 
@@ -69,14 +79,14 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 
 ## Interactions with Other Roles
 
-| Role | Nature of Interaction |
-|---|---|
-| VMware Architect | Solution design and implementation strategy |
-| VMware Product Owner | Technical planning and roadmap execution |
-| Storage Senior Engineers | Advanced storage virtualization |
-| Network Senior Engineers | Complex virtual networking |
-| Security Senior Engineers | Virtualization security controls |
-| VMware Engineers | Technical implementation |
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| VMware Architect | Solution design and implementation strategy | Escalates To |
+| VMware Product Owner | Technical planning and roadmap execution | Collaborates |
+| Storage Senior Engineers | Advanced storage virtualization | Collaborates |
+| Network Senior Engineers | Complex virtual networking | Collaborates |
+| Security Senior Engineers | Virtualization security controls | Governed By |
+| VMware Engineers | Technical implementation | Provides To |
 
 ## Key Technologies
 


### PR DESCRIPTION
## Summary

Batch 7/7 of #5 — **the final batch.** Backfills **Reports To**, **Direct Reports**, **Role Scope & Boundaries**, and **Interaction Mode** across all 77 files in the Cloud, Platform & Infrastructure chapter, per `docs/role_template.md`. Merging this closes #89 and, once #5's checklist reflects it, closes #5 itself and epic #35.

- **Cloud Platforms (14 files):** AWS/Azure/GCP ladders (4 each) plus `cloud_lead_architect` and `cloud_principal_architect`.
- **Kubernetes (4 files):** `kubernetes_architect/senior_engineer/engineer/product_owner`.
- **Modern Infrastructure (15 files):** Observability ladder (4), Platform Engineering ladder (4), `infrastructure_automation_architect`, `site_reliability_engineer/senior_engineer`, `chaos_engineer`, `genai_platform_architect/engineer`, `mlops_engineer`.
- **Virtualisation (12 files):** VMware, Hyper-V, and Nutanix ladders (4 each).
- **Specialised Computing (4 files):** HPC ladder.
- **Server Hardware (8 files):** vendor-agnostic and HPE ladders (4 each).
- **Server OS (8 files):** Linux and Windows ladders (4 each).
- **Network (6 files):** `network_architect/senior_engineer/engineer/product_owner`, `network_automation_architect/engineer`.
- **FinOps (6 files):** `finops_architect/senior_engineer/engineer/product_owner`, `cloud_cost_optimization_engineer`, `cloud_economics_analyst`. `cloud_cost_optimization_standards.md` is a reference doc (no Role Level field), not a role — left untouched, consistent with the "1 reference doc skipped" the validator has always reported.

## Reporting model

Standard IC ladder, consistent with batches 2-6: Engineer → Senior Engineer; Senior Engineer and Product Owner → **Cloud, Platform & Infrastructure Chapter Lead**. Two grounded structural exceptions, plus several specialist roles with no dedicated tier of their own:

- **Cloud Platforms has an explicit three-tier hierarchy above the standard architect ladder**, stated directly in the domain's own role-overview text rather than inferred: the Cloud Principal Architect "operat[es] below the Technical Area Lead (TAL)" and reports there directly, bypassing the Chapter Lead; the Cloud Lead Architect "bridges the gap" between the Principal Architect's strategy and the AWS/Azure/GCP Cloud Architects' platform-specific designs, and reports to the Principal Architect. The three platform Architects themselves still report to the Chapter Lead like every other domain — they escalate cross-platform problems to the Cloud Lead Architect rather than straight to the Chapter Lead.
- **Network Automation Architect is a peer to Network Architect**, per its own text ("automation extends and operationalises network designs," not replaces them) — both report to the Chapter Lead, the same peer pattern as API Strategy/API Platform Architect in batch 4.
- **Site Reliability Engineer/Senior Engineer** has no Architect tier of its own anywhere in the catalog — the Senior Engineer reports to the Chapter Lead directly and escalates to the Platform Engineering Architect (its closest real architectural relationship, referenced in its own table as "SRE Architect" even though no such file exists).
- **GenAI Platform Engineer and MLOps Engineer** both report to the GenAI Platform Architect (MLOps has no dedicated architect of its own in this domain).
- **Chaos Engineer** reports to the Site Reliability Senior Engineer.

## Other fixes bundled in

- Renamed the variant `## Relationships & Collaboration` heading to canonical `## Interactions with Other Roles` in all 4 Kubernetes files and `hyperv_engineer.md` (mirroring the #7 fix, same pattern as batch 4).
- **Fully restructured FinOps's interactions tables.** The pre-existing content used a degraded pseudo-row format ("Reports to | X" as a table row, several rows with a literally empty Role cell) unlike every other domain's proper two-column table — rewritten into the standard three-column format using the same underlying stakeholder information.
- Fixed a malformed row in `hpc_architect.md` (`| Facilitates knowledge sharing and documentation | All HPC stakeholders |` — Role and Nature columns reversed).
- Merged a duplicate pair of rows in `hpc_engineer.md` that described the same researcher-training relationship twice under different phrasing.

## Verification

- `npm run validate` — 220 files checked, 0 errors, 0 warnings, 0 duplicate titles.
- `npm test` — 91/91 passing.
- `npx markdownlint-cli2` on all 77 touched files — 0 issues.
- Cross-file directional consistency spot-checked, including both structural exceptions (Cloud Platforms' TAL/Principal/Lead chain and Network Automation Architect's peer relationship) and the specialist-role reporting lines.

## Test plan

- [x] `npm run validate`
- [x] `npm test`
- [x] `npx markdownlint-cli2` on touched files
- [ ] CI green on both matrix legs

Closes #89.