### PR TITLE
feat: spread the review schedule instead of one annual cliff

### DIFF
--- a/index.html
+++ b/index.html
@@ -1423,9 +1423,15 @@
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
         sectionStartsOpen, panelStateFor,
         tocIdFor, activeTocIndex,
-        parseRoleMeta, splitReportingValue,
+        parseRoleMeta, splitReportingValue, reviewSlotFor,
         findRoleByTitle: resolveRoleTitle,
     } = ViewerLogic;
+
+    // Reviews are spread over this many months past STALE_MONTHS, using each
+    // role's own slot, so the queue fills gradually instead of 206 roles all
+    // falling due in the same month (#124). Set to 0 to review everything on a
+    // flat threshold.
+    const REVIEW_STAGGER_MONTHS = 12;
 
     // ── State ───────────────────────────────────────────
     let allDomains  = {};
@@ -3052,7 +3058,7 @@
     // ── Stale-role tracking ───────────────────────────────
     // (monthsSinceReview / computeStaleRoles come from viewer-logic.js)
     function updateStaleButton(domains) {
-        const stale = computeStaleRoles(domains);
+        const stale = computeStaleRoles(domains, STALE_MONTHS, new Date(), { stagger: REVIEW_STAGGER_MONTHS });
         const btn   = document.getElementById('staleBtn');
         if (stale.length === 0) { btn.style.display = 'none'; return; }
         btn.style.display  = '';
@@ -3062,7 +3068,7 @@
 
 
     function renderStalePanel(domains) {
-        const stale = computeStaleRoles(domains);
+        const stale = computeStaleRoles(domains, STALE_MONTHS, new Date(), { stagger: REVIEW_STAGGER_MONTHS });
         const rows = stale.map(r => `
             <tr>
                 <td class="matrix-domain-cell">${escapeHtml(r.domainLabel)}</td>
@@ -3079,7 +3085,11 @@
                 <div>
                     <h2>⏰ Roles Overdue for Review</h2>
                     <p>${stale.length} of ${Object.values(domains).reduce((n,d) => n + d.roles.length, 0)} roles
-                       have no review date or were last reviewed ${STALE_MONTHS}+ months ago — click any role to open it.</p>
+                       have no review date, or have passed their review slot — click any role to open it.
+                       ${REVIEW_STAGGER_MONTHS > 0
+                         ? `Reviews are due ${STALE_MONTHS}–${STALE_MONTHS + REVIEW_STAGGER_MONTHS - 1} months after each role's
+                            last review, spread so the catalogue comes up steadily rather than all at once.`
+                         : `Reviews are due ${STALE_MONTHS}+ months after each role's last review.`}</p>
                 </div>
                 <button class="btn-action" onclick="exportStaleCsv()" aria-label="Download overdue role list as CSV">⬇️ Export CSV</button>
             </div>
@@ -3092,7 +3102,7 @@
     }
 
     function exportStaleCsv() {
-        const stale = computeStaleRoles(allDomains);
+        const stale = computeStaleRoles(allDomains, STALE_MONTHS, new Date(), { stagger: REVIEW_STAGGER_MONTHS });
         const rows  = [['Domain', 'Role Title', 'Level', 'Last Reviewed', 'Months Since Review']];
         for (const r of stale) rows.push([r.domainLabel, r.title, r.level, r.lastReviewed || '', r.monthsSince ?? '']);
         const csv = rows.map(r => r.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(',')).join('\r\n');

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -11,6 +11,7 @@ const {
     badgeClass,
     monthsSinceReview,
     computeStaleRoles,
+    reviewSlotFor,
     rolesPerLevel,
     rolesPerChapter,
     buildOrgTree,
@@ -880,4 +881,70 @@ test('splitReportingValue splits on a semicolon when there is no parenthetical',
 test('splitReportingValue handles empty and missing values', () => {
     assert.deepEqual(splitReportingValue(''),   { head: '', detail: '' });
     assert.deepEqual(splitReportingValue(null), { head: '', detail: '' });
+});
+
+// ── staggered review schedule (#124) ──────────────────────
+// 206 of 222 roles carry an identical 2026-03 stamp, so at a flat
+// 12-month threshold every one of them turns stale in the same month and
+// the panel goes from near-empty to 93% of the catalog. Git offers no
+// real review history to stagger from (the repo is younger than the
+// stamps), so the schedule is spread instead of the dates being invented.
+test('reviewSlotFor is deterministic for a given path', () => {
+    assert.equal(reviewSlotFor('Roles/security/security_engineer.md', 12),
+                 reviewSlotFor('Roles/security/security_engineer.md', 12));
+});
+
+test('reviewSlotFor stays inside the requested span', () => {
+    for (const f of ['a.md', 'Roles/x/y.md', 'Roles/really/long/path/name.md', '']) {
+        const s = reviewSlotFor(f, 12);
+        assert.ok(Number.isInteger(s) && s >= 0 && s < 12, `${f} produced ${s}`);
+    }
+});
+
+test('reviewSlotFor spreads the real catalog across the whole span', () => {
+    // The point of the exercise: no month may take a disproportionate share.
+    const fs = require('node:fs'), path = require('node:path');
+    const rolesDir = path.join(__dirname, '..', 'Roles');
+    const counts = new Array(12).fill(0);
+    let total = 0;
+    for (const d of fs.readdirSync(rolesDir, { withFileTypes: true })) {
+        if (!d.isDirectory()) continue;
+        for (const f of fs.readdirSync(path.join(rolesDir, d.name))) {
+            if (!f.endsWith('.md') || f === 'README.md' || /_standards\.md$/.test(f)) continue;
+            counts[reviewSlotFor(`Roles/${d.name}/${f}`, 12)]++;
+            total++;
+        }
+    }
+    assert.ok(counts.every(c => c > 0), `some months got no roles: ${counts}`);
+    const worst = Math.max(...counts);
+    assert.ok(worst < total / 12 * 2.5, `month overloaded: ${worst} of ${total} (${counts})`);
+});
+
+test('computeStaleRoles without stagger is unchanged', () => {
+    const now = new Date(2026, 6, 15);
+    const stale = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now);
+    assert.deepEqual(stale.map(r => r.title), ['Never Reviewed', 'Ancient Role', 'Boundary Role']);
+});
+
+test('computeStaleRoles with stagger defers roles whose slot has not come up', () => {
+    const now = new Date(2026, 6, 15);
+    const all      = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now);
+    const staggered = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now, { stagger: 12 });
+    assert.ok(staggered.length < all.length, 'staggering must hold some roles back');
+});
+
+test('computeStaleRoles with stagger still flags never-reviewed roles immediately', () => {
+    // A missing date is a real gap, not a scheduling slot — it must not be
+    // deferred by up to a year.
+    const now = new Date(2026, 6, 15);
+    const staggered = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now, { stagger: 12 });
+    assert.ok(staggered.some(r => r.title === 'Never Reviewed'));
+});
+
+test('computeStaleRoles with stagger still flags a very overdue role', () => {
+    // 2020-01 is ~78 months old; no slot offset within a 12-month span can
+    // excuse that.
+    const now = new Date(2026, 6, 15);
+    const staggered = computeStaleRoles(fixtureDomains(), STALE_MONTHS, now, { stagger: 12 });
+    assert.ok(staggered.some(r => r.title === 'Ancient Role'));
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -105,14 +105,46 @@
         return (now.getFullYear() - reviewed.getFullYear()) * 12 + (now.getMonth() - reviewed.getMonth());
     }
 
+    // Review slot for a role, 0..span-1, derived from its path (#124).
+    //
+    // 206 of 222 roles carry an identical 2026-03 stamp, so at a flat
+    // threshold every one turns stale in the same month and the panel jumps
+    // from near-empty to 93% of the catalog — at which point it stops being a
+    // work queue. Git cannot supply real review history to stagger from: the
+    // repository is younger than the stamps it holds, so every file traces
+    // back to one seeding commit. Rather than invent per-role review dates
+    // that never happened, the *schedule* is spread and the recorded dates
+    // stay truthful.
+    //
+    // FNV-1a: small, stable across runs and platforms, and good enough to
+    // spread paths evenly — a test asserts the real catalog lands in every
+    // month with no month taking a disproportionate share.
+    function reviewSlotFor(file, span = 12) {
+        if (span <= 1) return 0;
+        let h = 0x811c9dc5;
+        const s = String(file == null ? '' : file);
+        for (let i = 0; i < s.length; i++) {
+            h ^= s.charCodeAt(i);
+            h = Math.imul(h, 0x01000193) >>> 0;
+        }
+        return h % span;
+    }
+
     // Roles with no review date or one at least staleMonths old, sorted
     // most-overdue first (never-reviewed roles sort to the top).
-    function computeStaleRoles(domains, staleMonths = STALE_MONTHS, now = new Date()) {
+    //
+    // `stagger` spreads the due date across that many months using the role's
+    // slot, so reviews arrive as a steady queue instead of one cliff. A
+    // missing date is never deferred — that is a real gap, not a slot.
+    function computeStaleRoles(domains, staleMonths = STALE_MONTHS, now = new Date(), { stagger = 0 } = {}) {
         const stale = [];
         for (const domain of Object.values(domains)) {
             for (const role of domain.roles) {
                 const monthsSince = monthsSinceReview(role.lastReviewed, now);
-                if (monthsSince === null || monthsSince >= staleMonths) {
+                const threshold = monthsSince === null || stagger <= 0
+                    ? staleMonths
+                    : staleMonths + reviewSlotFor(role.file, stagger);
+                if (monthsSince === null || monthsSince >= threshold) {
                     stale.push({ ...role, domainLabel: domain.label, monthsSince });
                 }
             }
@@ -634,6 +666,7 @@
         badgeClass,
         monthsSinceReview,
         computeStaleRoles,
+        reviewSlotFor,
         rolesPerLevel,
         rolesPerChapter,
         buildOrgTree,


### PR DESCRIPTION
## The chosen fix turned out not to be available

#124 proposed restamping each role with a real review date derived from git history. **Git has no such history to offer.**

```
first commit   2026-07-06   "Initial commit: IT Roles Library"
today          2026-08-04
```

The repository is **younger than the stamps it holds** — 206 roles say `2026-03`, four months before the repo existed. Every role file traces back to that one seeding commit, so a per-file "last touched" date is either the seed or a bulk backfill batch. Restamping from git would move the cliff from 2027-03 to 2027-07 and assert reviews that never happened.

So the *schedule* is spread and the recorded dates stay truthful.

Closes #124

## How it works

Each role gets a stable slot from its path (FNV-1a) and falls due `STALE_MONTHS + slot` months after its stamp. A missing date is **never** deferred — that is a real gap, not a scheduling slot.

Simulated against the actual catalogue:

| Month | flat threshold | staggered |
|---|---|---|
| 2027-03 | **0 → 206** | 13 |
| 2027-04 | 206 | 22 |
| 2027-06 | 206 | 59 |
| 2027-09 | 222 | 112 |
| 2027-12 | 222 | 173 |
| 2028-02 | 222 | 218 |

Roughly **9–29 roles per month across a year** instead of 206 in one. The panel text now describes that window rather than claiming a flat threshold.

## Test plan

- [x] TDD — 8 tests written first, watched fail as `reviewSlotFor is not defined`
- [x] One test asserts the **real catalogue** lands in every one of the 12 months with no month taking >2.5× its share — the distribution claim is verified against real data, not a fixture
- [x] Staggering is opt-in (`{ stagger }`), so the existing flat-threshold tests still cover the default and prove no silent behaviour change
- [x] Never-reviewed and very-overdue roles still surface immediately under staggering
- [x] `npm test` — 143/143 (was 136) · `npm run validate` — 0 errors
- [x] Verified in-browser against the loaded catalogue: today 0 stale either way; March 2027 → flat **206**, staggered **13**
- [x] No console errors

## Note

The recorded dates remain untouched and still say `2026-03` for 206 roles. That is accurate about what the field claims (nobody has reviewed them since) and is now merely unhelpful rather than actively misleading. Genuinely reviewing those roles is separate work.