### PR TITLE
fix: resolve role cross-references and link the interactions table

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,6 +521,17 @@
             cursor: pointer;
         }
         .career-stepper .cs-chip[data-file]:hover { background: var(--bg-card-hover); text-decoration: underline; }
+
+        /* Resolvable role names inside the Interactions table (#120) */
+        .role-xref {
+            color: var(--accent-blue);
+            cursor: pointer;
+            text-decoration: underline;
+            text-decoration-style: dotted;
+            text-underline-offset: 3px;
+        }
+        .role-xref:hover, .role-xref:focus-visible { text-decoration-style: solid; }
+        @media print { .role-xref { color: inherit; text-decoration: none; } }
         .career-stepper .cs-current {
             padding: 3px 12px;
             border-radius: 20px;
@@ -1221,6 +1232,7 @@
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
+        findRoleByTitle: resolveRoleTitle,
     } = ViewerLogic;
 
     // ── State ───────────────────────────────────────────
@@ -2322,13 +2334,10 @@
     // Development Path section. Steps whose text exactly matches a catalog
     // role title (case-insensitive) become keyboard-operable links that
     // open that role; the rest render as plain chips.
+    // Resolution (plural/parenthetical normalisation) lives in
+    // viewer-logic.js under test; this just binds it to the loaded catalog.
     function findRoleByTitle(title) {
-        const t = title.trim().toLowerCase();
-        for (const d of Object.values(allDomains)) {
-            const hit = d.roles.find(r => r.title.trim().toLowerCase() === t);
-            if (hit) return { ...hit, domainLabel: d.label };
-        }
-        return null;
+        return resolveRoleTitle(title, allDomains);
     }
 
     function renderCareerStepper(markdown, currentTitle) {
@@ -2352,6 +2361,42 @@
             <span class="cs-arrow" aria-hidden="true">→</span>
             <span class="cs-group"><span class="cs-label">To</span>${to.map(chip).join('')}</span>`;
         el.hidden = false;
+    }
+
+    // Link the role names in the "Interactions with Other Roles" table.
+    // The section renders as plain Markdown, so until #120 every name in it
+    // was dead text even when the catalog defined that role. Resolution
+    // (plurals, parentheticals) is handled by viewer-logic's findRoleByTitle;
+    // anything that does not resolve — "Business Leaders", "delivery teams",
+    // vendor contacts — is left as text on purpose.
+    function linkInteractionRoles(container, currentTitle) {
+        if (!container) return;
+        for (const h2 of container.querySelectorAll('h2')) {
+            if (!/^Interactions with Other Roles/i.test(h2.textContent.trim())) continue;
+            let el = h2.nextElementSibling;
+            while (el && el.tagName !== 'TABLE' && el.tagName !== 'H2') el = el.nextElementSibling;
+            if (!el || el.tagName !== 'TABLE') break;
+            for (const row of el.querySelectorAll('tbody tr')) {
+                const cell = row.cells[0];
+                if (!cell) continue;
+                const raw = cell.textContent.trim().replace(/:$/, '').trim();
+                const hit = findRoleByTitle(raw);
+                if (!hit || hit.title === currentTitle) continue;
+                const a = document.createElement('span');
+                a.className = 'role-xref';
+                a.setAttribute('role', 'button');
+                a.tabIndex = 0;
+                a.dataset.file   = hit.file;
+                a.dataset.title  = hit.title;
+                a.dataset.level  = hit.level;
+                a.dataset.domain = hit.domainLabel;
+                a.title = `Open ${hit.title}`;
+                a.textContent = cell.textContent.trim();
+                cell.textContent = '';
+                cell.appendChild(a);
+            }
+            break;
+        }
     }
 
     // ── Shared: build role header HTML ───────────────────
@@ -2420,6 +2465,7 @@
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;
             document.getElementById('roleBody').innerHTML = renderMarkdown(body);
+            linkInteractionRoles(document.getElementById('roleBody'), title);
             renderCareerStepper(markdown, title);
             document.getElementById('mainArea').scrollTop = 0;
 
@@ -2459,6 +2505,7 @@
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;
             document.getElementById('roleBody2').innerHTML = renderMarkdown(body);
+            linkInteractionRoles(document.getElementById('roleBody2'), title);
 
         } catch {
             document.getElementById('roleBody2').innerHTML =
@@ -2934,6 +2981,15 @@
         const chipEl = e.target.closest('.cs-chip[data-file]');
         if (!chipEl) return;
         openRole(chipEl.dataset.file, chipEl.dataset.title, chipEl.dataset.level, chipEl.dataset.domain);
+    });
+
+    // ── Interactions-table cross-reference clicks (#120) ──
+    // One delegated listener covers both the main and comparison columns,
+    // including content re-rendered on every role open.
+    document.getElementById('rolesGrid').addEventListener('click', e => {
+        const x = e.target.closest('.role-xref[data-file]');
+        if (!x) return;
+        openRole(x.dataset.file, x.dataset.title, x.dataset.level, x.dataset.domain);
     });
 
     // ── Org list-fallback clicks (single delegated listener) ─

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -21,6 +21,8 @@ const {
     parseMobilityPaths,
     parseCareerPath,
     resolveDocHref,
+    roleTitleKey,
+    findRoleByTitle,
 } = require('../viewer-logic');
 
 const { CANONICAL_LEVELS, REFERENCE_DOC_PATTERN: ROLEMETA_REF_PATTERN } = require('../roleMeta');
@@ -576,4 +578,97 @@ test('parseCareerPath parses every role file in the catalog', () => {
     }
     assert.equal(total, 222);
     assert.equal(withBoth, 222, 'every role file yields both From and To lists');
+});
+
+// ── findRoleByTitle (#120) ────────────────────────────────
+// Career-path and interaction prose names roles the way English does —
+// plural for a group, with a parenthetical qualifier for a variant. An
+// exact-match lookup misses all of those, so the reference renders as
+// dead text instead of a link.
+const LOOKUP_DOMAINS = {
+    security: {
+        label: 'Security',
+        roles: [
+            { title: 'Security Engineer',        file: 'Roles/security/security_engineer.md',        level: 'Engineer' },
+            { title: 'Security Senior Engineer', file: 'Roles/security/security_senior_engineer.md', level: 'Senior Engineer' },
+        ],
+    },
+    modern_workplace: {
+        label: 'Modern Workplace',
+        roles: [
+            { title: 'Modern Workplace Architect (Microsoft 365)', file: 'Roles/modern_workplace/mw_architect.md', level: 'Architect' },
+        ],
+    },
+    leadership: {
+        label: 'Leadership',
+        roles: [
+            { title: 'Chief Information Security Officer', file: 'Roles/leadership/ciso.md', level: 'CISO' },
+        ],
+    },
+};
+
+test('findRoleByTitle matches an exact title', () => {
+    const hit = findRoleByTitle('Security Engineer', LOOKUP_DOMAINS);
+    assert.equal(hit.file, 'Roles/security/security_engineer.md');
+    assert.equal(hit.domainLabel, 'Security');
+});
+
+test('findRoleByTitle matches a plural reference to a singular role title', () => {
+    // "collaborates with Security Engineers" is correct prose; the catalog
+    // title is singular.
+    assert.equal(findRoleByTitle('Security Engineers', LOOKUP_DOMAINS)?.file,
+                 'Roles/security/security_engineer.md');
+    assert.equal(findRoleByTitle('Security Senior Engineers', LOOKUP_DOMAINS)?.file,
+                 'Roles/security/security_senior_engineer.md');
+});
+
+test('findRoleByTitle ignores a parenthetical qualifier on the reference', () => {
+    // e.g. "Chief Information Security Officer (CISO)" in a career path.
+    assert.equal(findRoleByTitle('Chief Information Security Officer (CISO)', LOOKUP_DOMAINS)?.file,
+                 'Roles/leadership/ciso.md');
+});
+
+test('findRoleByTitle matches when the catalog title carries the parenthetical', () => {
+    // The reverse case: prose says "Modern Workplace Architect", the
+    // catalog title is "Modern Workplace Architect (Microsoft 365)".
+    assert.equal(findRoleByTitle('Modern Workplace Architect', LOOKUP_DOMAINS)?.file,
+                 'Roles/modern_workplace/mw_architect.md');
+});
+
+test('findRoleByTitle returns null for a role the catalog does not define', () => {
+    // Aspirational exits like "Chief Architect" are deliberately outside
+    // the catalog and must stay unlinked rather than resolving to something
+    // approximate.
+    assert.equal(findRoleByTitle('Chief Architect', LOOKUP_DOMAINS), null);
+    assert.equal(findRoleByTitle('VP of Engineering', LOOKUP_DOMAINS), null);
+});
+
+test('findRoleByTitle does not fuzzy-match a different role', () => {
+    // "Security Architect" is not in this fixture; matching it to
+    // "Security Engineer" would send the reader to the wrong role.
+    assert.equal(findRoleByTitle('Security Architect', LOOKUP_DOMAINS), null);
+});
+
+test('no two catalog role titles collide under roleTitleKey', () => {
+    // The plural/parenthetical normalisation is what makes prose references
+    // resolve (#120), but it also merges keys. If two real role titles ever
+    // reduce to the same key, findRoleByTitle silently returns whichever
+    // comes first and half the links point at the wrong role.
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const rolesDir = path.join(__dirname, '..', 'Roles');
+    const seen = new Map();
+    const collisions = [];
+    for (const d of fs.readdirSync(rolesDir, { withFileTypes: true })) {
+        if (!d.isDirectory()) continue;
+        for (const f of fs.readdirSync(path.join(rolesDir, d.name))) {
+            if (!f.endsWith('.md') || f === 'README.md' || /_standards\.md$/.test(f)) continue;
+            const title = fs.readFileSync(path.join(rolesDir, d.name, f), 'utf8')
+                .replace(/^\uFEFF/, '').split('\n')[0].replace(/^#\s*/, '').trim();
+            const key = roleTitleKey(title);
+            if (seen.has(key)) collisions.push(`${seen.get(key)} <-> ${title}`);
+            else seen.set(key, title);
+        }
+    }
+    assert.deepEqual(collisions, [], 'role titles that normalise to the same lookup key');
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -468,6 +468,40 @@
         return stack.join('/');
     }
 
+    // Reduce a role name to a comparison key. Career-path and interaction
+    // prose names roles the way English does — plural for a group
+    // ("Security Engineers"), or with a parenthetical qualifier
+    // ("Enterprise Architect (AI governance domain)") — while catalog H1
+    // titles are singular and mostly unqualified. Exact matching misses
+    // every one of those, leaving the reference as dead text (#120).
+    //
+    // Deliberately conservative: case, punctuation, a trailing
+    // parenthetical, and a trailing plural only. No fuzzy or token-overlap
+    // matching — a near-miss that resolves to the wrong role is worse than
+    // one that stays unlinked.
+    function roleTitleKey(name) {
+        return String(name == null ? '' : name)
+            .replace(/\s*\([^)]*\)\s*$/, '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '')
+            .replace(/s$/, '');
+    }
+
+    // Find the catalog role a prose name refers to, or null when the
+    // catalog does not define it. Aspirational career exits ("Chief
+    // Architect", "VP of Engineering") legitimately return null and must
+    // stay unlinked.
+    function findRoleByTitle(title, domains) {
+        const want = roleTitleKey(title);
+        if (!want) return null;
+        for (const d of Object.values(domains || {})) {
+            for (const r of (d.roles || [])) {
+                if (roleTitleKey(r.title) === want) return { ...r, domainLabel: d.label };
+            }
+        }
+        return null;
+    }
+
     return {
         STALE_MONTHS,
         REFERENCE_DOC_PATTERN,
@@ -487,5 +521,7 @@
         parseMobilityPaths,
         parseCareerPath,
         resolveDocHref,
+        roleTitleKey,
+        findRoleByTitle,
     };
 });


### PR DESCRIPTION
## Summary

Role names written in prose never matched the viewer's exact-match lookup, so cross-references rendered as dead text. Two distinct causes, one shared fix:

- **Career Development Path** — the resolver ran and returned `null` on plurals and parenthetical qualifiers.
- **Interactions with Other Roles** — was never linked at all; the section rendered as plain Markdown.

Adds `roleTitleKey` / `findRoleByTitle` to `viewer-logic.js` (the tested module), normalising case, punctuation, a trailing parenthetical, and a trailing plural — **and nothing else**. No fuzzy or token-overlap matching: a near-miss that resolves to the wrong role is worse than one that stays unlinked.

## Results (measured across all 222 role files)

| | Before | After |
|---|---|---|
| Interaction rows navigable | 0 (never linked) | **639** |
| Career-path entries resolved | 294 | **375** |

Correctly left as plain text: non-catalog actors (`Development Teams`, `Compliance Managers`, `Business Leaders`) and aspirational career exits the catalog deliberately doesn't define (`Chief Architect`, `VP of Engineering`).

## Test plan

- [x] TDD — 7 new tests written first and watched fail with `findRoleByTitle is not defined`, then implemented
- [x] Includes a **collision guard**: asserts no two real catalog titles reduce to the same lookup key, since plural-stripping merges keys and a collision would silently link to the wrong role
- [x] `npm test` — 106/106 passing (was 99)
- [x] `npm run validate` — 0 errors, 0 warnings
- [x] Verified in browser on `Security Architect`: `Enterprise Architects`, `Solution Architects`, `Security Engineers` link; `Compliance Managers`, `Development Teams`, `Risk Management` stay text; clicking navigates correctly
- [x] No console errors
- [x] Keyboard activation covered by the existing `[role="button"]` delegated handler; print styling suppresses link colour

## Note

One case deliberately still unlinked: `Azure Cloud Platform Architect` (catalog title is `Azure Cloud Architect`). Matching an inserted word requires fuzzy logic this PR rejects — that is a content fix belonging to #122, not a resolver change.