### PR TITLE
feat: add a sticky section nav to role documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,12 @@
         }
 
         /* Role view */
-        .role-view { display: none; animation: fadeInUp 0.3s ease-out; }
+        /* min-width:0 overrides the grid item's auto minimum. Without it the
+           section nav's nowrap flex row sets the track's minimum width, so
+           the column grew to ~2300px on a 375px screen instead of the nav
+           scrolling inside itself (#111). Same reason the tables below use
+           their own overflow container. */
+        .role-view { display: none; min-width: 0; animation: fadeInUp 0.3s ease-out; }
         .role-view.show { display: block; }
 
         .role-card {
@@ -609,6 +614,47 @@
         }
 
         .md-body h1 { display: none; }
+
+        /* ── Sticky section nav (#111) ──────────────────────── */
+        .toc-nav {
+            position: sticky;
+            top: 0;
+            z-index: 20;
+            display: flex;
+            gap: 6px;
+            overflow-x: auto;
+            scrollbar-width: thin;
+            padding: 10px 2px;
+            margin-bottom: 14px;
+            background: var(--bg-main);
+            border-bottom: 1px solid var(--border-color);
+        }
+        .toc-nav[hidden] { display: none; }
+
+        .toc-chip {
+            flex: 0 0 auto;
+            padding: 5px 11px;
+            border-radius: 20px;
+            border: 1px solid var(--border-color);
+            background: var(--bg-card);
+            color: var(--text-muted);
+            font-size: 0.78em;
+            font-family: inherit;
+            white-space: nowrap;
+            cursor: pointer;
+            transition: color var(--transition), border-color var(--transition), background var(--transition);
+        }
+        .toc-chip:hover { color: var(--text-primary); border-color: var(--border-hover); }
+        .toc-chip:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }
+        .toc-chip.active {
+            color: var(--accent-blue);
+            border-color: var(--accent-blue);
+            background: var(--bg-card-hover);
+            font-weight: 600;
+        }
+
+        /* The nav is a reading aid, not content. */
+        @media print { .toc-nav { display: none !important; } }
 
         /* ── Collapsible role sections (#112) ───────────────── */
         .md-section { border-bottom: 1px solid var(--border-color); }
@@ -794,6 +840,13 @@
             margin-bottom: 12px;
         }
         .role-actions { display: flex; gap: 8px; flex-shrink: 0; padding-top: 3px; }
+        /* Three nowrap buttons are ~283px, so on a 375px screen Compare fell
+           off the right edge and the content area scrolled sideways (#132).
+           Let the header stack and the buttons wrap instead. */
+        @media (max-width: 768px) {
+            .role-header-row { flex-wrap: wrap; }
+            .role-actions { flex-wrap: wrap; flex-shrink: 1; }
+        }
         .btn-action {
             padding: 5px 12px;
             border: 1px solid var(--border-color);
@@ -1237,6 +1290,7 @@
             <div class="role-view" id="roleView">
                 <div class="role-card" id="roleHeader"></div>
                 <nav class="career-stepper" id="careerStepper" aria-label="Career progression for this role" hidden></nav>
+                <nav class="toc-nav" id="sectionNav" aria-label="Jump to a section of this role" hidden></nav>
                 <div class="md-body"  id="roleBody"></div>
             </div>
 
@@ -1330,6 +1384,7 @@
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
         sectionStartsOpen, panelStateFor,
+        tocIdFor, activeTocIndex,
         findRoleByTitle: resolveRoleTitle,
     } = ViewerLogic;
 
@@ -2417,11 +2472,82 @@
     }
 
     // Expand the section containing an element (used when navigating to a
