### PR TITLE
refactor: drive the five overlay panels from one registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -1329,7 +1329,7 @@
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
-        sectionStartsOpen,
+        sectionStartsOpen, panelStateFor,
         findRoleByTitle: resolveRoleTitle,
     } = ViewerLogic;
 
@@ -1613,7 +1613,6 @@
     }
 
     // ── Org chart view (ECharts tree) ─────────────────────
-    let orgOpen  = false;
     let orgChart = null; // ECharts instance, disposed on re-render
 
     // Decorate the pure buildOrgTree() output with per-kind display hints
@@ -1709,57 +1708,81 @@
         return `<ul><li>${label}${meta}${kids ? kids : ''}</li></ul>`;
     }
 
-    function toggleOrg() {
-        orgOpen = !orgOpen;
-        const ov  = document.getElementById('orgView');
-        const btn = document.getElementById('orgBtn');
-        btn.setAttribute('aria-pressed', String(orgOpen));
+    // ── Overlay panels (#119) ────────────────────────────
+    // Matrix, Stale, Org, Graph and Careers are mutually exclusive overlays.
+    // Each toggle used to hide the other four by hand, so the teardown lived
+    // in five copies; when one copy (Matrix) learned to restore the role grid
+    // on close, the other four did not — that divergence is #129, where
+    // closing Org/Graph/Careers over an open role left a blank screen.
+    //
+    // The desired state is now computed once by panelStateFor (viewer-logic,
+    // under test) and applied here, so adding a sixth panel means adding one
+    // row to this table and nothing else.
+    const PANELS = {
+        matrix:  { viewId: 'matrixView',  btnId: 'matrixBtn',
+                   onOpen: () => { renderMatrix(allDomains);
+                                   renderSidebar(allDomains, document.getElementById('searchInput').value); } },
+        stale:   { viewId: 'staleView',   btnId: 'staleBtn',
+                   onOpen: () => renderStalePanel(allDomains) },
+        org:     { viewId: 'orgView',     btnId: 'orgBtn',
+                   onOpen: () => renderOrgChart() },
+        graph:   { viewId: 'graphView',   btnId: 'graphBtn',
+                   onOpen: () => renderDomainGraph() },
+        careers: { viewId: 'careersView', btnId: 'careersBtn',
+                   onOpen: () => renderCareerSankey() },
+    };
+    let activePanel = null;
 
-        if (orgOpen) {
+    // Apply panel visibility and button state. Split out so callers that
+    // render their own content afterwards (openDoc, openChapter) can clear
+    // the panels without also triggering the content decision below.
+    function applyPanels(state) {
+        activePanel = state.active;
+        for (const [key, panel] of Object.entries(PANELS)) {
+            const { show, pressed } = state.panels[key];
+            const view = document.getElementById(panel.viewId);
+            const btn  = document.getElementById(panel.btnId);
+            view.classList.toggle('show', show);
+            if (show) view.style.display = '';
+            btn.setAttribute('aria-pressed', String(pressed));
+            btn.style.background  = pressed ? 'rgba(255,255,255,0.3)' : '';
+            btn.style.borderColor = pressed ? 'rgba(255,255,255,0.6)' : '';
+        }
+    }
+
+    // Close every panel and leave the content area to the caller.
+    function resetPanels() {
+        applyPanels(panelStateFor(null, Object.keys(PANELS), { hasRole: false }));
+    }
+
+    function setPanel(name) {
+        const state = panelStateFor(name, Object.keys(PANELS), { hasRole: !!activeFile });
+        applyPanels(state);
+
+        // A panel owns the whole content area while it is open.
+        if (state.active) {
             document.getElementById('welcomeState').style.display = 'none';
             document.getElementById('chapterView').style.display  = 'none';
             document.getElementById('rolesGrid').style.display    = 'none';
             document.getElementById('docView').style.display      = 'none';
             activeDoc = null;
-            ov.classList.add('show');
-            btn.style.background = 'rgba(255,255,255,0.3)';
-            btn.style.borderColor = 'rgba(255,255,255,0.6)';
-            renderOrgChart();
-
-            // Org, graph, matrix, and stale views are mutually exclusive
-            if (matrixOpen) {
-                matrixOpen = false;
-                document.getElementById('matrixView').classList.remove('show');
-                const mb = document.getElementById('matrixBtn');
-                mb.style.background = ''; mb.style.borderColor = ''; mb.setAttribute('aria-pressed', 'false');
-            }
-            if (staleOpen) {
-                staleOpen = false;
-                document.getElementById('staleView').classList.remove('show');
-                document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
-            }
-            if (graphOpen) {
-                graphOpen = false;
-                document.getElementById('graphView').classList.remove('show');
-                const gb = document.getElementById('graphBtn');
-                gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
-            }
-            if (careersOpen) {
-                careersOpen = false;
-                document.getElementById('careersView').classList.remove('show');
-                const cb = document.getElementById('careersBtn');
-                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
-            }
+            PANELS[state.active].onOpen?.();
         } else {
-            ov.classList.remove('show');
-            btn.style.background = '';
-            btn.style.borderColor = '';
-            if (!activeFile) document.getElementById('welcomeState').style.display = '';
+            document.getElementById('rolesGrid').style.display    = state.showRolesGrid ? '' : 'none';
+            document.getElementById('welcomeState').style.display = state.showWelcome ? '' : 'none';
         }
     }
 
+    function togglePanel(name) { setPanel(activePanel === name ? null : name); }
+    function closePanels()     { setPanel(null); }
+
+    const toggleMatrix     = () => togglePanel('matrix');
+    const toggleStalePanel = () => togglePanel('stale');
+    const toggleOrg        = () => togglePanel('org');
+    const toggleGraph      = () => togglePanel('graph');
+    const toggleCareers    = () => togglePanel('careers');
+
     // ── Domain relationship graph (ECharts force graph) ───
-    let graphOpen  = false;
     let graphChart = null;
 
     // Chapter-categorical palettes, validated (dataviz six-checks) against
@@ -1889,57 +1912,8 @@
         return `<ul>${byNode}</ul>`;
     }
 
-    function toggleGraph() {
-        graphOpen = !graphOpen;
-        const gv  = document.getElementById('graphView');
-        const btn = document.getElementById('graphBtn');
-        btn.setAttribute('aria-pressed', String(graphOpen));
-
-        if (graphOpen) {
-            document.getElementById('welcomeState').style.display = 'none';
-            document.getElementById('chapterView').style.display  = 'none';
-            document.getElementById('rolesGrid').style.display    = 'none';
-            document.getElementById('docView').style.display      = 'none';
-            activeDoc = null;
-            gv.classList.add('show');
-            btn.style.background = 'rgba(255,255,255,0.3)';
-            btn.style.borderColor = 'rgba(255,255,255,0.6)';
-            renderDomainGraph();
-
-            // Graph, org, matrix, and stale views are mutually exclusive
-            if (matrixOpen) {
-                matrixOpen = false;
-                document.getElementById('matrixView').classList.remove('show');
-                const mb = document.getElementById('matrixBtn');
-                mb.style.background = ''; mb.style.borderColor = ''; mb.setAttribute('aria-pressed', 'false');
-            }
-            if (staleOpen) {
-                staleOpen = false;
-                document.getElementById('staleView').classList.remove('show');
-                document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
-            }
-            if (orgOpen) {
-                orgOpen = false;
-                document.getElementById('orgView').classList.remove('show');
-                const ob = document.getElementById('orgBtn');
-                ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
-            }
-            if (careersOpen) {
-                careersOpen = false;
-                document.getElementById('careersView').classList.remove('show');
-                const cb = document.getElementById('careersBtn');
-                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
-            }
-        } else {
-            gv.classList.remove('show');
-            btn.style.background = '';
-            btn.style.borderColor = '';
-            if (!activeFile) document.getElementById('welcomeState').style.display = '';
-        }
-    }
 
     // ── Career path flow (ECharts sankey) ─────────────────
-    let careersOpen  = false;
     let careersChart = null;
 
     // Ordinal blue ramp (light→dark with seniority) for the main IC line,
@@ -2021,42 +1995,6 @@
             <ul>${mobilityHtml}</ul>`;
     }
 
-    function toggleCareers() {
-        careersOpen = !careersOpen;
-        const cv  = document.getElementById('careersView');
-        const btn = document.getElementById('careersBtn');
-        btn.setAttribute('aria-pressed', String(careersOpen));
-
-        if (careersOpen) {
-            document.getElementById('welcomeState').style.display = 'none';
-            document.getElementById('chapterView').style.display  = 'none';
-            document.getElementById('rolesGrid').style.display    = 'none';
-            document.getElementById('docView').style.display      = 'none';
-            activeDoc = null;
-            cv.classList.add('show');
-            btn.style.background = 'rgba(255,255,255,0.3)';
-            btn.style.borderColor = 'rgba(255,255,255,0.6)';
-            renderCareerSankey();
-
-            // All five side panels are mutually exclusive
-            for (const [flagOff, viewId, btnId] of [
-                [() => { matrixOpen = false; }, 'matrixView', 'matrixBtn'],
-                [() => { staleOpen  = false; }, 'staleView',  'staleBtn'],
-                [() => { orgOpen    = false; }, 'orgView',    'orgBtn'],
-                [() => { graphOpen  = false; }, 'graphView',  'graphBtn'],
-            ]) {
-                flagOff();
-                document.getElementById(viewId).classList.remove('show');
-                const b = document.getElementById(btnId);
-                b.style.background = ''; b.style.borderColor = ''; b.setAttribute('aria-pressed', 'false');
-            }
-        } else {
-            cv.classList.remove('show');
-            btn.style.background = '';
-            btn.style.borderColor = '';
-            if (!activeFile) document.getElementById('welcomeState').style.display = '';
-        }
-    }
 
     // Keep the ECharts canvases sized to their containers.
     window.addEventListener('resize', () => { orgChart?.resize(); graphChart?.resize(); careersChart?.resize(); });
@@ -2407,27 +2345,6 @@
     }
 
     // Close the matrix, stale, org, and graph panels (used when opening a role/doc/chapter).
-    function closePanels() {
-        matrixOpen = false;
-        staleOpen  = false;
-        orgOpen    = false;
-        graphOpen  = false;
-        document.getElementById('matrixView').classList.remove('show');
-        document.getElementById('staleView').classList.remove('show');
-        document.getElementById('orgView').classList.remove('show');
-        document.getElementById('graphView').classList.remove('show');
-        const mb = document.getElementById('matrixBtn');
-        mb.style.background = ''; mb.style.borderColor = ''; mb.setAttribute('aria-pressed', 'false');
-        document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
-        const ob = document.getElementById('orgBtn');
-        ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
-        const gb = document.getElementById('graphBtn');
-        gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
-        careersOpen = false;
-        document.getElementById('careersView').classList.remove('show');
-        const cb = document.getElementById('careersBtn');
-        cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
-    }
 
     // ── Career stepper (role view, #55) ───────────────────
     // From → current role → To chips parsed from the role's own Career
@@ -2683,33 +2600,7 @@
         document.getElementById('roleView').classList.remove('show');
         document.getElementById('welcomeState').style.display = 'none';
         document.getElementById('chapterView').style.display  = 'none';
-        document.getElementById('matrixView').classList.remove('show');
-        matrixOpen = false;
-        document.getElementById('matrixBtn').style.background  = '';
-        document.getElementById('matrixBtn').style.borderColor = '';
-        document.getElementById('matrixBtn').setAttribute('aria-pressed', 'false');
-
-        document.getElementById('staleView').classList.remove('show');
-        staleOpen = false;
-        document.getElementById('staleBtn').setAttribute('aria-pressed', 'false');
-
-        document.getElementById('orgView').classList.remove('show');
-        orgOpen = false;
-        document.getElementById('orgBtn').style.background  = '';
-        document.getElementById('orgBtn').style.borderColor = '';
-        document.getElementById('orgBtn').setAttribute('aria-pressed', 'false');
-
-        document.getElementById('graphView').classList.remove('show');
-        graphOpen = false;
-        document.getElementById('graphBtn').style.background  = '';
-        document.getElementById('graphBtn').style.borderColor = '';
-        document.getElementById('graphBtn').setAttribute('aria-pressed', 'false');
-
-        document.getElementById('careersView').classList.remove('show');
-        careersOpen = false;
-        document.getElementById('careersBtn').style.background  = '';
-        document.getElementById('careersBtn').style.borderColor = '';
-        document.getElementById('careersBtn').setAttribute('aria-pressed', 'false');
+        resetPanels();
 
         renderSidebar(allDomains, document.getElementById('searchInput').value);
 
@@ -2866,15 +2757,12 @@
         // Charts read their colors from CSS variables at render time, so a
         // theme flip means a re-render against the new surface.
         if (Object.keys(allDomains).length) renderDistributionCharts(allDomains);
-        if (orgOpen) renderOrgChart();
-        if (graphOpen) renderDomainGraph();
-        if (careersOpen) renderCareerSankey();
+        // Only the panel actually on screen needs re-rendering.
+        if (activePanel) PANELS[activePanel].onOpen?.();
     }
 
     // ── Matrix view ───────────────────────────────────────
     // (LEVEL_ORDER / LEVEL_SHORT come from viewer-logic.js)
-    let matrixOpen = false;
-    let staleOpen  = false;
 
     function renderMatrix(domains) {
         // Collect which levels actually exist in the data
@@ -2945,56 +2833,6 @@
             </div>`;
     }
 
