### PR TITLE
tooling: warn on non-canonical headings and content formats

### DIFF
--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -31,11 +31,18 @@ test.after(() => {
 function completeRole({ except = null, transform = null } = {}) {
   const sections = REQUIRED_SECTIONS
     .filter(s => s.name !== except)
-    .map(s => s.name === 'Interactions with Other Roles'
-      // This section must carry the Interaction Mode column (#6), so it needs
-      // a real table rather than the placeholder prose the others use.
-      ? `## ${s.name}\n\n| Role | Nature of Interaction | Interaction Mode |\n|---|---|---|\n| Peer Role | Shared delivery work | Collaborates |\n`
-      : `## ${s.name}\n\nContent for ${s.name}.\n`)
+    .map(s => {
+      // Two sections have a required shape rather than free prose:
+      // Interactions needs the Interaction Mode column (#6), and KPIs need
+      // the measurable table form (#121). The rest use placeholder text.
+      if (s.name === 'Interactions with Other Roles') {
+        return `## ${s.name}\n\n| Role | Nature of Interaction | Interaction Mode |\n|---|---|---|\n| Peer Role | Shared delivery work | Collaborates |\n`;
+      }
+      if (s.name === 'Key Performance Indicators') {
+        return `## ${s.name}\n\n| Metric | Target | Frequency |\n|---|---|---|\n| Delivery within agreed scope | ≥95% | Monthly |\n`;
+      }
+      return `## ${s.name}\n\nContent for ${s.name}.\n`;
+    })
     .join('\n');
   let content = `# Test Role
 
@@ -336,4 +343,79 @@ test('CLI exits 1 and names both files when a duplicate title exists', () => {
   assert.match(run.stdout, /testdomain\/a\.md/);
   assert.match(run.stdout, /testdomain\/b\.md/);
   fs.rmSync(root, { recursive: true, force: true });
+});
+
+// ── canonical formatting warnings (#121) ─────────────────
+// The validator accepts several historical spellings and formats so that a
+// missing section is reported instead of a cosmetic difference. That
+// permissiveness is why the catalog drifted (203/19 on "and" vs "&",
+// 155/67 on "Required Skills", 200/22 on KPI format). These now warn, so
+// the drift is visible and `--strict` can gate it once #122 normalises the
+// files.
+
+test('a non-canonical but accepted heading spelling warns', () => {
+  const file = writeFixture('warn-heading.md', completeRole({
+    transform: c => c.replace('## Key Decisions & Accountabilities', '## Key Decisions and Accountabilities'),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, [], 'still not an error - the section is present');
+  assert.ok(
+    r.warnings.some(w => /Key Decisions & Accountabilities/.test(w)),
+    `expected a canonical-heading warning, got: ${JSON.stringify(r.warnings)}`
+  );
+});
+
+test('the canonical heading spelling does not warn', () => {
+  const file = writeFixture('ok-heading.md', completeRole());
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.warnings.filter(w => /canonical heading/i.test(w)), []);
+});
+
+test('bullet-format Key Performance Indicators warn', () => {
+  // 200 of 222 roles list KPI topics rather than measurable targets; the
+  // template calls the table form preferred. See #122.
+  const file = writeFixture('kpi-bullets.md', completeRole({
+    transform: c => c.replace(
+      '| Metric | Target | Frequency |\n|---|---|---|\n| Delivery within agreed scope | ≥95% | Monthly |\n',
+      '- Architecture design quality and effectiveness\n- Cost efficiency of designed solutions\n'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  assert.ok(
+    r.warnings.some(w => /Key Performance Indicators/.test(w) && /table/i.test(w)),
+    `expected a KPI table warning, got: ${JSON.stringify(r.warnings)}`
+  );
+});
+
+test('table-format Key Performance Indicators do not warn', () => {
+  const file = writeFixture('kpi-table.md', completeRole());
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.warnings.filter(w => /Key Performance Indicators/.test(w)), []);
+});
+
+test('inline-bullet Technology Proficiency Levels warn', () => {
+  const file = writeFixture('prof-inline.md', completeRole({
+    transform: c => c.replace(
+      'Content for Required Skills & Qualifications.',
+      '**Technology Proficiency Levels:**\n\n- **Expert level required:** Kubernetes, Terraform\n- **Proficient level required:** Helm\n'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  assert.ok(
+    r.warnings.some(w => /Technology Proficiency Levels/.test(w)),
+    `expected a proficiency-format warning, got: ${JSON.stringify(r.warnings)}`
+  );
+});
+
+test('sub-heading Technology Proficiency Levels do not warn', () => {
+  const file = writeFixture('prof-subhead.md', completeRole({
+    transform: c => c.replace(
+      'Content for Required Skills & Qualifications.',
+      '**Technology Proficiency Levels:**\n\n**Expert level required:**\n\n- Kubernetes\n\n**Proficient level required:**\n\n- Helm\n'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.warnings.filter(w => /Technology Proficiency Levels/.test(w)), []);
 });

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -19,7 +19,10 @@ const STRICT     = process.argv.includes('--strict');
 
 // Required section headings. Each entry accepts one or more historical
 // spellings so the validator surfaces genuinely missing content rather than
-// failing on cosmetic wording differences (tracked as a follow-up cleanup).
+// failing on cosmetic wording differences. Anything other than `name` itself
+// now also raises a canonical-heading warning (#121) so the drift is visible
+// and countable; #122 normalises the files, after which the alternates can be
+// dropped and CI can move to `--strict`.
 const REQUIRED_SECTIONS = [
   { name: 'Role Overview',                          patterns: [/^##\s+Role Overview/im] },
   { name: 'Role Scope & Boundaries',                patterns: [/^##\s+Role Scope (&|and) Boundaries/im] },
@@ -43,6 +46,29 @@ const REQUIRED_SECTIONS = [
 // bare mention of the words — the template's explanatory blockquote above the
 // table would otherwise satisfy a looser check.
 const INTERACTION_MODE_COLUMN = /^\|.*Interaction Mode.*\|[ \t]*\r?\n\|[\s:|-]+\|/im;
+
+// Return the body of a "## " section: everything up to the next H2 or EOF.
+function sectionBody(content, heading) {
+  const start = content.search(new RegExp('^##\\s+' + heading, 'im'));
+  if (start === -1) return '';
+  const rest = content.slice(start);
+  const next = rest.search(/\n##\s+/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+// The template calls the KPI table (| Metric | Target | Frequency |) the
+// preferred form because a bullet list records topics, not measurable
+// targets: "Architecture design quality and effectiveness" cannot be met or
+// missed. 200 of 222 roles still use bullets — see #122.
+function hasKpiTable(body) {
+  return /^\|.*\|[ \t]*\r?\n\|[\s:|-]+\|/im.test(body);
+}
+
+// Technology Proficiency Levels should use the template's sub-heading form
+// (**Expert level required:** on its own line, then a bullet list) rather
+// than folding each tier into a single bullet. 191 of 222 use the inline
+// form — see #122.
+const PROFICIENCY_INLINE = /^[ \t]*-[ \t]+\*\*(Expert|Proficient|Working Knowledge|Awareness)[^*]*\*\*/im;
 
 function listRoleFiles(rolesDir = ROLES_DIR) {
   const files = [];
@@ -105,7 +131,28 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
 
   for (const section of REQUIRED_SECTIONS) {
     const found = section.patterns.some(re => re.test(content));
-    if (!found) errors.push(`Missing section: ## ${section.name}`);
+    if (!found) {
+      errors.push(`Missing section: ## ${section.name}`);
+      continue;
+    }
+    // Present, but is it spelled the canonical way? An accepted alternate is
+    // not an error (the content is there) but it is drift worth counting.
+    const canonical = new RegExp('^##\\s+' + section.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*$', 'im');
+    if (!canonical.test(content)) {
+      warnings.push(`Non-canonical heading for "${section.name}" — use "## ${section.name}" exactly`);
+    }
+  }
+
+  // Content-format conventions. Warnings rather than errors while #122
+  // normalises the catalog; `--strict` already fails on warnings, so CI can
+  // be switched over the moment that lands.
+  const kpiBody = sectionBody(content, 'Key Performance Indicators');
+  if (kpiBody && !hasKpiTable(kpiBody)) {
+    warnings.push('Key Performance Indicators uses bullets — the template prefers a | Metric | Target | Frequency | table so targets are measurable');
+  }
+
+  if (PROFICIENCY_INLINE.test(content)) {
+    warnings.push('Technology Proficiency Levels uses inline bullets — the template puts each level on its own **sub-heading** line');
   }
 
   if (!INTERACTION_MODE_COLUMN.test(content)) {


### PR DESCRIPTION
## Summary

`validate-roles.js` accepted several historical heading spellings and content formats so a genuinely missing section was reported rather than a cosmetic difference. The code comment called the cleanup "a follow-up" — it was never filed, and that permissiveness is exactly why the catalog drifted.

Three checks added, deliberately as **warnings**:

- A section present under an accepted alternate spelling warns, naming the canonical form.
- **KPIs written as bullets** warn — a bullet records a topic, not a target that can be met or missed.
- **Technology Proficiency Levels folded into inline bullets** warn.

Closes #121

## Why warnings, not errors

222 files are non-conforming today. Making these errors turns CI red until #122 finishes normalising the catalog, which would block all other work. Warnings keep the drift visible and countable now, and `--strict` (which already fails on warnings) becomes the gate for the cleanup:

```
npm run validate        → exit 0   (CI stays green)
node validate-roles.js --strict → exit 1   (gates #122)
```

Once #122 lands, CI switches to `--strict` and the alternate spellings can be deleted from `REQUIRED_SECTIONS`.

## What it reports against the catalog

**214 of 222 files**, 0 errors:

| Warning | Files |
|---|---|
| `Key Decisions and Accountabilities` → `&` | 203 |
| KPIs use bullets, not a measurable table | 200 |
| Proficiency levels use inline bullets | 191 |
| bare `Required Skills` → `& Qualifications` | 67 |
| `Key Technologies & Platforms` / `& Tools` | **4** |
| `Recommended Certifications and …` → `&` | 1 |

The first four and the last match the counts from the analysis that produced #121/#122 exactly, which is a good independent check on both.

**The 4 `Key Technologies` variants are new** — a manual survey missed them: `finops_architect`, `devops_product_owner`, `observability_product_owner`, `observability_senior_engineer` use `## Key Technologies & Platforms` or `## Key Technologies & Tools`. Precisely the drift a tool catches and a person doesn't.

## Test plan

- [x] TDD — 6 tests written first; the 3 asserting new warnings watched fail with empty `warnings` arrays, then implemented
- [x] The shared `completeRole()` fixture now uses a real KPI table, so it represents a genuinely conforming file
- [x] `npm test` — 120/120 (was 114)
- [x] `npm run validate` → exit **0**, 0 errors (CI unaffected)
- [x] `node validate-roles.js --strict` → exit **1** (gate works)