-    // collapsed section — the TOC in #111 will rely on this too).
+    // collapsed section — the TOC in #111 relies on this).
     function revealSection(el) {
         for (let p = el; p; p = p.parentElement) {
             if (p.tagName === 'DETAILS') p.open = true;
         }
+    }
+
+    // Sticky section nav for a role body (#111).
+    //
+    // Collapsing the sections (#112) already gives an overview *at the top of
+    // the page*; this covers the case that remains — once a section is
+    // expanded and the reader scrolls into it, that overview is gone. The nav
+    // stays pinned, marks where you are, and jumps (expanding the target
+    // first, since it may be collapsed).
+    //
+    // A horizontal bar rather than the side rail the issue sketched: compare
+    // mode splits .roles-grid into two equal columns, so a rail would either
+    // break that layout or have to be suppressed exactly when two dense
+    // documents make navigation most useful.
+    let tocSpy = null;
+
+    function buildSectionNav(container, navEl, scroller) {
+        const sections = [...container.querySelectorAll('details.md-section')];
+        if (sections.length < 2) { navEl.hidden = true; navEl.innerHTML = ''; return; }
+
+        for (const s of sections) {
+            s.id = tocIdFor(s.querySelector('summary').textContent.trim());
+        }
+
+        navEl.innerHTML = sections.map((s, i) => {
+            const label = s.querySelector('summary').textContent.trim();
+            return `<button class="toc-chip${i === 0 ? ' active' : ''}" data-target="${escapeHtml(s.id)}"
+                     >${escapeHtml(label)}</button>`;
+        }).join('');
+        navEl.hidden = false;
+
+        const chips = [...navEl.querySelectorAll('.toc-chip')];
+        const markActive = i => chips.forEach((c, n) => c.classList.toggle('active', n === i));
+
+        // An explicit jump wins over the spy until the smooth scroll settles.
+        // Near the end of the document the target often cannot reach the top
+        // of the scrollport at all, so the spy would otherwise immediately
+        // re-highlight a different chip and make the click look ignored.
+        let jumpUntil = 0;
+
+        navEl.onclick = e => {
+            const chip = e.target.closest('.toc-chip');
+            if (!chip) return;
+            const target = container.querySelector('#' + CSS.escape(chip.dataset.target));
+            if (!target) return;
+            revealSection(target);            // may be collapsed
+            markActive(chips.indexOf(chip));
+            jumpUntil = Date.now() + 800;
+            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        };
+
+        // Scroll-spy. rAF-throttled: this fires on every scroll frame.
+        let ticking = false;
+        const spy = () => {
+            if (ticking) return;
+            ticking = true;
+            requestAnimationFrame(() => {
+                ticking = false;
+                if (Date.now() < jumpUntil) return;
+                const base = scroller.getBoundingClientRect().top;
+                // 90px lookahead so a section counts as current once its
+                // heading is comfortably on screen, not only at the very top.
+                const tops = sections.map(s => s.getBoundingClientRect().top - base + scroller.scrollTop - 90);
+                const atBottom = scroller.scrollTop >= scroller.scrollHeight - scroller.clientHeight - 2;
+                markActive(activeTocIndex(tops, scroller.scrollTop, { atBottom }));
+            });
+        };
+        if (tocSpy) scroller.removeEventListener('scroll', tocSpy);
+        tocSpy = spy;
+        scroller.addEventListener('scroll', spy, { passive: true });
+        spy();
     }
 
     // Link the role names in the "Interactions with Other Roles" table.
@@ -2534,6 +2660,9 @@
             // every cross-reference link.
             linkInteractionRoles(document.getElementById('roleBody'), title);
             collapseSections(document.getElementById('roleBody'));
+            buildSectionNav(document.getElementById('roleBody'),
+                            document.getElementById('sectionNav'),
+                            document.getElementById('mainArea'));
             renderCareerStepper(markdown, title);
             document.getElementById('mainArea').scrollTop = 0;
 

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -25,6 +25,8 @@ const {
     roleTitleKey,
     findRoleByTitle,
     panelStateFor,
+    tocIdFor,
+    activeTocIndex,
 } = require('../viewer-logic');
 
 const { CANONICAL_LEVELS, REFERENCE_DOC_PATTERN: ROLEMETA_REF_PATTERN } = require('../roleMeta');
@@ -741,4 +743,55 @@ test('panelStateFor falls back to the welcome screen when no role is open', () =
     const s = panelStateFor(null, PANEL_KEYS, { hasRole: false });
     assert.equal(s.showWelcome, true);
     assert.equal(s.showRolesGrid, false);
+});
+
+// ── TOC helpers (#111) ────────────────────────────────────
+// Role bodies are 13 collapsible sections. Once one is expanded and the
+// reader scrolls into it the overview is lost, so a sticky section nav needs
+// stable ids to jump to and a scroll-spy to say where you are.
+
+test('tocIdFor slugifies a heading into a stable anchor id', () => {
+    assert.equal(tocIdFor('Role Overview'), 'sec-role-overview');
+    assert.equal(tocIdFor('Key Decisions & Accountabilities'), 'sec-key-decisions-accountabilities');
+    assert.equal(tocIdFor('Typical Day-to-Day Activities'), 'sec-typical-day-to-day-activities');
+});
+
+test('tocIdFor gives the heading spelling variants the same id', () => {
+    // 203 files use "and", 19 use "&" (#121). A link built from one spelling
+    // must still resolve in a file that uses the other.
+    assert.equal(tocIdFor('Key Decisions and Accountabilities'),
+                 tocIdFor('Key Decisions & Accountabilities'));
+});
+
+test('activeTocIndex reports the last section at or above the scroll line', () => {
+    const tops = [0, 400, 900, 1500];
+    assert.equal(activeTocIndex(tops, 0), 0);
+    assert.equal(activeTocIndex(tops, 399), 0);
+    assert.equal(activeTocIndex(tops, 400), 1);
+    assert.equal(activeTocIndex(tops, 1200), 2);
+    assert.equal(activeTocIndex(tops, 99999), 3);
+});
+
+test('activeTocIndex stays on the first section when scrolled above it', () => {
+    // Negative scroll happens with rubber-banding; it must not return -1 and
+    // leave the nav with nothing highlighted.
+    assert.equal(activeTocIndex([120, 500], -50), 0);
+});
+
+test('activeTocIndex returns -1 only when there are no sections', () => {
+    assert.equal(activeTocIndex([], 0), -1);
+});
+
+test('activeTocIndex highlights the last section once scrolled to the bottom', () => {
+    // At max scroll the remaining sections are all on screen and none of
+    // their tops can reach the scroll line, so the plain rule sticks on
+    // whichever section last crossed it. Jumping to the final section would
+    // then highlight the wrong chip.
+    const tops = [0, 400, 900, 1500];
+    assert.equal(activeTocIndex(tops, 853), 1, 'mid-scroll is unchanged (900 has not passed 853)');
+    assert.equal(activeTocIndex(tops, 853, { atBottom: true }), 3);
+});
+
+test('activeTocIndex atBottom is ignored when there are no sections', () => {
+    assert.equal(activeTocIndex([], 500, { atBottom: true }), -1);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -551,6 +551,37 @@
         };
     }
 
