### PR TITLE
feat: surface the reporting line and weight sections by scan value

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,6 +615,44 @@
 
         .md-body h1 { display: none; }
 
+        /* ── Reporting line in the header (#113) ────────────── */
+        .role-reporting { margin-top: 8px; }
+        .meta-reporting {
+            display: inline-flex;
+            align-items: baseline;
+            gap: 6px;
+            background: transparent;
+            border: 1px dashed var(--border-color);
+        }
+        .meta-reporting .meta-key {
+            color: var(--text-muted);
+            font-size: 0.92em;
+            letter-spacing: 0.2px;
+        }
+        .meta-note {
+            color: var(--text-muted);
+            cursor: help;
+            margin-left: 4px;
+            font-size: 0.9em;
+        }
+        .meta-note:hover { color: var(--accent-blue); }
+
+        /* ── Section emphasis (#113) ────────────────────────── */
+        /* The Owns vs. Advises On table is the role's core accountability
+           statement; it read at the same weight as a certification list. */
+        .md-section .owns-advises th:first-child { color: var(--accent-blue); }
+        .md-section .owns-advises td:first-child {
+            font-weight: 600;
+            color: var(--text-primary);
+            border-right: 2px solid var(--accent-blue);
+        }
+        .md-section .owns-advises td:last-child { color: var(--text-secondary); }
+
+        /* Trailing reference material is looked up deliberately rather than
+           read through, so it sits back from the substantive sections. */
+        .md-section.section-reference > .md-section-hd { color: var(--text-secondary); font-weight: 600; }
+        .md-section.section-reference { font-size: 0.95em; }
+
         /* ── Sticky section nav (#111) ──────────────────────── */
         .toc-nav {
             position: sticky;
@@ -1385,6 +1423,7 @@
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
         sectionStartsOpen, panelStateFor,
         tocIdFor, activeTocIndex,
+        parseRoleMeta, splitReportingValue,
         findRoleByTitle: resolveRoleTitle,
     } = ViewerLogic;
 
@@ -2457,6 +2496,13 @@
             details.className = 'md-section';
             if (sectionStartsOpen(heading)) details.open = true;
 
+            // Reference sections are looked up on demand rather than read
+            // through, so they carry less visual weight than the sections
+            // that state what the role owns and does (#113).
+            if (/^(Key Technologies|Recommended Certifications|Remote Work Considerations)/i.test(heading)) {
+                details.classList.add('section-reference');
+            }
+
             const summary = document.createElement('summary');
             summary.className = 'md-section-hd';
             summary.textContent = heading;
@@ -2468,6 +2514,14 @@
             while (el && el.tagName !== 'H2') { body.push(el); el = el.nextElementSibling; }
             h2.replaceWith(details);
             for (const node of body) details.appendChild(node);
+
+            // Tag the Owns / Advises On table so it can carry more weight
+            // than an ordinary two-column table (#113).
+            if (/^Key Decisions/i.test(heading)) {
+                for (const t of details.querySelectorAll('table')) {
+                    if (/\bOwns\b/i.test(t.rows[0]?.cells[0]?.textContent || '')) t.classList.add('owns-advises');
+                }
+            }
         }
     }
 
@@ -2588,7 +2642,7 @@
     }
 
     // ── Shared: build role header HTML ───────────────────
