### PR TITLE
feat: collapse role sections so the page opens as an outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,6 +599,52 @@
 
         .md-body h1 { display: none; }
 
+        /* ── Collapsible role sections (#112) ───────────────── */
+        .md-section { border-bottom: 1px solid var(--border-color); }
+        .md-section:last-child { border-bottom: none; }
+
+        .md-section > .md-section-hd {
+            font-size: 1.1em;
+            font-weight: 700;
+            color: var(--accent-blue);
+            letter-spacing: -0.2px;
+            padding: 14px 0 14px 26px;
+            position: relative;
+            cursor: pointer;
+            list-style: none;          /* hide the native marker … */
+            user-select: none;
+        }
+        .md-section > .md-section-hd::-webkit-details-marker { display: none; }
+
+        /* … and draw our own, so it can rotate and match the type scale. */
+        .md-section > .md-section-hd::before {
+            content: '▸';
+            position: absolute;
+            left: 4px;
+            color: var(--text-muted);
+            transition: transform 0.15s ease;
+            display: inline-block;
+        }
+        .md-section[open] > .md-section-hd::before { transform: rotate(90deg); }
+        .md-section > .md-section-hd:hover { color: var(--accent-blue); }
+        .md-section > .md-section-hd:hover::before { color: var(--accent-blue); }
+        .md-section > .md-section-hd:focus-visible {
+            outline: 2px solid var(--accent-blue);
+            outline-offset: 2px;
+            border-radius: 4px;
+        }
+        .md-section[open] > .md-section-hd { padding-bottom: 8px; }
+        .md-section > *:not(.md-section-hd):last-child { margin-bottom: 18px; }
+
+        /* Sections are force-opened for printing by the beforeprint handler
+           (CSS alone cannot expand a closed <details>); this just drops the
+           interactive affordances from the printed page. */
+        @media print {
+            .md-section > .md-section-hd::before { display: none; }
+            .md-section > .md-section-hd { padding-left: 0; }
+            .md-section { border-bottom: none; }
+        }
+
         .md-body h2 {
             font-size: 1.1em;
             font-weight: 700;
@@ -1221,6 +1267,7 @@
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
+        sectionStartsOpen,
     } = ViewerLogic;
 
     // ── State ───────────────────────────────────────────
@@ -2354,6 +2401,48 @@
         el.hidden = false;
     }
 
+    // Wrap each "## " section of a rendered role body in a <details> so the
+    // page opens as a scannable outline instead of ~9,000 characters of
+    // expanded prose (#112). Which sections start open is decided by
+    // sectionStartsOpen in viewer-logic.js (under test).
+    //
+    // <details> is used deliberately over a custom widget: the browser gives
+    // keyboard operation, correct ARIA semantics, and — importantly for this
+    // repo — Ctrl+F still finds text inside a closed section in current
+    // browsers, and printing is handled by forcing [open] in the print CSS.
+    // State is intentionally not persisted across roles; each role opens in
+    // the same predictable shape.
+    function collapseSections(container) {
+        if (!container) return;
+        const headings = [...container.querySelectorAll('h2')];
+        for (const h2 of headings) {
+            const heading = h2.textContent.trim();
+            const details = document.createElement('details');
+            details.className = 'md-section';
+            if (sectionStartsOpen(heading)) details.open = true;
+
+            const summary = document.createElement('summary');
+            summary.className = 'md-section-hd';
+            summary.textContent = heading;
+            details.appendChild(summary);
+
+            // Move everything between this h2 and the next one inside.
+            const body = [];
+            let el = h2.nextElementSibling;
+            while (el && el.tagName !== 'H2') { body.push(el); el = el.nextElementSibling; }
+            h2.replaceWith(details);
+            for (const node of body) details.appendChild(node);
+        }
+    }
+
+    // Expand the section containing an element (used when navigating to a
+    // collapsed section — the TOC in #111 will rely on this too).
+    function revealSection(el) {
+        for (let p = el; p; p = p.parentElement) {
+            if (p.tagName === 'DETAILS') p.open = true;
+        }
+    }
+
     // ── Shared: build role header HTML ───────────────────
     function buildHeader(title, level, domainLabel, lastReviewed, slot) {
         const isCompare = slot === 'B';
@@ -2420,6 +2509,7 @@
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;
             document.getElementById('roleBody').innerHTML = renderMarkdown(body);
+            collapseSections(document.getElementById('roleBody'));
             renderCareerStepper(markdown, title);
             document.getElementById('mainArea').scrollTop = 0;
 
@@ -2459,6 +2549,7 @@
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;
             document.getElementById('roleBody2').innerHTML = renderMarkdown(body);
+            collapseSections(document.getElementById('roleBody2'));
 
         } catch {
             document.getElementById('roleBody2').innerHTML =
@@ -2568,6 +2659,21 @@
     }
 
     function printRole() { window.print(); }
