### PR TITLE
feat: backfill enterprise_architecture engineer and product_owner tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/JeanKadang/DOC-ITRoles/actions/workflows/ci.yml/badge.svg)](https://github.com/JeanKadang/DOC-ITRoles/actions/workflows/ci.yml)
 
-A portable role definition repository for infrastructure and platform engineering teams. Covers 33 domains grouped into 7 chapters, and 219 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
+A portable role definition repository for infrastructure and platform engineering teams. Covers 33 domains grouped into 7 chapters, and 221 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
 
 Repository: [github.com/JeanKadang/DOC-ITRoles](https://github.com/JeanKadang/DOC-ITRoles) (private). Issues and backlog are tracked on the [Issues tab](https://github.com/JeanKadang/DOC-ITRoles/issues).
 
@@ -107,7 +107,7 @@ roles_master/
 ├── .github/
 │   ├── workflows/ci.yml                    # CI: npm test, npm run validate, check-counts, markdownlint
 │   └── dependabot.yml                      # Weekly GitHub Actions + npm update checks
-├── Roles/                                  # All role definitions (33 domains, 219 roles)
+├── Roles/                                  # All role definitions (33 domains, 221 roles)
 │   ├── leadership/                         # SVP, CISO, Chapter Leads, TAL, PAL
 │   ├── c_suite/                            # CEO, CTO, CIO, CFO
 │   ├── cloud_platforms/                    # Azure, AWS, GCP + Lead/Principal

--- a/Roles/enterprise_architecture/enterprise_architecture_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_engineer.md
@@ -1,0 +1,156 @@
+# Enterprise Architecture Engineer
+
+| Field | Value |
+|---|---|
+| **Domain** | Enterprise Architecture |
+| **Chapter:** | Service & Governance |
+| **Role Level** | Engineer |
+| **Reports To** | Enterprise Architecture Senior Engineer |
+| **Direct Reports** | None |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Enterprise Architecture Engineer supports the enterprise architecture function's day-to-day operations: keeping the architecture repository current, producing first-draft diagrams and documentation, and handling routine data-quality tasks in the EA tooling. This is an entry point into architecture practice for engineers who want to move from domain delivery work into architecture — the role builds the foundational habits of accurate modelling, standards-aware documentation, and governance-process discipline under the direction of the Senior Engineer.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — execution of architecture repository maintenance and documentation tasks to defined standards
+- **Experience Anchor:** 1-3 years in an architecture, ITSM, or technical documentation role — works under guidance, building toward independent ownership of repository and documentation workstreams
+- **Out of Scope:** Enterprise architecture strategy and standards decisions (Enterprise Architect-owned); solution-level design (Solution Architect-owned); reference architecture authorship without senior review (Senior Engineer-owned); architecture review board facilitation (Senior Engineer-owned)
+- **Escalates To:** Enterprise Architecture Senior Engineer — tooling issues, data-quality questions, and documentation standards clarification
+- **Escalated To By:** No standing escalation source; may field ad hoc architecture repository questions from delivery teams
+
+## Business Impact
+
+- **Business Objective:** Keep the enterprise architecture repository and supporting documentation accurate and current so architects, delivery teams, and governance forums can rely on it for decision-making
+- **Value Metrics:** Architecture repository data-quality score, documentation update turnaround time, diagram/artefact rework rate
+- **Key Stakeholders:** Enterprise Architecture Senior Engineer, Enterprise Architect, Solution Architect, domain architects, delivery teams consuming architecture documentation
+- **Processes Supported:** Architecture repository maintenance, reference architecture documentation, architecture review board pack preparation, technology radar data collection
+
+## Key Responsibilities
+
+- Update the enterprise architecture repository (LeanIX, Bizzdesign, ARIS, or equivalent) with new applications, capabilities, and technology records under senior engineer direction
+- Produce first-draft architecture diagrams (capability maps, system context diagrams) from source material for senior review
+- Maintain the technology radar's underlying data set, tracking version and lifecycle status changes for existing entries
+- Assist with architecture review board pack preparation: collating materials, updating the decision log, and tracking action items
+- Perform data-quality checks on the architecture repository and flag inconsistencies to the Senior Engineer
+- Respond to routine, well-precedented documentation and repository access questions from delivery teams
+- Maintain personal working knowledge of architecture modelling notation (ArchiMate, C4) sufficient to update existing artefacts accurately
+- Support onboarding logistics for the architecture community of practice (scheduling, materials, attendance tracking)
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Routine architecture repository updates and data-entry accuracy | Reference architecture content and pattern decisions (Senior Engineer-owned) |
+| First-draft diagram production from supplied source material | Architecture review board agenda and decision facilitation (Senior Engineer-owned) |
+| Technology radar data-set currency for existing entries | New technology radar entries and lifecycle categorisation (Senior Engineer-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Working knowledge of at least one enterprise architecture platform (LeanIX, Bizzdesign, ARIS, Sparx EA) or willingness to learn quickly
+- Basic proficiency with a diagramming notation (ArchiMate, UML, or C4) sufficient to update existing diagrams accurately
+- Comfortable working in spreadsheets and structured documentation formats for data-quality tasks
+- Familiarity with diagramming and documentation tools: Miro, draw.io, Confluence, SharePoint
+- Basic understanding of enterprise architecture concepts (capability, application, technology layers)
+
+**Soft Skills & Leadership:**
+
+- Careful, detail-oriented approach to data entry and documentation accuracy
+- Clear written communication for documentation intended for a technical audience
+- Willingness to ask questions rather than guess when architecture terminology or standards are unclear
+
+**Technology Proficiency Levels:**
+
+- **Expert level required:** Confluence/SharePoint (documentation), Miro/draw.io (diagramming)
+- **Proficient level required:** LeanIX/Bizzdesign/ARIS (repository data entry), ArchiMate/C4 notation basics
+- **Working Knowledge required:** Excel/Power BI (data-quality reporting), Git/Azure DevOps (version control for artefacts)
+- **Awareness level expected:** TOGAF framework concepts, cloud architecture fundamentals (Azure/AWS/GCP)
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architecture Senior Engineer | Receives task direction, review feedback, and escalates tooling or data-quality issues | Escalates To |
+| Enterprise Architect | Repository accuracy supports architecture governance decisions | Provides To |
+| Solution Architect | Repository and diagram support for solution-level design work | Provides To |
+| Domain Architects | Source data and confirmation for repository updates in their domain | Consumes From |
+| Delivery Teams | Fields routine documentation and repository access questions | Provides To |
+
+## Key Technologies
+
+- Enterprise architecture platforms: LeanIX, Bizzdesign, ARIS, or Sparx Enterprise Architect
+- Architecture modelling: ArchiMate, UML, C4 model basics
+- Diagramming and visualization: Miro, draw.io, Microsoft Visio, Lucidchart
+- Documentation and knowledge management: Confluence, SharePoint
+- Spreadsheet and reporting tools: Excel, Power BI
+- Version control: Git/GitHub or Azure DevOps
+
+## Typical Day-to-Day Activities
+
+- Entering and updating application, capability, and technology records in the architecture repository
+- Producing first-draft diagrams from source material for senior engineer review
+- Running data-quality checks and flagging inconsistencies
+- Collating materials for architecture review board packs
+- Updating the technology radar data set for existing entries
+- Responding to routine documentation and access questions from delivery teams
+- Attending architecture community of practice sessions and supporting logistics
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture repository data-quality score for assigned records | ≥95% | Monthly |
+| Documentation update turnaround time | ≤3 business days | Monthly |
+| First-draft diagram rework rate (senior review revisions) | Decreasing trend | Quarterly |
+| Architecture review board pack readiness | 100% on time | Per board cycle |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; all repository, documentation, and diagramming work is performed through cloud tooling
+- **Collaboration Tools:** Microsoft Teams, LeanIX or equivalent EA platform, Confluence, SharePoint, Miro, draw.io
+- **On-Site Requirements:** None typically; occasional on-site for architecture community of practice events
+- **Time Zone Flexibility:** Standard business hours
+- **On-Call / Operational Demands:** Not on-call
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Technical Analyst or Business Analyst with documentation experience
+- Domain Engineer (Cloud, Network, Security) developing an architecture interest
+- IT Asset or CMDB Analyst
+- Help Desk / Service Desk (Level 2-3) with a technical documentation aptitude
+
+**Potential Next Roles:**
+
+- Enterprise Architecture Senior Engineer
+- Solution Architect (via broader domain experience)
+- Domain Engineer role with architecture exposure
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- TOGAF Foundation (The Open Group Architecture Framework)
+- ArchiMate 3 Foundation (The Open Group)
+
+**Complementary Certifications:**
+
+- Microsoft Certified: Azure Fundamentals (AZ-900) or AWS Cloud Practitioner
+- ITIL 4 Foundation
+
+**Learning Resources & Communities:**
+
+- The Open Group (opengroup.org) for TOGAF and ArchiMate foundational resources
+- LeanIX Academy or vendor-equivalent tooling training
+- IASA Global architect community (iasaglobal.org)

--- a/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
@@ -1,0 +1,157 @@
+# Enterprise Architecture Product Owner
+
+| Field | Value |
+|---|---|
+| **Domain** | Enterprise Architecture |
+| **Chapter:** | Service & Governance |
+| **Role Level** | Product Owner |
+| **Reports To** | Service & Governance Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Enterprise Architecture Product Owner owns the backlog for the enterprise architecture function's own delivery work: architecture repository and tooling improvements, governance process automation, reference architecture publishing pipelines, and technology radar tooling. Where the Enterprise Architect sets architectural direction and standards, the Product Owner ensures the practice's own supporting capabilities — the repository, the review board tooling, the documentation platform — are delivered and improved as a managed product with a prioritised backlog, rather than as ad hoc requests absorbed into architects' and engineers' spare capacity.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — enterprise architecture practice tooling backlog and delivery prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with architecture, ITSM, or governance-tooling exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Enterprise architecture standards, principles, and governance framework content (Enterprise Architect-owned); solution-level design decisions (Solution Architect-owned); architecture repository data-quality execution (Senior Engineer/Engineer-owned)
+- **Escalates To:** Service & Governance Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Enterprise Architecture Senior Engineer and Enterprise Architecture Engineer on ceremony direction and delivery-transparency questions
+
+## Business Impact
+
+- **Business Objective:** Ensure the enterprise architecture practice's own tooling and processes — the repository, review board workflow, reference architecture publishing, and technology radar — are delivered and continuously improved so the practice can operate efficiently and scale its governance reach across the organisation
+- **Value Metrics:** Architecture repository tooling uptime and usability scores, review board cycle-time improvement, reference architecture publishing throughput, backlog delivery rate for practice tooling initiatives
+- **Key Stakeholders:** Enterprise Architect, Solution Architect, Service & Governance Chapter Lead, domain architects across all IT areas, delivery teams consuming architecture artefacts and tooling
+- **Processes Supported:** Architecture practice backlog management, tooling procurement and roadmap, review board process improvement, reference architecture publishing pipeline, technology radar tooling operations
+
+## Key Responsibilities
+
+- Own and manage the enterprise architecture practice's delivery backlog: create, groom, and prioritise epics and user stories for repository tooling, governance process automation, and documentation platform improvements
+- Develop and maintain the practice's tooling roadmap aligned with enterprise architecture strategy and the wider Service & Governance chapter's priorities
+- Gather improvement requirements from the Enterprise Architect, Solution Architect, Senior Engineer, and Engineer on tooling pain points and governance process friction
+- Lead agile ceremonies for the enterprise architecture practice's delivery work: sprint or kanban planning, backlog refinement, and reviews
+- Coordinate procurement and licensing for enterprise architecture tooling (LeanIX, Bizzdesign, ARIS, or equivalent) in partnership with the Chapter Lead and Procurement
+- Track and report on practice tooling health metrics: repository uptime, review board cycle time, and documentation platform usability
+- Prioritise automation of manual governance steps (review board pack generation, technology radar publishing, repository data-quality checks) to free architect and engineer capacity for higher-value work
+- Represent the enterprise architecture practice's delivery priorities to the Service & Governance Chapter Lead and other domain Product Owners when tooling or process dependencies span chapters
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Enterprise architecture practice tooling backlog, sprint/kanban prioritisation, and roadmap sequencing | Enterprise architecture standards, principles, and governance framework content (Enterprise Architect-owned) |
+| Tooling procurement and licensing prioritisation for the practice | Solution-level design decisions and architecture review outcomes (Enterprise/Solution Architect-owned) |
+| Practice delivery ceremony cadence and backlog transparency | Individual repository data-entry and documentation execution (Senior Engineer/Engineer-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Understanding of enterprise architecture practice operations: repository management, review board workflow, reference architecture publishing, and technology radar processes
+- Familiarity with enterprise architecture tooling: LeanIX, Bizzdesign, ARIS, or Sparx EA, sufficient to scope improvement backlog items
+- Experience with agile product ownership: backlog management, user story writing with acceptance criteria, ceremony facilitation, and roadmap communication
+- Ability to assess business impact of internal tooling investments and translate technical improvements into value for the Chapter Lead and stakeholders
+- Experience with product management and roadmapping tooling: Jira, Confluence, or equivalent
+
+**Soft Skills & Leadership:**
+
+- Ability to balance competing improvement requests from architects, senior engineers, and delivery teams consuming architecture artefacts
+- Effective communication bridging technical architecture staff and the Chapter Lead's business-level reporting needs
+- Data-driven prioritisation using tooling health metrics and stakeholder feedback rather than the loudest request
+
+**Technology Proficiency Levels:**
+
+- **Expert level required:** Practice backlog and sprint/kanban management (Jira, Confluence)
+- **Proficient level required:** LeanIX/Bizzdesign/ARIS enterprise architecture platform capabilities, architecture review board workflow tooling
+- **Working Knowledge required:** TOGAF framework concepts, technology radar tooling, Power BI or equivalent for tooling health reporting
+- **Awareness level expected:** ArchiMate/C4 modelling notation, AI-assisted architecture documentation tools
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Enterprise Architect | Receives architecture strategy direction; ensures practice tooling backlog supports governance priorities | Governed By |
+| Solution Architect | Gathers tooling and documentation-platform improvement needs | Consumes From |
+| Enterprise Architecture Senior Engineer | As the team's product owner, leading ceremonies and providing delivery direction | Provides To |
+| Enterprise Architecture Engineer | As the team's product owner, leading ceremonies and providing delivery direction | Provides To |
+| Service & Governance Chapter Lead | Escalates budget, headcount, and cross-domain roadmap trade-offs | Escalates To |
+| Domain Architects | Collect feedback on repository and documentation platform usability | Collaborates |
+| Vendor TAM/PAM (LeanIX, Bizzdesign, ARIS) | Product roadmap updates, support agreements, and licensing strategy | Collaborates |
+
+## Key Technologies
+
+- Enterprise architecture platforms: LeanIX, Bizzdesign, ARIS, or Sparx Enterprise Architect
+- Backlog and ceremony tooling: Jira, Confluence, Azure DevOps Boards
+- Reporting: Power BI or equivalent for tooling health dashboards
+- Documentation and knowledge management: Confluence, SharePoint
+- Technology radar tooling (Thoughtworks Build Your Own Radar or equivalent)
+
+## Typical Day-to-Day Activities
+
+- Grooming and prioritising the enterprise architecture practice's delivery backlog
+- Running sprint or kanban ceremonies with the Senior Engineer and Engineer
+- Meeting with the Enterprise Architect and Solution Architect to capture tooling and process pain points
+- Reviewing tooling health metrics (repository uptime, review board cycle time) and identifying improvement candidates
+- Coordinating vendor licensing renewals and tooling procurement with the Chapter Lead
+- Preparing practice roadmap updates for the Service & Governance Chapter Lead
+- Following up on automation opportunities for manual governance steps
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Practice backlog delivery rate | ≥85% of committed items delivered | Per sprint/cycle |
+| Architecture repository tooling uptime | ≥99.5% | Monthly |
+| Review board cycle time (submission to decision) | Decreasing trend | Quarterly |
+| Manual governance steps automated | ≥2 per year | Annual |
+| Stakeholder satisfaction with practice tooling | ≥80% positive | Quarterly survey |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; backlog management and stakeholder engagement conducted through digital tooling
+- **Collaboration Tools:** Microsoft Teams, Jira, Confluence, LeanIX or equivalent EA platform, Power BI
+- **On-Site Requirements:** Occasional on-site for Chapter Lead planning sessions or vendor briefings
+- **Time Zone Flexibility:** Standard business hours
+- **On-Call / Operational Demands:** Not on-call
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Enterprise Architecture Senior Engineer transitioning to product ownership
+- Product Owner in a platform engineering, DevOps, or ITSM tooling domain
+- Business Analyst with enterprise architecture or governance-tooling focus
+
+**Potential Next Roles:**
+
+- Service & Governance Chapter Lead
+- Enterprise Architect (via architecture practice depth)
+- Head of Architecture Practice / Architecture Operations
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Professional Scrum Product Owner (PSPO I) — Scrum.org
+- TOGAF Foundation — for enterprise architecture context
+
+**Complementary Certifications:**
+
+- ITIL 4 Foundation — for governance and service management context
+- LeanIX or Bizzdesign platform certifications (vendor-specific tooling)
+
+**Learning Resources & Communities:**
+
+- Scrum.org PSPO learning paths and Product Owner community
+- The Open Group (opengroup.org) for TOGAF resources
+- LeanIX Academy and community

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -6,7 +6,7 @@
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |
 | **Reports To** | Enterprise Architect |
-| **Direct Reports** | None |
+| **Direct Reports** | Enterprise Architecture Engineer (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
 | **Last Reviewed** | 2026-03 |
 
 ---
@@ -85,6 +85,7 @@ The Enterprise Architecture Senior Engineer operates at the intersection of tech
 | Enterprise Architect | Providing operational and documentation support for governance processes | Escalates To |
 | Solution Architect | Providing operational and documentation support for governance processes | Provides To |
 | architecture review board | Chaired by the Enterprise Architect | Provides To |
+| Enterprise Architecture Engineer | Provides task direction, review, and mentoring on repository and documentation work | Provides To |
 
 ## Key Technologies
 

--- a/docs/SKILLS_PROGRESSION.md
+++ b/docs/SKILLS_PROGRESSION.md
@@ -147,8 +147,10 @@ Every domain in the catalog is listed below (alphabetically), with every role fi
 
 ### Enterprise Architecture
 
+- Engineer: `enterprise_architecture_engineer`
 - Senior Engineer: `enterprise_architecture_senior_engineer`
 - Architect: `enterprise_architect`, `solution_architect`
+- Product Owner: `enterprise_architecture_product_owner`
 
 ### FinOps
 

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -524,7 +524,7 @@ test('career sankey handles the real SKILLS_PROGRESSION.md', () => {
     const ladders = parseProgressionLadders(md);
     assert.equal(ladders.length, 33, 'all 33 domain ladders parse');
     const totalRoles = ladders.reduce((n, l) => n + Object.values(l.levels).flat().length, 0);
-    assert.equal(totalRoles, 219, 'parser sees every role the drift guard guarantees');
+    assert.equal(totalRoles, 221, 'parser sees every role the drift guard guarantees');
     const s = buildCareerSankey(ladders);
     assert.ok(s.nodes.length >= 8, 'all level rungs present');
     const engSr = s.links.find(l => l.source === 'Engineer' && l.target === 'Senior Engineer');
@@ -574,6 +574,6 @@ test('parseCareerPath parses every role file in the catalog', () => {
             if (cp.from.length && cp.to.length) withBoth++;
         }
     }
-    assert.equal(total, 219);
-    assert.equal(withBoth, 219, 'every role file yields both From and To lists');
+    assert.equal(total, 221);
+    assert.equal(withBoth, 221, 'every role file yields both From and To lists');
 });


### PR DESCRIPTION
## Summary
- Adds `enterprise_architecture_engineer.md` and `enterprise_architecture_product_owner.md` — the chapter had only 3 roles, breaking the 4-tier pattern (engineer/senior_engineer/architect/product_owner) every comparable chapter follows.
- Wires reporting lines: Senior Engineer now lists the new Engineer as a direct report.
- Adds both new roles to `docs/SKILLS_PROGRESSION.md`'s Enterprise Architecture ladder (drift-guarded by tests).
- Updates hardcoded 219→221 role counts in README.md and test/viewer-logic.test.js.

Closes #103

## Test plan
- [x] `npm run validate` — 222 files checked, 0 errors/warnings
- [x] `npm run check-counts` — README counts match filesystem
- [x] `npm test` — 99/99 passing
- [x] Verified in browser preview: total-roles counter shows 221, new Engineer role renders correctly with career-path Sankey data