### PR TITLE
ci: categorise generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,53 @@
+# Categorises GitHub's auto-generated release notes.
+#
+# Categories are matched in order against each merged PR's labels, and a PR
+# lands in the first category it matches, so "*" must stay last. Note these are
+# the *PR's* labels, not the linked issue's — an unlabelled PR falls through to
+# "Other Changes" regardless of how its issue was labelled (see #100).
+#
+# Preview the output before tagging:
+#   gh api repos/{owner}/{repo}/releases/generate-notes -f tag_name=vX.Y.Z --jq .body
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Security
+      labels:
+        - security
+    - title: Features
+      labels:
+        - enhancement
+    - title: Content & Backfill
+      labels:
+        - backfill
+    - title: Fixes
+      labels:
+        - bug
+    - title: Accessibility
+      labels:
+        - accessibility
+    - title: Performance
+      labels:
+        - performance
+    - title: Visualization
+      labels:
+        - visualization
+        - ux
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Tooling & CI
+      labels:
+        - tooling
+        - ci-cd
+        - testing
+        - developer-experience
+    - title: Maintenance & Refactoring
+      labels:
+        - maintenance
+        - refactor
+        - process
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## What changed

Adds `.github/release.yml`, mapping the repo's existing category labels to release-note sections so GitHub's auto-generated notes are grouped instead of a flat list.

Categories, in match order: Security → Features → Content & Backfill → Fixes → Accessibility → Performance → Visualization → Documentation → Tooling & CI → Maintenance & Refactoring → Other Changes (`"*"` catch-all, last).

Also adds an `ignore-for-release` label so release/chore PRs can be kept out of the notes.

## How it was verified

YAML parsed locally (11 categories, `"*"` confirmed last, exclude block intact), then the live API was asked to generate notes against this branch:

```bash
gh api repos/{owner}/{repo}/releases/generate-notes   -f tag_name=v1.7.0-probe -f target_commitish=ci/release-notes-config -f previous_tag_name=v1.5.0 --jq .body
```

GitHub confirms it read the config:

```
<!-- Release notes generated using configuration in .github/release.yml at ci/release-notes-config -->
```

All 14 PRs currently render under **Other Changes** — expected, and the point of the follow-up: categories match the **PR's** labels, and no merged PR in this repo carries any. The config is correct but inert until PRs are labelled at open time (#100).

No workflow, action, or scheduled job is added. This does not replace `CHANGELOG.md` — generated notes say what merged, the changelog says what changed and why.

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)