### PR TITLE
docs: add c_suite README cross-referencing the CISO's actual location

### DIFF
--- a/Roles/c_suite/README.md
+++ b/Roles/c_suite/README.md
@@ -1,0 +1,12 @@
+# C-Suite domain
+
+This domain covers the top executive roles setting organisation-wide strategy and direction: CEO, CFO, CIO, and CTO. The Chief Information Security Officer (CISO) is also a C-suite-level role but is filed under `leadership/` — a cross-cutting chapter alongside the Chapter Lead and TAL/PAL roles — rather than here, since its reporting line (SVP of Technology, CTO/CIO, or directly to the CEO/Board) varies by governance model rather than sitting fixed in the standalone executive line. See `Roles/leadership/chief_information_security_officer.md`.
+
+## Roles in this domain
+
+- `chief_executive_officer.md`
+- `chief_financial_officer.md`
+- `chief_information_officer.md`
+- `chief_technology_officer.md`
+
+For the CISO, see `Roles/leadership/chief_information_security_officer.md`.


### PR DESCRIPTION
## Summary
- Adds `Roles/c_suite/README.md` explaining CEO/CFO/CIO/CTO live here and pointing to `Roles/leadership/chief_information_security_officer.md` for the CISO.
- Mirrors the existing cross-reference README pattern used to split `security/` from `security_cross_platform/` and `security_identity/`.

Closes #105

## Test plan
- [x] `npm run validate` — 222 files checked, 0 errors/warnings (README excluded from role-file checks, as with the security domain READMEs)
- [x] `npm test` — 99/99 passing