### PR TITLE
ci: label PRs from conventional-commit title prefix

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,81 @@
+name: PR labeler
+
+# Derives a category label from the conventional-commit prefix already used in
+# every PR title (feat:, fix:, docs:, ci:, ...). This is what makes
+# .github/release.yml work: generated release notes categorise by the *PR's*
+# labels, and an unlabelled PR falls through to "Other Changes".
+#
+# Uses `pull_request` rather than `pull_request_target`. The repo is private, so
+# there are no fork PRs to accommodate, and pull_request_target would hand a
+# write token to a workflow evaluating untrusted input for no benefit.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+# Least-privilege: this workflow only reads and edits PR labels. It never
+# checks out code, reads contents, or writes to the repository.
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label from title prefix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Map conventional-commit prefix to a category label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Passed as an environment variable, never interpolated into the
+          # script body -- a PR title is attacker-controlled text and `${{ }}`
+          # inside `run:` would be a shell injection.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # "feat(scope)!: subject" -> "feat"
+          prefix="${PR_TITLE%%:*}"
+          prefix="${prefix%%(*}"
+          prefix="$(printf '%s' "$prefix" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]!')"
+
+          case "$prefix" in
+            feat)        label="enhancement" ;;
+            fix)         label="bug" ;;
+            docs)        label="documentation" ;;
+            ci)          label="ci-cd" ;;
+            test)        label="testing" ;;
+            perf)        label="performance" ;;
+            refactor)    label="refactor" ;;
+            build)       label="tooling" ;;
+            chore|style) label="maintenance" ;;
+            release)     label="ignore-for-release" ;;
+            *)           label="" ;;
+          esac
+
+          if [ -z "$label" ]; then
+            echo "No recognised conventional-commit prefix in: $PR_TITLE"
+            echo "Leaving the PR unlabelled; label it by hand if it should appear in release notes."
+            exit 0
+          fi
+
+          # Respect manual labelling: if a human already put this PR in a
+          # category, don't add a second one. release.yml matches categories in
+          # order, so two category labels would silently pick the earlier one.
+          known="accessibility backfill bug ci-cd documentation enhancement
+                 ignore-for-release maintenance performance process refactor
+                 security testing tooling ux visualization"
+          current="$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')"
+
+          for c in $current; do
+            for k in $known; do
+              if [ "$c" = "$k" ]; then
+                echo "PR #$PR_NUMBER already has category label '$c' -- leaving it alone."
+                exit 0
+              fi
+            done
+          done
+
+          echo "Title prefix '$prefix' -> label '$label'"
+          gh pr edit "$PR_NUMBER" --add-label "$label"


### PR DESCRIPTION
## What changed

Adds `.github/workflows/pr-label.yml`, which reads the conventional-commit prefix from a PR's title and applies the matching category label.

This is the other half of #101 — release-note categorisation matches the **PR's** labels, and no PR in this repo has ever carried one, so without this every entry falls through to "Other Changes".

| Prefix | Label |
|---|---|
| `feat` | `enhancement` |
| `fix` | `bug` |
| `docs` | `documentation` |
| `ci` | `ci-cd` |
| `test` | `testing` |
| `perf` | `performance` |
| `refactor` | `refactor` |
| `build` | `tooling` |
| `chore`, `style` | `maintenance` |
| `release` | `ignore-for-release` |

Two deliberate restraints: it **skips a PR that already carries a category label** (a human's choice wins — and two category labels would silently resolve to whichever `release.yml` lists first), and an **unrecognised title is left alone** rather than guessed at.

## Security notes

- **`pull_request`, not `pull_request_target`.** The repo is private, so there are no fork PRs to accommodate, and `pull_request_target` would hand a write token to a workflow evaluating attacker-controlled input for no benefit.
- **The PR title is passed via `env:`, never interpolated into the `run:` body.** A `${{ }}` expression carrying a PR title into a shell script is a command-injection sink.
- **`permissions: pull-requests: write`** only — no `contents`, no checkout, no third-party action.

## How it was verified

The mapping logic was extracted and run against **all 16 real PR titles in this repo** plus edge cases. Every real title mapped correctly:

```
ci: categorise generated release notes        -> ci-cd
release: 1.6.0                                -> ignore-for-release
docs: refresh stale README and template ...   -> documentation
feat: enforce template fields in the ...      -> enhancement
fix: End User & Workplace Chapter Lead ...    -> bug
```

Edge cases: `feat(validator)!: ...` → `enhancement` (scope and `!` stripped), `FIX:` → `bug` (case-insensitive), `fix: handle a: colon in the subject` → `bug` (only the first colon splits), `Update the readme` → no label (no guess).

YAML parsed and confirmed: `on.pull_request.types = [opened, edited, reopened]`, one step, zero actions used.

**This PR self-tests it** — the workflow runs on this PR, whose title starts with `ci:`, so it should apply `ci-cd` to itself.

Closes #100
Depends on #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