-    function buildHeader(title, level, domainLabel, lastReviewed, slot) {
+    function buildHeader(title, level, domainLabel, lastReviewed, slot, meta = null) {
         const isCompare = slot === 'B';
         const actions = isCompare
             ? `<button class="btn-action btn-danger" onclick="closeComparison()" aria-label="Close comparison">✕ Close</button>`
@@ -2597,6 +2651,31 @@
                <button class="btn-action" id="compareBtn" onclick="startCompare()" aria-label="Compare with another role">⚖️ Compare</button>`;
         const compareLabel = isCompare ? `<div class="compare-label">Comparing with</div>` : '';
         const reviewedTag  = lastReviewed ? `<span class="meta-tag">🗓️ Reviewed ${escapeHtml(lastReviewed)}</span>` : '';
+
+        // Reporting line (#113). The body is rendered from the first "## "
+        // heading onward, so the metadata table above it never appears — these
+        // two fields were absent from the viewer entirely despite being
+        // backfilled across all 222 files in #5. Each name that resolves to a
+        // catalog role becomes a link, reusing the .role-xref affordance.
+        const reportingChip = (icon, label, value) => {
+            if (!value) return '';
+            const { head, detail } = splitReportingValue(value);
+            const hit = findRoleByTitle(head);
+            const inner = hit
+                ? `<span class="role-xref" role="button" tabindex="0"
+                         data-file="${escapeHtml(hit.file)}" data-title="${escapeHtml(hit.title)}"
+                         data-level="${escapeHtml(hit.level)}" data-domain="${escapeHtml(hit.domainLabel)}"
+                         title="Open ${escapeHtml(hit.title)}">${escapeHtml(head)}</span>`
+                : escapeHtml(head);
+            // The qualifier stays reachable without dominating the header.
+            const note = detail ? `<span class="meta-note" title="${escapeHtml(detail)}">ⓘ</span>` : '';
+            return `<span class="meta-tag meta-reporting" title="${escapeHtml(value)}"><span class="meta-key">${icon} ${label}</span> ${inner}${note}</span>`;
+        };
+        const reporting = meta
+            ? reportingChip('↑', 'Reports to', meta.reportsTo) +
+              reportingChip('↓', 'Direct reports', meta.directReports)
+            : '';
+
         return `
             ${compareLabel}
             <div class="role-header-row">
@@ -2607,7 +2686,8 @@
                 <span class="meta-tag">📂 ${escapeHtml(domainLabel)}</span>
                 <span class="meta-tag badge ${badgeClass(level)}">${escapeHtml(level)}</span>
                 ${reviewedTag}
-            </div>`;
+            </div>
+            ${reporting ? `<div class="role-meta role-reporting">${reporting}</div>` : ''}`;
     }
 
     // ── Open a role (primary slot) ────────────────────────
@@ -2645,11 +2725,14 @@
             const res      = await fetch(`/api/role?file=${encodeURIComponent(file)}`);
             const markdown = await res.text();
 
-            const reviewMatch  = markdown.match(/\|\s*\*\*Last Reviewed\*\*\s*\|\s*(.+?)\s*\|/);
-            const lastReviewed = reviewMatch ? reviewMatch[1].trim() : null;
+            // parseRoleMeta also recovers Reports To / Direct Reports, which
+            // the body slice below discards with the rest of the metadata
+            // table — that is why they never reached the UI (#113).
+            const meta         = parseRoleMeta(markdown);
+            const lastReviewed = meta.lastReviewed;
 
             // Re-render header with reviewed date
-            document.getElementById('roleHeader').innerHTML = buildHeader(title, level, domainLabel, lastReviewed, 'A');
+            document.getElementById('roleHeader').innerHTML = buildHeader(title, level, domainLabel, lastReviewed, 'A', meta);
 
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;
@@ -2694,10 +2777,13 @@
             const res      = await fetch(`/api/role?file=${encodeURIComponent(file)}`);
             const markdown = await res.text();
 
-            const reviewMatch  = markdown.match(/\|\s*\*\*Last Reviewed\*\*\s*\|\s*(.+?)\s*\|/);
-            const lastReviewed = reviewMatch ? reviewMatch[1].trim() : null;
+            // parseRoleMeta also recovers Reports To / Direct Reports, which
+            // the body slice below discards with the rest of the metadata
+            // table — that is why they never reached the UI (#113).
+            const meta         = parseRoleMeta(markdown);
+            const lastReviewed = meta.lastReviewed;
 
-            document.getElementById('roleHeader2').innerHTML = buildHeader(title, level, domainLabel, lastReviewed, 'B');
+            document.getElementById('roleHeader2').innerHTML = buildHeader(title, level, domainLabel, lastReviewed, 'B', meta);
 
             const h2idx = markdown.indexOf('\n## ');
             const body  = h2idx > -1 ? markdown.slice(h2idx + 1) : markdown;

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -25,6 +25,8 @@ const {
     roleTitleKey,
     findRoleByTitle,
     panelStateFor,
+    parseRoleMeta,
+    splitReportingValue,
     tocIdFor,
     activeTocIndex,
 } = require('../viewer-logic');
@@ -794,4 +796,88 @@ test('activeTocIndex highlights the last section once scrolled to the bottom', (
 
 test('activeTocIndex atBottom is ignored when there are no sections', () => {
     assert.equal(activeTocIndex([], 500, { atBottom: true }), -1);
+});
+
+// ── parseRoleMeta (#113) ──────────────────────────────────
+// openRole slices the body at the first "## ", so the metadata table above
+// it never renders. Reports To / Direct Reports were therefore absent from
+// the viewer entirely — the whole #5 backfill was invisible in the UI.
+const META_MD = `# AWS Cloud Architect
+
+| Field | Value |
+|---|---|
+| **Domain** | Cloud Platforms |
+| **Chapter:** | Cloud, Platform & Infrastructure |
+| **Role Level** | Architect |
+| **Reports To** | Cloud Lead Architect |
+| **Direct Reports** | AWS Cloud Senior Engineers |
+| **Last Reviewed** | 2026-03 |
+
+---
+
+## Role Overview
+
+Body text.
+`;
+
+test('parseRoleMeta reads the reporting line out of the metadata table', () => {
+    const m = parseRoleMeta(META_MD);
+    assert.equal(m.reportsTo, 'Cloud Lead Architect');
+    assert.equal(m.directReports, 'AWS Cloud Senior Engineers');
+});
+
+test('parseRoleMeta reads the remaining metadata fields', () => {
+    const m = parseRoleMeta(META_MD);
+    assert.equal(m.domain, 'Cloud Platforms');
+    assert.equal(m.level, 'Architect');
+    assert.equal(m.lastReviewed, '2026-03');
+    assert.equal(m.chapter, 'Cloud, Platform & Infrastructure');
+});
+
+test('parseRoleMeta returns null for fields a file omits', () => {
+    const m = parseRoleMeta('# Role\n\n| Field | Value |\n|---|---|\n| **Domain** | X |\n\n## Role Overview\n');
+    assert.equal(m.domain, 'X');
+    assert.equal(m.reportsTo, null);
+    assert.equal(m.directReports, null);
+    assert.equal(m.lastReviewed, null);
+});
+
+test('parseRoleMeta does not read past the first section heading', () => {
+    // A "Reports To" mentioned in prose must not be mistaken for metadata.
+    const md = '# Role\n\n| Field | Value |\n|---|---|\n| **Domain** | X |\n\n## Role Overview\n\n| **Reports To** | Someone Else |\n';
+    assert.equal(parseRoleMeta(md).reportsTo, null);
+});
+
+test('parseRoleMeta treats "None" as a real Direct Reports value', () => {
+    // Individual-contributor roles say "None"; that is meaningful and should
+    // render, not be dropped as empty.
+    const md = META_MD.replace('AWS Cloud Senior Engineers', 'None');
+    assert.equal(parseRoleMeta(md).directReports, 'None');
+});
+
+// ── splitReportingValue (#113) ────────────────────────────
+// 34% of Reports To / Direct Reports values exceed 60 characters (max 241)
+// because most carry a parenthetical qualifier explaining the arrangement.
+// The chip shows the lead-in; the qualifier moves to a tooltip.
+test('splitReportingValue separates the lead-in from a parenthetical qualifier', () => {
+    const v = 'None (sets technical direction and mentors AWS Cloud Senior Engineers; formal line management sits with the Chapter Lead)';
+    assert.deepEqual(splitReportingValue(v), {
+        head: 'None',
+        detail: 'sets technical direction and mentors AWS Cloud Senior Engineers; formal line management sits with the Chapter Lead',
+    });
+});
+
+test('splitReportingValue leaves a short plain value untouched', () => {
+    assert.deepEqual(splitReportingValue('Cloud Lead Architect'),
+                     { head: 'Cloud Lead Architect', detail: '' });
+});
+
+test('splitReportingValue splits on a semicolon when there is no parenthetical', () => {
+    assert.deepEqual(splitReportingValue('Solution Architect; Enterprise Architecture Senior Engineer'),
+                     { head: 'Solution Architect', detail: 'Enterprise Architecture Senior Engineer' });
+});
+
+test('splitReportingValue handles empty and missing values', () => {
+    assert.deepEqual(splitReportingValue(''),   { head: '', detail: '' });
+    assert.deepEqual(splitReportingValue(null), { head: '', detail: '' });
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -582,6 +582,49 @@
         return idx;
     }
 
+    // Read the metadata table that sits between the H1 and the first "## "
+    // section. The viewer renders the body from that first heading onward, so
+    // anything here is otherwise invisible — which is why Reports To and
+    // Direct Reports never appeared in the UI at all despite being backfilled
+    // across the whole catalog in #5 (see #113).
+    //
+    // Deliberately stops at the first section heading: a "Reports To" written
+    // in prose further down is not metadata.
+    function parseRoleMeta(markdown) {
+        const text = String(markdown == null ? '' : markdown).replace(/\r\n/g, '\n');
+        const end  = text.indexOf('\n## ');
+        const head = end === -1 ? text : text.slice(0, end);
+        const field = label => {
+            const m = head.match(new RegExp('\\|\\s*\\*\\*' + label + ':?\\*\\*\\s*\\|\\s*([^|]*?)\\s*\\|'));
+            const v = m && m[1].trim();
+            return v ? v : null;
+        };
+        return {
+            domain:        field('Domain'),
+            chapter:       field('Chapter'),
+            level:         field('Role Level'),
+            reportsTo:     field('Reports To'),
+            directReports: field('Direct Reports'),
+            lastReviewed:  field('Last Reviewed'),
+        };
+    }
+
+    // Split a Reports To / Direct Reports value into the part worth showing
+    // and the qualifier behind it. 34% of these values run past 60 characters
+    // (longest is 241) because they explain the arrangement inline — "None
+    // (sets technical direction and mentors …; formal line management sits
+    // with the Chapter Lead)". Rendering that whole string as a chip is
+    // unreadable, so the lead-in shows and the rest becomes a tooltip (#113).
+    function splitReportingValue(value) {
+        const v = String(value == null ? '' : value).trim();
+        if (!v) return { head: '', detail: '' };
+        const paren = v.match(/^([^(]+?)\s*\((.+)\)\s*$/);
+        if (paren) return { head: paren[1].trim(), detail: paren[2].trim() };
+        const semi = v.indexOf(';');
+        if (semi > -1) return { head: v.slice(0, semi).trim(), detail: v.slice(semi + 1).trim() };
+        return { head: v, detail: '' };
+    }
+
     return {
         STALE_MONTHS,
         REFERENCE_DOC_PATTERN,
@@ -605,6 +648,8 @@
         roleTitleKey,
         findRoleByTitle,
         panelStateFor,
+        parseRoleMeta,
+        splitReportingValue,
         tocIdFor,
         activeTocIndex,
     };


### PR DESCRIPTION
## The issue's premise was wrong, in a useful way

#113 asked to "promote Reports To / Direct Reports into the header and drop the duplicated body rows." There is nothing to de-duplicate — **those fields were not in the viewer at all.**

`openRole` renders the body from the first `## ` heading onward, so the metadata table above it never rendered. Confirmed in the browser: body contains `Reports To` → **false**, `Direct Reports` → **false**. Domain, Role Level and Last Reviewed survived only because `openRole` re-derived them separately with its own regex.

So the #5 backfill that added a reporting line to all 222 role files was invisible to anyone using the web UI. This PR makes it additive rather than a move.

Closes #113

## What changed

**Reporting line in the header.** Both fields render as chips, and each name that resolves to a catalog role links to it, reusing the `.role-xref` affordance from #120. `Board of Directors` correctly stays plain text.

**Long values are readable.** 34% of these values exceed 60 characters (longest 241) because they explain the arrangement inline. `splitReportingValue` keeps the lead-in in the chip and moves the qualifier to a `ⓘ` tooltip:

> `None (sets technical direction and mentors AWS Cloud Senior Engineers; formal line management sits with the Chapter Lead)` — **121 chars → 23**

**Section emphasis follows scan value.** The Owns vs. Advises On table gets a rule and a stronger first column as the role's core accountability statement. Key Technologies, Remote Work Considerations and Recommended Certifications step back as reference material.

**`parseRoleMeta`** replaces the ad-hoc `Last Reviewed` regex in both the primary and comparison render paths.

## Test plan

- [x] TDD — 9 tests written first across two rounds, each watched fail as `not defined`
- [x] `npm test` — 136/136 (was 127) · `npm run validate` — 0 errors
- [x] Reporting chips render on AWS Cloud Architect, Security Engineer, and CEO; `Reports To` links navigate (AWS Cloud Architect → Cloud, Platform & Infrastructure Chapter Lead)
- [x] Reference vs. substantive headings render in measurably different colours; Owns/Advises cells carry the 2px rule
- [x] Comparison column gets both chips
- [x] 375px: no page or content horizontal scroll (`mainArea` 369px), **zero overflowing elements** outside their own scroll containers
- [x] No console errors