+
+    // A closed <details> cannot be expanded by CSS, so the printed page would
+    // silently lose every collapsed section (#112). Force them open for the
+    // print, then restore exactly what the reader had. Covers Ctrl+P as well
+    // as the Print button, since both fire beforeprint.
+    let printRestore = [];
+    window.addEventListener('beforeprint', () => {
+        printRestore = [...document.querySelectorAll('details.md-section')]
+            .filter(d => !d.open);
+        for (const d of printRestore) d.open = true;
+    });
+    window.addEventListener('afterprint', () => {
+        for (const d of printRestore) d.open = false;
+        printRestore = [];
+    });
 
     // ── Export: download the currently open role/doc as a .md file ──
     function downloadText(filename, text, mime) {

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -21,6 +21,7 @@ const {
     parseMobilityPaths,
     parseCareerPath,
     resolveDocHref,
+    sectionStartsOpen,
 } = require('../viewer-logic');
 
 const { CANONICAL_LEVELS, REFERENCE_DOC_PATTERN: ROLEMETA_REF_PATTERN } = require('../roleMeta');
@@ -576,4 +577,34 @@ test('parseCareerPath parses every role file in the catalog', () => {
     }
     assert.equal(total, 222);
     assert.equal(withBoth, 222, 'every role file yields both From and To lists');
+});
+
+// ── sectionStartsOpen (#112) ──────────────────────────────
+// Role bodies open with all 14 sections expanded (~9,000 chars). Collapsing
+// them turns the page into a scannable outline, but the orienting sections
+// must stay open or the reader lands on a wall of closed headings.
+test('sectionStartsOpen keeps the two orienting sections expanded', () => {
+    assert.equal(sectionStartsOpen('Role Overview'), true);
+    assert.equal(sectionStartsOpen('Role Scope & Boundaries'), true);
+});
+
+test('sectionStartsOpen collapses the reference sections', () => {
+    assert.equal(sectionStartsOpen('Key Technologies'), false);
+    assert.equal(sectionStartsOpen('Recommended Certifications & Learning Paths'), false);
+    assert.equal(sectionStartsOpen('Typical Day-to-Day Activities'), false);
+    assert.equal(sectionStartsOpen('Key Performance Indicators'), false);
+});
+
+test('sectionStartsOpen tolerates the catalog heading spelling variants', () => {
+    // 67 files use "Required Skills", 155 "Required Skills & Qualifications";
+    // "and" vs "&" splits 203/19 (see #121). Matching must not depend on
+    // which variant a given file happens to use.
+    assert.equal(sectionStartsOpen('Role Scope and Boundaries'), true);
+    assert.equal(sectionStartsOpen('  role scope & boundaries  '), true);
+});
+
+test('sectionStartsOpen defaults unknown sections to collapsed', () => {
+    assert.equal(sectionStartsOpen('Something New We Added Later'), false);
+    assert.equal(sectionStartsOpen(''), false);
+    assert.equal(sectionStartsOpen(null), false);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -468,6 +468,30 @@
         return stack.join('/');
     }
 
+    // Role bodies carry 14 sections and open with all of them expanded, so
+    // the reader parses ~9,000 characters to find the one they came for
+    // (#112). Sections collapse by default; these two stay open because they
+    // orient the reader — everything else is reference material they seek out
+    // deliberately.
+    //
+    // Compared on a normalised key so the catalog's heading spelling variants
+    // ("&" vs "and", with/without "& Qualifications") all match — see #121,
+    // which removes those variants at source.
+    const DEFAULT_OPEN_SECTIONS = ['Role Overview', 'Role Scope & Boundaries'];
+
+    function sectionKey(heading) {
+        return String(heading == null ? '' : heading)
+            .toLowerCase()
+            .replace(/\band\b/g, '&')
+            .replace(/[^a-z0-9&]+/g, '');
+    }
+
+    function sectionStartsOpen(heading) {
+        const key = sectionKey(heading);
+        if (!key) return false;
+        return DEFAULT_OPEN_SECTIONS.some(s => sectionKey(s) === key);
+    }
+
     return {
         STALE_MONTHS,
         REFERENCE_DOC_PATTERN,
@@ -487,5 +511,6 @@
         parseMobilityPaths,
         parseCareerPath,
         resolveDocHref,
+        sectionStartsOpen,
     };
 });


### PR DESCRIPTION
## Summary

Opening a role expanded all 14 sections at once — ~9,000 characters for AWS Cloud Architect — so the reader had to parse the whole document to reach the one section they wanted.

Each `## ` section is now wrapped in a `<details>`. **Role Overview** and **Role Scope & Boundaries** stay open (they orient the reader); everything else starts closed.

| | Visible text on load |
|---|---|
| Before | 8,946 chars |
| After | **1,407 chars** (−84%) |

## Decisions

- **Native `<details>` over a custom widget** — free keyboard operation, correct ARIA semantics, and browser find-in-page still reaches closed sections in current browsers.
- **Print is handled in JS, not CSS.** A closed `<details>` cannot be expanded by a stylesheet, so `beforeprint` force-opens every section and `afterprint` restores exactly what the reader had. This covers Ctrl+P as well as the Print button. Markdown export is unaffected — it uses the raw source, not the DOM.
- **State is not persisted across roles.** Every role opens in the same predictable shape; remembering per-section state across 222 roles would be surprising more often than helpful.
- **`sectionStartsOpen` lives in `viewer-logic.js`** and compares on a normalised key, so the catalog's heading spelling variants (`&` vs `and`, with/without `& Qualifications` — see #121) all match regardless of which variant a file uses.
- Also adds `revealSection()`, which #111's table of contents will need to expand a collapsed target before jumping to it.

## Test plan

- [x] TDD — 4 tests written first and watched fail with `sectionStartsOpen is not defined`, then implemented
- [x] `npm test` — 103/103 passing
- [x] `npm run validate` — 0 errors, 0 warnings
- [x] Browser: 13 sections render, correct 2 open, 11 closed
- [x] Toggle verified open → closed → open via summary click
- [x] Print verified by dispatching `beforeprint`/`afterprint`: 11 closed → **0 closed during print** → 11 restored
- [x] No console errors

## Merge note

This branches from `main` and does not include #126 (#120). When both land, `linkInteractionRoles` must run **before** `collapseSections` — it walks `h2.nextElementSibling` to find the interactions table, and after collapsing that table lives inside a `<details>`. I will verify the combined behaviour on merge.