-    function toggleMatrix() {
-        matrixOpen = !matrixOpen;
-        const mv  = document.getElementById('matrixView');
-        const btn = document.getElementById('matrixBtn');
-        btn.setAttribute('aria-pressed', String(matrixOpen));
-
-        if (matrixOpen) {
-            // Hide normal content and doc view, show matrix
-            document.getElementById('welcomeState').style.display = 'none';
-            document.getElementById('chapterView').style.display  = 'none';
-            document.getElementById('rolesGrid').style.display    = 'none';
-            document.getElementById('docView').style.display      = 'none';
-            activeDoc = null;
-            mv.style.display = '';
-            mv.classList.add('show');
-            btn.style.background = 'rgba(255,255,255,0.3)';
-            btn.style.borderColor = 'rgba(255,255,255,0.6)';
-            renderMatrix(allDomains);
-            renderSidebar(allDomains, document.getElementById('searchInput').value);
-
-            // Matrix, stale, org, and graph panels are mutually exclusive
-            if (staleOpen) { staleOpen = false; document.getElementById('staleView').classList.remove('show'); document.getElementById('staleBtn').setAttribute('aria-pressed', 'false'); }
-            if (orgOpen) {
-                orgOpen = false;
-                document.getElementById('orgView').classList.remove('show');
-                const ob = document.getElementById('orgBtn');
-                ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
-            }
-            if (graphOpen) {
-                graphOpen = false;
-                document.getElementById('graphView').classList.remove('show');
-                const gb = document.getElementById('graphBtn');
-                gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
-            }
-            if (careersOpen) {
-                careersOpen = false;
-                document.getElementById('careersView').classList.remove('show');
-                const cb = document.getElementById('careersBtn');
-                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
-            }
-        } else {
-            // Restore normal content
-            document.getElementById('rolesGrid').style.display = '';
-            mv.classList.remove('show');
-            btn.style.background = '';
-            btn.style.borderColor = '';
-            // Show welcome if no role loaded
-            if (!activeFile) document.getElementById('welcomeState').style.display = '';
-        }
-    }
 
     // ── Stale-role tracking ───────────────────────────────
     // (monthsSinceReview / computeStaleRoles come from viewer-logic.js)