+    // Anchor id for a role section heading (#111). Built on sectionKey so the
+    // catalog's heading spelling variants ("and" vs "&", see #121) produce the
+    // same id — a jump link must not depend on which variant a file used.
+    function tocIdFor(heading) {
+        const slug = String(heading == null ? '' : heading)
+            .toLowerCase()
+            .replace(/\band\b/g, '&')
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '');
+        return 'sec-' + slug;
+    }
+
+    // Scroll-spy: index of the last section whose top has passed the scroll
+    // line. Clamps to the first section rather than returning -1 when scrolled
+    // above it (rubber-banding gives a negative scrollTop), so the nav always
+    // has exactly one entry highlighted while sections exist.
+    //
+    // `atBottom` handles the end of the document: there the remaining sections
+    // are all on screen and none of their tops can reach the scroll line, so
+    // the plain rule sticks on whichever section last crossed it — jumping to
+    // the final section would highlight the wrong chip.
+    function activeTocIndex(tops, scrollTop, { atBottom = false } = {}) {
+        if (!tops || !tops.length) return -1;
+        if (atBottom) return tops.length - 1;
+        let idx = 0;
+        for (let i = 0; i < tops.length; i++) {
+            if (tops[i] <= scrollTop) idx = i;
+        }
+        return idx;
+    }
+
     return {
         STALE_MONTHS,
         REFERENCE_DOC_PATTERN,
@@ -574,5 +605,7 @@
         roleTitleKey,
         findRoleByTitle,
         panelStateFor,
+        tocIdFor,
+        activeTocIndex,
     };
 });


### PR DESCRIPTION
## Summary

Collapsing the sections (#112) gives an overview *at the top of the page*. This covers what remains: once a section is expanded and the reader scrolls into it, that overview is gone. A sticky nav now lists every section, marks the current one, and jumps to any of them — expanding the target first, since it may be collapsed.

Closes #111
Closes #132

## Design deviation from the issue

The issue sketched a **side rail**. I built a **horizontal sticky bar** instead: compare mode splits `.roles-grid` into two equal columns, so a rail would either break that layout or have to be suppressed exactly when two dense documents make navigation most useful. The bar works in both modes and degrades to a scrollable chip row on mobile.

## Two bugs the scroll-spy surfaced

**1. Jumping to a late section highlighted the wrong chip.** Not an animation artifact — at max scroll the remaining sections are all on screen and none of their tops can reach the scroll line, so the plain "last section past the line" rule stuck on an earlier chip. Measured: target at content-top 1465 with `maxScroll` 853, so it can never reach the top. `activeTocIndex` now takes an `atBottom` case, and an explicit click wins over the spy for 800ms while the smooth scroll settles.

**2. `.role-view` needed `min-width: 0`.** The nav's nowrap flex row was setting the grid track's minimum width, so on a 375px screen the column grew to **2283px** instead of the nav scrolling inside itself. `mainArea` scrolled to 2301px with content off-screen.

## Drive-by fix (#132, filed separately)

Verifying at 375px showed the Print/Export/Compare row is 283px wide and pushed **Compare off-screen** (right edge 463px vs a 375px viewport). Pre-existing, unrelated to the TOC — it only became reachable once #110 made mobile usable. The row now wraps below 768px. Filed as #132 and fixed here since it is one rule in the same media query.

## Test plan

- [x] TDD — 7 tests written first (5 watched fail as `not defined`, 2 more for the `atBottom` case). One caught an arithmetic error in my own assertion.
- [x] `npm test` — 127/127 (was 120) · `npm run validate` — 0 errors
- [x] 13 chips, sticky, exactly one active at all times
- [x] Jumping to **Career Development Path**, **Recommended Certifications**, **KPIs**, **Business Impact** each highlights its own chip and expands it if collapsed
- [x] Free scrolling hands control back to the spy: top → Role Overview, bottom → last section
- [x] 375px: `roleView` 333px, nav scrolls inside itself, `mainArea` 369px, **page does not scroll horizontally**, all three action buttons on screen
- [x] Compare mode: one nav only, second column keeps its 13 sections and 3 cross-reference links
- [x] Print: nav hidden, all 11 collapsed sections force-opened then restored
- [x] Reference docs correctly get no section nav
- [x] No console errors