### PR TITLE
feat: backfill service_desk_product_owner tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/JeanKadang/DOC-ITRoles/actions/workflows/ci.yml/badge.svg)](https://github.com/JeanKadang/DOC-ITRoles/actions/workflows/ci.yml)
 
-A portable role definition repository for infrastructure and platform engineering teams. Covers 33 domains grouped into 7 chapters, and 221 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
+A portable role definition repository for infrastructure and platform engineering teams. Covers 33 domains grouped into 7 chapters, and 222 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
 
 Repository: [github.com/JeanKadang/DOC-ITRoles](https://github.com/JeanKadang/DOC-ITRoles) (private). Issues and backlog are tracked on the [Issues tab](https://github.com/JeanKadang/DOC-ITRoles/issues).
 
@@ -107,7 +107,7 @@ roles_master/
 ├── .github/
 │   ├── workflows/ci.yml                    # CI: npm test, npm run validate, check-counts, markdownlint
 │   └── dependabot.yml                      # Weekly GitHub Actions + npm update checks
-├── Roles/                                  # All role definitions (33 domains, 221 roles)
+├── Roles/                                  # All role definitions (33 domains, 222 roles)
 │   ├── leadership/                         # SVP, CISO, Chapter Leads, TAL, PAL
 │   ├── c_suite/                            # CEO, CTO, CIO, CFO
 │   ├── cloud_platforms/                    # Azure, AWS, GCP + Lead/Principal

--- a/Roles/service_desk/service_desk_product_owner.md
+++ b/Roles/service_desk/service_desk_product_owner.md
@@ -1,0 +1,156 @@
+# Service Desk Product Owner
+
+| Field | Value |
+|---|---|
+| **Domain** | Service Desk |
+| **Chapter:** | End User & Workplace |
+| **Role Level** | Product Owner |
+| **Reports To** | End User & Workplace Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Service Desk Product Owner owns the backlog for the tooling and self-service capabilities the service desk runs on: the ITSM ticketing platform's desk-facing configuration, the self-service portal, the knowledge base platform, chatbot/virtual-agent deflection tooling, and telephony/contact-centre integration. Where the Service Desk Lead owns the desk as an operating function — staffing, SLAs, escalation boundaries — the Product Owner owns the desk's *tooling roadmap* as a managed product: prioritising automation and self-service investment that reduces ticket volume, improves first-contact resolution, and frees Analyst capacity for the issues that genuinely need a person.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — service desk tooling backlog, self-service and automation roadmap, and desk-facing ITSM platform configuration prioritisation
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with service desk, ITSM, or digital-workplace tooling exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Desk staffing, SLA targets, and escalation boundary ownership (Service Desk Lead-owned); ITSM platform's core technical architecture (ITSM Configuration/Service Management-owned); endpoint and identity engineering standards that shape ticket categories (respective domain Architects-owned)
+- **Escalates To:** End User & Workplace Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Service Desk Lead on tooling gaps blocking operational targets; Service Desk Senior Analysts on recurring tooling friction surfaced through ticket patterns
+
+## Business Impact
+
+- **Business Objective:** Maximise the value of the service desk's tooling investment by prioritising self-service, automation, and knowledge base capabilities that deflect avoidable tickets, shorten resolution time, and let the desk absorb organisational growth without proportional headcount growth
+- **Value Metrics:** Self-service deflection rate, knowledge base article usage and effectiveness, chatbot/virtual-agent resolution rate, backlog delivery rate for desk tooling initiatives, ticket volume per FTE trend
+- **Key Stakeholders:** Service Desk Lead, End User & Workplace Chapter Lead, Service Management Product Owner, Client Platform Architect, Endpoint Management Architect, employees as the desk's end users
+- **Processes Supported:** Service desk tooling backlog management, self-service portal roadmap, knowledge base platform governance, chatbot/virtual-agent tuning, telephony/contact-centre tooling integration, agile ceremonies for the desk tooling workstream
+
+## Key Responsibilities
+
+- Own and manage the service desk tooling product backlog: create, groom, and prioritise epics and user stories for self-service portal, knowledge base platform, and virtual-agent/chatbot capabilities
+- Develop and maintain the desk's tooling roadmap aligned with the End User & Workplace chapter's priorities and the desk's operational targets
+- Gather tooling requirements from the Service Desk Lead, Senior Analysts, and Analysts based on recurring friction and ticket-pattern analysis
+- Lead agile ceremonies for the desk tooling workstream: sprint or kanban planning, backlog refinement, and reviews
+- Prioritise self-service and automation investment that measurably reduces avoidable ticket volume and improves first-contact resolution
+- Coordinate with the Service Management Product Owner to align desk-facing tooling with the broader ITSM platform roadmap and avoid duplicated backlog effort
+- Track and report on self-service deflection rate, knowledge base effectiveness, and tooling backlog delivery to the End User & Workplace Chapter Lead
+- Manage vendor relationships and licensing for desk-specific tooling (chatbot/virtual-agent platforms, telephony integration) in partnership with the Chapter Lead and Procurement
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Service desk tooling backlog, self-service/automation roadmap prioritisation | Desk staffing, SLA targets, and escalation boundary decisions (Service Desk Lead-owned) |
+| Knowledge base platform governance and self-service portal roadmap | Core ITSM platform technical architecture (ITSM Configuration/Service Management-owned) |
+| Chatbot/virtual-agent tooling prioritisation and vendor selection input | Ticket categorisation schemas tied to underlying endpoint/identity engineering standards (domain Architects-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Understanding of service desk and ITSM operating models: ticket lifecycle, SLA/KPI frameworks, Tier-1/2/3 escalation patterns
+- Familiarity with self-service, knowledge base, and virtual-agent/chatbot platforms (ServiceNow Virtual Agent, Microsoft Copilot in ITSM contexts, or equivalent)
+- Experience with agile product ownership: backlog management, user story writing with acceptance criteria, ceremony facilitation, roadmap communication
+- Ability to read ticket-pattern and self-service deflection data to identify high-value automation candidates
+- Experience with product management and roadmapping tooling: Jira, Confluence, or equivalent
+
+**Soft Skills & Leadership:**
+
+- Ability to balance the Service Desk Lead's operational priorities against longer-horizon tooling investment
+- Effective communication bridging desk operations staff and chapter-level roadmap reporting
+- Data-driven prioritisation using deflection metrics and ticket-pattern trends rather than anecdote
+
+**Technology Proficiency Levels:**
+
+- **Expert level required:** Desk tooling backlog and sprint/kanban management (Jira, Confluence)
+- **Proficient level required:** ServiceNow (or equivalent) self-service portal and knowledge base configuration, chatbot/virtual-agent platform capabilities
+- **Working Knowledge required:** ITIL 4 request fulfilment and knowledge management practices, Power BI or ServiceNow Performance Analytics for deflection reporting
+- **Awareness level expected:** AI-assisted ticket triage and resolution tooling, telephony/contact-centre platform integration patterns
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Service Desk Lead | Gathers operational requirements and tooling friction points; delivers tooling that supports SLA and staffing targets | Provides To |
+| Service Desk Senior Analyst | As the tooling backlog owner, incorporates ticket-pattern feedback into prioritisation | Consumes From |
+| End User & Workplace Chapter Lead | Escalates budget, headcount, and cross-domain roadmap trade-offs | Escalates To |
+| Service Management Product Owner | Aligns desk-facing tooling roadmap with the broader ITSM platform backlog | Collaborates |
+| Client Platform Architect / Endpoint Management Architect | Aligns self-service and automation tooling with underlying endpoint and identity standards | Collaborates |
+| vendor TAM/PAM (ServiceNow, virtual-agent platforms) | Product roadmap updates, support agreements, and licensing strategy | Collaborates |
+
+## Key Technologies
+
+- ITSM/ticketing platform self-service and knowledge base modules (ServiceNow or equivalent)
+- Virtual-agent/chatbot platforms (ServiceNow Virtual Agent, Microsoft Copilot, or equivalent)
+- Telephony/contact-centre integration tooling
+- Backlog and ceremony tooling: Jira, Confluence, Azure DevOps Boards
+- Reporting: Power BI or ServiceNow Performance Analytics for deflection and effectiveness metrics
+
+## Typical Day-to-Day Activities
+
+- Grooming and prioritising the service desk tooling backlog
+- Running sprint or kanban ceremonies with contributors delivering desk tooling work
+- Meeting with the Service Desk Lead and Senior Analysts to capture tooling friction and automation candidates
+- Reviewing self-service deflection and knowledge base effectiveness metrics
+- Coordinating with the Service Management Product Owner on shared ITSM platform roadmap items
+- Preparing tooling roadmap updates for the End User & Workplace Chapter Lead
+- Managing vendor relationships for chatbot/virtual-agent and telephony tooling renewals
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Self-service deflection rate | ≥20% of eligible ticket categories | Quarterly |
+| Knowledge base article effectiveness (resolved-without-escalation rate) | ≥70% | Monthly |
+| Tooling backlog delivery rate | ≥85% of committed items delivered | Per sprint/cycle |
+| Chatbot/virtual-agent resolution rate | ≥30% of routed interactions | Quarterly |
+| Ticket volume per FTE (trend, alongside Service Desk Lead's staffing model) | Improving trend | Quarterly |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; backlog management and stakeholder engagement conducted through digital tooling
+- **Collaboration Tools:** Microsoft Teams, Jira, Confluence, ServiceNow (or equivalent), Power BI
+- **On-Site Requirements:** Occasional on-site for Chapter Lead planning sessions or vendor briefings
+- **Time Zone Flexibility:** Standard business hours
+- **On-Call / Operational Demands:** Not on-call
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Service Desk Senior Analyst or Service Desk Lead transitioning to product ownership
+- Product Owner in an ITSM, digital-workplace, or platform tooling domain
+- Business Analyst with service desk or self-service tooling focus
+
+**Potential Next Roles:**
+
+- Service Management Product Owner
+- End User & Workplace Chapter Lead
+- Client Platform Product Owner
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Professional Scrum Product Owner (PSPO I) — Scrum.org
+- ITIL 4 Foundation
+
+**Complementary Certifications:**
+
+- ServiceNow Certified Implementation Specialist (self-service/knowledge modules)
+- SAFe Product Owner / Product Manager (POPM)
+
+**Learning Resources & Communities:**
+
+- Scrum.org PSPO learning paths and Product Owner community
+- ServiceNow community and self-service/knowledge learning paths (community.servicenow.com)
+- HDI (Help Desk Institute) resources on self-service and deflection strategy

--- a/docs/SKILLS_PROGRESSION.md
+++ b/docs/SKILLS_PROGRESSION.md
@@ -261,6 +261,7 @@ Every domain in the catalog is listed below (alphabetically), with every role fi
 
 - Engineer: `service_desk_analyst`
 - Senior Engineer: `service_desk_lead`, `service_desk_senior_analyst`
+- Product Owner: `service_desk_product_owner`
 
 ### Service Management
 

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -524,7 +524,7 @@ test('career sankey handles the real SKILLS_PROGRESSION.md', () => {
     const ladders = parseProgressionLadders(md);
     assert.equal(ladders.length, 33, 'all 33 domain ladders parse');
     const totalRoles = ladders.reduce((n, l) => n + Object.values(l.levels).flat().length, 0);
-    assert.equal(totalRoles, 221, 'parser sees every role the drift guard guarantees');
+    assert.equal(totalRoles, 222, 'parser sees every role the drift guard guarantees');
     const s = buildCareerSankey(ladders);
     assert.ok(s.nodes.length >= 8, 'all level rungs present');
     const engSr = s.links.find(l => l.source === 'Engineer' && l.target === 'Senior Engineer');
@@ -574,6 +574,6 @@ test('parseCareerPath parses every role file in the catalog', () => {
             if (cp.from.length && cp.to.length) withBoth++;
         }
     }
-    assert.equal(total, 221);
-    assert.equal(withBoth, 221, 'every role file yields both From and To lists');
+    assert.equal(total, 222);
+    assert.equal(withBoth, 222, 'every role file yields both From and To lists');
 });


### PR DESCRIPTION
## Summary
- Adds `service_desk_product_owner.md` — the desk had no backlog owner for its own tooling roadmap (self-service portal, knowledge base, virtual-agent/chatbot deflection tooling), distinct from the Lead's operational ownership (staffing, SLAs, escalation boundaries).
- Deliberately does **not** add a separate "manager" role: `service_desk_lead.md` already covers that scope at Senior Engineer level (staffing, SLA ownership, people management), consistent with how other domains fold "manager"-titled roles into the Senior Engineer tier (e.g. `service_management`'s Change/Release Manager and Major Incident Manager).
- Adds the new role to `docs/SKILLS_PROGRESSION.md`'s Service Desk ladder and updates drift-guarded role counts (221→222).

Closes #104

## Test plan
- [x] `npm run validate` — 223 files checked, 0 errors/warnings
- [x] `npm run check-counts` — README counts match filesystem
- [x] `npm test` — 99/99 passing