@@ -3007,53 +2845,6 @@
         btn.setAttribute('aria-label', `${stale.length} roles overdue for review`);
     }
 
-    function toggleStalePanel() {
-        staleOpen = !staleOpen;
-        const sv  = document.getElementById('staleView');
-        const btn = document.getElementById('staleBtn');
-        btn.setAttribute('aria-pressed', String(staleOpen));
-
-        if (staleOpen) {
-            document.getElementById('welcomeState').style.display = 'none';
-            document.getElementById('chapterView').style.display  = 'none';
-            document.getElementById('rolesGrid').style.display    = 'none';
-            document.getElementById('docView').style.display      = 'none';
-            activeDoc = null;
-            sv.style.display = '';
-            sv.classList.add('show');
-            renderStalePanel(allDomains);
-
-            // Matrix, stale, org, and graph panels are mutually exclusive
-            if (matrixOpen) {
-                matrixOpen = false;
-                document.getElementById('matrixView').classList.remove('show');
-                document.getElementById('matrixBtn').setAttribute('aria-pressed', 'false');
-                document.getElementById('matrixBtn').style.background  = '';
-                document.getElementById('matrixBtn').style.borderColor = '';
-            }
-            if (orgOpen) {
-                orgOpen = false;
-                document.getElementById('orgView').classList.remove('show');
-                const ob = document.getElementById('orgBtn');
-                ob.style.background = ''; ob.style.borderColor = ''; ob.setAttribute('aria-pressed', 'false');
-            }
-            if (graphOpen) {
-                graphOpen = false;
-                document.getElementById('graphView').classList.remove('show');
-                const gb = document.getElementById('graphBtn');
-                gb.style.background = ''; gb.style.borderColor = ''; gb.setAttribute('aria-pressed', 'false');
-            }
-            if (careersOpen) {
-                careersOpen = false;
-                document.getElementById('careersView').classList.remove('show');
-                const cb = document.getElementById('careersBtn');
-                cb.style.background = ''; cb.style.borderColor = ''; cb.setAttribute('aria-pressed', 'false');
-            }
-        } else {
-            sv.classList.remove('show');
-            if (!activeFile) document.getElementById('welcomeState').style.display = '';
-        }
-    }
 
     function renderStalePanel(domains) {
         const stale = computeStaleRoles(domains);

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -24,6 +24,7 @@ const {
     sectionStartsOpen,
     roleTitleKey,
     findRoleByTitle,
+    panelStateFor,
 } = require('../viewer-logic');
 
 const { CANONICAL_LEVELS, REFERENCE_DOC_PATTERN: ROLEMETA_REF_PATTERN } = require('../roleMeta');
@@ -702,4 +703,42 @@ test('no two catalog role titles collide under roleTitleKey', () => {
         }
     }
     assert.deepEqual(collisions, [], 'role titles that normalise to the same lookup key');
+});
+
+// ── panelStateFor (#119, #129) ────────────────────────────
+// The five overlay panels are mutually exclusive, and their show/hide plus
+// button state was copy-pasted into each toggle. One copy (Matrix) learned
+// to restore the role grid on close and the other four never did, which is
+// #129: closing Org/Graph/Careers over an open role left a blank screen.
+// This computes the whole desired state in one place instead.
+const PANEL_KEYS = ['matrix', 'stale', 'org', 'graph', 'careers'];
+
+test('panelStateFor activates exactly one panel and clears the rest', () => {
+    const s = panelStateFor('org', PANEL_KEYS, { hasRole: false });
+    assert.equal(s.active, 'org');
+    assert.deepEqual(s.panels.org, { show: true, pressed: true });
+    for (const k of PANEL_KEYS.filter(k => k !== 'org')) {
+        assert.deepEqual(s.panels[k], { show: false, pressed: false }, `${k} must be cleared`);
+    }
+});
+
+test('panelStateFor hides the content views while a panel is open', () => {
+    const s = panelStateFor('graph', PANEL_KEYS, { hasRole: true });
+    assert.equal(s.showRolesGrid, false);
+    assert.equal(s.showWelcome, false);
+});
+
+test('panelStateFor restores the open role when every panel closes (#129)', () => {
+    // The regression: closing a panel over an open role must bring the role
+    // back, not leave an empty content area.
+    const s = panelStateFor(null, PANEL_KEYS, { hasRole: true });
+    assert.equal(s.showRolesGrid, true, 'the open role must become visible again');
+    assert.equal(s.showWelcome, false, 'welcome must not cover an open role');
+    for (const k of PANEL_KEYS) assert.deepEqual(s.panels[k], { show: false, pressed: false });
+});
+
+test('panelStateFor falls back to the welcome screen when no role is open', () => {
+    const s = panelStateFor(null, PANEL_KEYS, { hasRole: false });
+    assert.equal(s.showWelcome, true);
+    assert.equal(s.showRolesGrid, false);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -526,6 +526,31 @@
         return null;
     }
 
+    // The viewer has five mutually exclusive overlay panels (matrix, stale,
+    // org, graph, careers). Each toggle used to hide the others by hand, so
+    // the teardown existed in five copies — and when one copy learned to
+    // restore the role grid on close, the other four did not, which is #129:
+    // closing Org/Graph/Careers over an open role left a blank screen.
+    //
+    // Given the panel being requested (null = close everything), this returns
+    // the complete desired state, so the caller applies one description
+    // instead of maintaining five divergent ones (#119).
+    function panelStateFor(requested, keys, { hasRole = false } = {}) {
+        const panels = {};
+        for (const key of keys) {
+            const on = key === requested;
+            panels[key] = { show: on, pressed: on };
+        }
+        return {
+            active: requested || null,
+            panels,
+            // While a panel is open it owns the content area. When they all
+            // close, an open role takes it back; otherwise the welcome screen.
+            showRolesGrid: !requested && hasRole,
+            showWelcome:   !requested && !hasRole,
+        };
+    }
+
     return {
         STALE_MONTHS,
         REFERENCE_DOC_PATTERN,
@@ -548,5 +573,6 @@
         sectionStartsOpen,
         roleTitleKey,
         findRoleByTitle,
+        panelStateFor,
     };
 });


