### PR TITLE
feat: enforce template fields in the validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **The role template's reporting-line and interaction fields are now
+  enforced by `npm run validate` (closes #6).** With the #5 backfill
+  complete across all 219 role files, `Reports To` and `Direct Reports`
+  metadata, the `Role Scope & Boundaries` section, and the Interactions
+  table's `Interaction Mode` column are all required — missing any of them
+  is an error, not a silent omission. The canonical structure is therefore
+  now 14 sections rather than 13. `parseMeta` in `roleMeta.js` exposes
+  `reportsTo` and `directReports` alongside the existing metadata fields.
+  The Interaction Mode check matches a real table header followed by its
+  delimiter row, so the template's explanatory blockquote above the table
+  cannot satisfy it on its own.
+
 - **Reports To / Direct Reports / Role Scope & Boundaries / Interaction
   Mode backfilled for the Cloud, Platform & Infrastructure chapter (#89,
   batch 7/7 — the final batch: 77 of 219 files, completing #5).** Cloud

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ roles_master/
    - Standard levels: `architect`, `senior_engineer`, `engineer`, `product_owner`, `reliability_engineer`
    - Special levels: `product_area_lead`, `technical_area_lead`, `cloud_lead_architect`, `cloud_principal_architect`
    - Example: `Roles/kubernetes/kubernetes_platform_engineer.md`
-3. Fill in all 13 sections following the template.
+3. Fill in all 14 sections following the template.
 4. Run `npm run validate` to confirm the file has all required sections and metadata.
 5. Restart the server — new roles are picked up automatically on each request.
 
@@ -158,7 +158,7 @@ roles_master/
 
 ## Role file format
 
-Each role file follows the canonical 13-section structure. See `docs/role_template.md` for full guidance.
+Each role file follows the canonical 14-section structure. See `docs/role_template.md` for full guidance.
 
 ```markdown
 # Role Title
@@ -167,11 +167,14 @@ Each role file follows the canonical 13-section structure. See `docs/role_templa
 |---|---|
 | **Domain** | Domain Name |
 | **Role Level** | Architect / Senior Engineer / Engineer / Product Owner |
+| **Reports To** | Role this position reports to |
+| **Direct Reports** | Roles managed, or "None" for individual contributors |
 | **Last Reviewed** | YYYY-MM |
 
 ---
 
 ## Role Overview
+## Role Scope & Boundaries
 ## Business Impact
 ## Key Responsibilities
 ## Key Decisions & Accountabilities
@@ -213,7 +216,9 @@ Runs the Node.js built-in test runner (`node --test`) against `test/` — covers
 npm run validate
 ```
 
-Checks every role file against the canonical 13-section template and required metadata fields (`Domain`, `Role Level`, `Last Reviewed`). Missing sections or metadata are reported as errors (exit code 1); non-canonical values (e.g. an unrecognized `Role Level`, or a `Domain` that doesn't match its folder's canonical label) are reported as warnings. Pass `--strict` to fail the build on warnings too.
+Checks every role file against the canonical 14-section template and required metadata fields (`Domain`, `Role Level`, `Reports To`, `Direct Reports`, `Last Reviewed`), and requires the Interactions table to carry an `Interaction Mode` column. Missing sections, metadata, or the mode column are reported as errors (exit code 1); non-canonical values (e.g. an unrecognized `Role Level`, or a `Domain` that doesn't match its folder's canonical label) are reported as warnings. Pass `--strict` to fail the build on warnings too.
+
+Duplicate H1 role titles across the catalog are also errors — the same title appearing in two files is a content-integrity bug that shipped twice before this check existed.
 
 ### Checking counts
 

--- a/roleMeta.js
+++ b/roleMeta.js
@@ -135,10 +135,12 @@ function parseMeta(content) {
   const titleMatch = clean.match(/^#\s+(.+)/m);
   return {
     title:        titleMatch ? titleMatch[1].trim() : null,
-    domain:       parseField(content, 'Domain'),
-    chapter:      parseField(content, 'Chapter:') || parseField(content, 'Chapter'),
-    levelRaw:     parseField(content, 'Role Level'),
-    lastReviewed: parseField(content, 'Last Reviewed'),
+    domain:         parseField(content, 'Domain'),
+    chapter:        parseField(content, 'Chapter:') || parseField(content, 'Chapter'),
+    levelRaw:       parseField(content, 'Role Level'),
+    reportsTo:      parseField(content, 'Reports To'),
+    directReports:  parseField(content, 'Direct Reports'),
+    lastReviewed:   parseField(content, 'Last Reviewed'),
   };
 }
 

--- a/test/roleMeta.test.js
+++ b/test/roleMeta.test.js
@@ -13,6 +13,8 @@ test('parseMeta extracts title and metadata fields', () => {
     '|---|---|',
     '| **Domain** | Example Domain |',
     '| **Role Level** | Architect |',
+    '| **Reports To** | Example Chapter Lead |',
+    '| **Direct Reports** | None |',
     '| **Last Reviewed** | 2026-03 |',
     '',
     '---',
@@ -24,7 +26,15 @@ test('parseMeta extracts title and metadata fields', () => {
   assert.equal(meta.title, 'Example Architect');
   assert.equal(meta.domain, 'Example Domain');
   assert.equal(meta.levelRaw, 'Architect');
+  assert.equal(meta.reportsTo, 'Example Chapter Lead');
+  assert.equal(meta.directReports, 'None');
   assert.equal(meta.lastReviewed, '2026-03');
+});
+
+test('parseMeta returns null for reporting-line fields when absent', () => {
+  const meta = parseMeta('# Bare Role\n\n| **Role Level** | Engineer |\n');
+  assert.equal(meta.reportsTo, null);
+  assert.equal(meta.directReports, null);
 });
 
 test('parseMeta strips a leading UTF-8 BOM before matching the H1 title', () => {

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -31,7 +31,11 @@ test.after(() => {
 function completeRole({ except = null, transform = null } = {}) {
   const sections = REQUIRED_SECTIONS
     .filter(s => s.name !== except)
-    .map(s => `## ${s.name}\n\nContent for ${s.name}.\n`)
+    .map(s => s.name === 'Interactions with Other Roles'
+      // This section must carry the Interaction Mode column (#6), so it needs
+      // a real table rather than the placeholder prose the others use.
+      ? `## ${s.name}\n\n| Role | Nature of Interaction | Interaction Mode |\n|---|---|---|\n| Peer Role | Shared delivery work | Collaborates |\n`
+      : `## ${s.name}\n\nContent for ${s.name}.\n`)
     .join('\n');
   let content = `# Test Role
 
@@ -39,6 +43,8 @@ function completeRole({ except = null, transform = null } = {}) {
 |---|---|
 | **Domain** | testdomain |
 | **Role Level** | Engineer |
+| **Reports To** | Test Chapter Lead |
+| **Direct Reports** | None |
 | **Last Reviewed** | 2026-07 |
 
 ${sections}`;
@@ -68,8 +74,14 @@ test('each required section individually missing produces exactly that error', (
   for (const section of REQUIRED_SECTIONS) {
     const file = writeFixture('missing-section.md', completeRole({ except: section.name }));
     const r = validateFile(file, tmpRoot);
-    assert.deepEqual(r.errors, [`Missing section: ## ${section.name}`],
-      `expected a single missing-section error for "${section.name}"`);
+    const expected = [`Missing section: ## ${section.name}`];
+    // Dropping the Interactions section also drops the table carrying the
+    // Interaction Mode column, so both errors are legitimately expected.
+    if (section.name === 'Interactions with Other Roles') {
+      expected.push('Interactions table is missing the "Interaction Mode" column');
+    }
+    assert.deepEqual(r.errors, expected,
+      `unexpected errors for a file missing "${section.name}"`);
   }
 });
 
@@ -107,6 +119,64 @@ test('missing Last Reviewed metadata is an error', () => {
   const file = writeFixture('no-reviewed.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Last Reviewed\*\*.*\n/, '') }));
   const r = validateFile(file, tmpRoot);
   assert.ok(r.errors.includes('Missing **Last Reviewed** metadata field'));
+});
+
+// ── template fields enforced after the #5 backfill (#6) ──
+
+test('missing Reports To metadata is an error', () => {
+  const file = writeFixture('no-reports-to.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Reports To\*\*.*\n/, '') }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, ['Missing **Reports To** metadata field']);
+});
+
+test('missing Direct Reports metadata is an error', () => {
+  const file = writeFixture('no-direct-reports.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Direct Reports\*\*.*\n/, '') }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, ['Missing **Direct Reports** metadata field']);
+});
+
+test('"None" is a valid Direct Reports value for individual contributors', () => {
+  const file = writeFixture('ic-role.md', completeRole());
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+});
+
+test('Role Scope & Boundaries is a required section', () => {
+  const file = writeFixture('no-scope.md', completeRole({ except: 'Role Scope & Boundaries' }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, ['Missing section: ## Role Scope & Boundaries']);
+});
+
+test('"Role Scope and Boundaries" is accepted as an equivalent heading', () => {
+  const file = writeFixture('scope-and.md', completeRole({
+    transform: c => c.replace('## Role Scope & Boundaries', '## Role Scope and Boundaries'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+});
+
+test('an Interactions table without the Interaction Mode column is an error', () => {
+  const file = writeFixture('no-mode-column.md', completeRole({
+    transform: c => c
+      .replace('| Role | Nature of Interaction | Interaction Mode |', '| Role | Nature of Interaction |')
+      .replace('|---|---|---|', '|---|---|')
+      .replace('| Peer Role | Shared delivery work | Collaborates |', '| Peer Role | Shared delivery work |'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, ['Interactions table is missing the "Interaction Mode" column']);
+});
+
+test('prose mentioning Interaction Mode does not satisfy the column check', () => {
+  // docs/role_template.md explains the Interaction Mode vocabulary in a
+  // blockquote above the table; that text alone must not count as the column.
+  const file = writeFixture('mode-prose-only.md', completeRole({
+    transform: c => c
+      .replace('| Role | Nature of Interaction | Interaction Mode |', '> **Interaction Mode** describes the direction of the relationship.\n\n| Role | Nature of Interaction |')
+      .replace('|---|---|---|', '|---|---|')
+      .replace('| Peer Role | Shared delivery work | Collaborates |', '| Peer Role | Shared delivery work |'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, ['Interactions table is missing the "Interaction Mode" column']);
 });
 
 // ── warnings (not errors) ────────────────────────────────

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -1,4 +1,4 @@
-// Validates every role file under Roles/ against the canonical 13-section
+// Validates every role file under Roles/ against the canonical 14-section
 // structure defined in docs/role_template.md. Zero dependencies — run with
 // `npm run validate` or `node validate-roles.js [--strict]`.
 //
@@ -22,6 +22,7 @@ const STRICT     = process.argv.includes('--strict');
 // failing on cosmetic wording differences (tracked as a follow-up cleanup).
 const REQUIRED_SECTIONS = [
   { name: 'Role Overview',                          patterns: [/^##\s+Role Overview/im] },
+  { name: 'Role Scope & Boundaries',                patterns: [/^##\s+Role Scope (&|and) Boundaries/im] },
   { name: 'Business Impact',                        patterns: [/^##\s+Business Impact/im] },
   { name: 'Key Responsibilities',                    patterns: [/^##\s+Key Responsibilities/im] },
   { name: 'Key Decisions & Accountabilities',        patterns: [/^##\s+Key Decisions (&|and) Accountabilities/im] },
@@ -34,6 +35,14 @@ const REQUIRED_SECTIONS = [
   { name: 'Career Development Path',                 patterns: [/^##\s+Career Development Path/im] },
   { name: 'Recommended Certifications & Learning Paths', patterns: [/^##\s+Recommended Certifications (&|and) Learning Paths/im] },
 ];
+
+// The Interactions table must carry an Interaction Mode column (Collaborates /
+// Consumes From / Provides To / Governed By / Escalates To) so each cross-role
+// relationship states its direction, not just its subject. Matches a table
+// header row naming the column followed by the delimiter row, rather than a
+// bare mention of the words — the template's explanatory blockquote above the
+// table would otherwise satisfy a looser check.
+const INTERACTION_MODE_COLUMN = /^\|.*Interaction Mode.*\|[ \t]*\r?\n\|[\s:|-]+\|/im;
 
 function listRoleFiles(rolesDir = ROLES_DIR) {
   const files = [];
@@ -82,6 +91,12 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
     warnings.push(`Role Level "${meta.levelRaw}" is not in the canonical level vocabulary (roleMeta.js)`);
   }
 
+  // Reporting line. Backfilled across all role files in #5; enforced here so
+  // the vertical relationship can't silently go missing from new roles the
+  // way it was absent from the whole catalogue before that backfill.
+  if (!meta.reportsTo) errors.push('Missing **Reports To** metadata field');
+  if (!meta.directReports) errors.push('Missing **Direct Reports** metadata field');
+
   if (!meta.lastReviewed) {
     errors.push('Missing **Last Reviewed** metadata field');
   } else if (!/^\d{4}-\d{2}$/.test(meta.lastReviewed)) {
@@ -91,6 +106,10 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
   for (const section of REQUIRED_SECTIONS) {
     const found = section.patterns.some(re => re.test(content));
     if (!found) errors.push(`Missing section: ## ${section.name}`);
+  }
+
+  if (!INTERACTION_MODE_COLUMN.test(content)) {
+    errors.push('Interactions table is missing the "Interaction Mode" column');
   }
 
   return { rel, errors, warnings, skipped: false };


### PR DESCRIPTION
Closes #6.

## What changed

The #5 backfill (7 chapter batches, PRs #82 and #90–#95) landed `Reports To`, `Direct Reports`, `Role Scope & Boundaries`, and `Interaction Mode` across all 219 role files. Those checks were deliberately held back until the backfill completed — enabling them earlier would have failed every file at once. This turns them on.

**`roleMeta.js`** — `parseMeta` now exposes `reportsTo` and `directReports` alongside the existing metadata fields.

**`validate-roles.js`**
- Missing `**Reports To**` or `**Direct Reports**` metadata → error.
- `## Role Scope & Boundaries` added to `REQUIRED_SECTIONS` (accepts `and` as well as `&`, matching the existing convention for other headings).
- The Interactions table must carry an `Interaction Mode` column → error if absent.
- Canonical structure is now **14 sections**, not 13.

The Interaction Mode check matches a table header row followed by its delimiter row, rather than a bare mention of the words. `docs/role_template.md` explains the mode vocabulary in a blockquote above the table, and a looser check would have been satisfied by that prose alone — there's a regression test for exactly this.

**Docs** — README's validator description updated, plus its role-file-format example, which was stale: it predated the reporting-line fields and still showed the 13-section shape.

## How it was verified

- `npm test` — 99/99 pass (up from 98; new cases cover each new check, the `and`/`&` heading variant, `None` as a valid `Direct Reports` value, and the prose-doesn't-count regression).
- `npm run validate` — **0 errors, 0 warnings** across all 220 files (219 roles + 1 reference doc skipped). Confirmed before committing that all 219 files already satisfy every new check, so this cannot break CI.
- `npm run check-counts` and markdownlint — clean.

Existing fixtures in `test/validate-roles.test.js` needed the new fields added. One behavioural note: removing the Interactions section now legitimately produces two errors (the missing section *and* the missing mode column, since the table lives inside it) — the per-section test asserts that explicitly rather than loosening to a substring match.