### PR DESCRIPTION
## Summary

Matrix, Stale, Org, Graph and Careers are mutually exclusive, but each toggle hid the other four by hand — the teardown lived in **five copies**, plus a sixth in `closePanels` and a seventh inline in `openDoc`.

That divergence had already shipped a real bug. **Only `toggleMatrix` restored the role grid on close**, so closing Org, Graph or Careers over an open role left a blank screen (#129). Fixing that per-panel would have meant four more copies of the same teardown, so both issues are resolved together.

`panelStateFor` (in `viewer-logic.js`, under test) now computes the complete desired state — which panel shows, which button is pressed, and what reclaims the content area — and `index.html` applies that single description. Adding a sixth panel is one row in the `PANELS` table.

**`index.html` loses ~245 lines** (133 insertions / 277 deletions overall).

Also replaces the five `*Open` booleans with one `activePanel`, which lets the theme handler re-render just the panel on screen rather than testing three flags.

Closes #119
Closes #129

## Test plan

**#129 regression — role open → panel → close → role must return.** Was broken for 3 of 4 testable panels on `main`:

| Panel | before | after |
|---|---|---|
| Matrix | ✅ role returns | ✅ |
| Org | ❌ **blank screen** | ✅ role returns |
| Graph | ❌ **blank screen** | ✅ role returns |
| Careers | ❌ **blank screen** | ✅ role returns |

**Behaviour preserved (verified in-browser):**
- [x] Mutual exclusivity: opening each panel leaves exactly one `show` and exactly one `aria-pressed="true"`
- [x] Org/Graph/Careers still render their ECharts canvas
- [x] Closing all panels: nothing shown, nothing pressed, **no button left with a stuck background**, welcome screen returns
- [x] `openDoc` from an open panel clears all panels and their pressed state (the 35-line inline block → `resetPanels()`)
- [x] Theme flip with a panel open keeps it shown and redraws its chart
- [x] Chapter view unaffected

**Suite:** TDD — 4 tests written first and watched fail with `panelStateFor is not defined`. `npm test` 114/114 (was 110) · `npm run validate` clean · no console errors.

## Note on `stale`

The Stale button previously never got the active highlight the other four use — it set `aria-pressed` but no background. The registry now treats all five uniformly, so the Stale button highlights when its panel is open. That is a small deliberate visual change; say the word if you want the old asymmetry preserved. (It is currently hidden anyway: no role is stale until 2027-03, see #124.)