### PR TITLE
docs: normalise section headings to the canonical spellings

### DIFF
--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -43,7 +43,7 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 - Maintain and update optimisation runbooks, savings tracking logs, and reservation coverage dashboards
 - Evaluate FinOps tooling and contribute to tool configuration, alert tuning, and reporting improvements
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 | Day-to-day cost anomaly triage, investigation, and resolution within defined thresholds | Architectural changes required to address structural cost inefficiencies |
 | Tagging enforcement actions and non-compliance remediation workflows | Tagging policy design, governance framework, and enforcement tooling strategy |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Practical experience with cloud cost management and billing platforms across one or more major cloud providers
 - Working knowledge of cloud compute, storage, networking, and database service pricing models
@@ -72,7 +72,7 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 - **Working Knowledge required:** Cloud provider CLIs (AWS CLI, Azure CLI, gcloud) for bulk resource auditing and operational remediation tasks, GCP Billing Console and GCP Recommender for GCP-specific optimisation actions
 - **Awareness level expected:** Infracost for shift-left cost estimation integrated into IaC pipelines, Harness Cloud Cost Management (CCM) and Densify for AI-driven rightsizing and workload optimisation
 
-## Qualifications
+### Qualifications
 
 - Bachelor's degree in Computer Science, Information Technology, Engineering, or a related field; equivalent practical experience considered
 - 2+ years of experience in cloud engineering, DevOps, or infrastructure roles with exposure to cloud cost management

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -43,7 +43,7 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 - Support annual cloud budgeting cycles with historical analysis, trend modelling, and scenario planning inputs
 - Continuously improve reporting automation, data pipelines, and dashboard quality to reduce manual effort and increase analytical depth
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 | Forecast model design, assumptions documentation, and variance explanation | Budget approval, financial planning targets, and cloud spend governance thresholds |
 | Unit economics model construction and maintenance for assigned products or domains | Product investment decisions, architectural choices with cost implications, and commercial cloud negotiations |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Strong analytical and financial modelling skills, including forecasting, variance analysis, and TCO construction
 - Proficiency in data visualisation tools such as Power BI or Tableau for building stakeholder-ready dashboards and reports
@@ -72,7 +72,7 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 - **Working Knowledge required:** Anodot for cloud cost anomaly detection and spend forecasting, FinOps Foundation Framework cost allocation methodologies and chargeback/showback design patterns
 - **Awareness level expected:** Cloud provider billing APIs (AWS Billing API, Azure Cost Management API, GCP Billing API) for automated data extraction pipelines, FOCUS (FinOps Open Cost and Usage Specification) standard for multi-cloud billing normalisation
 
-## Qualifications
+### Qualifications
 
 - Bachelor's degree in Finance, Business, Economics, Data Analytics, Computer Science, or a related field; equivalent practical experience considered
 - 2+ years of experience in a business analyst, financial analyst, or data analyst role, ideally with cloud cost or IT financial management exposure

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -46,7 +46,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 - Drive sustainability and carbon footprint optimization alongside cloud cost initiatives
 - Drive cloud cost optimization initiatives across business units
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Cost allocation model, chargeback/showback design, tagging taxonomy, and cost optimisation strategy | Business unit spending decisions and financial planning priorities |
 | FinOps practice maturity roadmap and AI/LLM cost governance standards | Reserved capacity and commitment discount commercial negotiation decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Deep understanding of cloud service provider pricing models and billing systems
 - Expert knowledge of cloud architecture patterns and cost optimization techniques
@@ -74,7 +74,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 - **Working Knowledge required:** Carbon footprint and sustainability reporting tools (Cloud Carbon Footprint, Azure Carbon Optimization, AWS Customer Carbon Footprint Tool, GCP Carbon Footprint), Enterprise architecture tooling (LeanIX, Sparx EA) for documenting cloud cost governance architecture
 - **Awareness level expected:** FinOps automation and workflow orchestration platforms (Spot Ocean, CAST AI auto-scaling) for emerging optimisation patterns, Technology Business Management (TBM) frameworks and unit economics benchmarking standards
 
-## Qualifications
+### Qualifications
 
 - Bachelor's degree in Computer Science, Information Technology, Finance, or related field
 - 8+ years of IT experience with at least 3 years in cloud cost management
@@ -95,7 +95,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Executive leadership | Advises on cloud economics and optimization strategy | Provides To |
 | Cloud engineering teams | Guides teams on cost-efficient architectures | Provides To |
 
-## Key Technologies & Platforms
+## Key Technologies
 
 - Multi-cloud cost management platforms (CloudHealth, Apptio Cloudability, Spot by NetApp)
 - Cloud-native cost tools (AWS Cost Explorer, Azure Cost Management, GCP Billing & Recommender)

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -45,7 +45,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 - Support cloud resource rightsizing and optimization efforts
 - Maintain cloud cost dashboards and visualizations
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Cost allocation report generation, dashboard maintenance, and cost optimisation script execution | Architecture decisions with cloud cost impact |
 | Reserved capacity tracking, cost forecast data maintenance, and billing anomaly investigation | Financial planning, budgeting, and commercial cloud commitment decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Solid understanding of cloud service provider billing systems
 - Experience with cloud cost management tools
@@ -74,7 +74,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 - **Working Knowledge required:** Infrastructure as Code (Terraform, Bicep, CloudFormation) for understanding resource cost implications of IaC changes, Reserved instance and savings plan tracking tools for commitment coverage monitoring
 - **Awareness level expected:** FinOps Foundation Framework and maturity model for practice development context, AI/LLM cost attribution patterns and token-level cost management for emerging cloud consumption
 
-## Qualifications
+### Qualifications
 
 - Bachelor's degree in Computer Science, Information Technology, or related field
 - 3+ years of experience in cloud engineering or IT operations

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -43,7 +43,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 - Drive adoption of FinOps practices and tools
 - Communicate cloud financial insights to leadership and stakeholders
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 | Stakeholder cloud cost reporting, financial accountability governance, and chargeback/showback model | Commercial cloud provider negotiations and budget allocation decisions |
 | FinOps practice adoption programme and team capability development priorities | Enterprise financial planning, cloud strategy, and reserved capacity commercial decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Strong understanding of product management and agile methodologies
 - Knowledge of cloud service provider billing models and pricing structures
@@ -71,7 +71,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 - **Working Knowledge required:** FinOps tooling platforms (CloudHealth, Apptio Cloudability) for service catalogue definition and tool governance decisions, ITIL service management framework for aligning FinOps processes with IT service delivery and SLA management
 - **Awareness level expected:** FinOps automation and reserved capacity management platforms for technical roadmap and investment oversight, AI/LLM cost governance patterns and emerging cloud consumption models (spot GPU, token pricing, inference reservations)
 
-## Qualifications
+### Qualifications
 
 - Bachelor's degree in Business, Finance, Computer Science, or related field
 - 5+ years of experience in product management, preferably in IT or cloud services

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -43,7 +43,7 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 - Provide technical leadership for cloud cost anomaly detection
 - Develop integrations between FinOps tools and existing systems
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 | FinOps toolchain integrations, tagging enforcement automation, and cost anomaly detection solution design | Product roadmap priorities and FinOps tool procurement decisions |
 | Reserved and committed capacity management methodology and optimisation execution | Financial planning, budget governance, and cloud commitment commercial decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Advanced knowledge of cloud service provider pricing models and optimization techniques
 - Expert-level experience with cloud cost management tools and platforms
@@ -72,7 +72,7 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 - **Working Knowledge required:** Cloud architecture principles across AWS, Azure, and GCP for evaluating the cost impact of design decisions, Machine learning concepts and tooling for cloud cost forecasting and anomaly prediction models
 - **Awareness level expected:** AI/LLM cost governance patterns (token attribution, GPU reservation management, prompt caching cost optimization), FinOps Foundation Framework maturity model and emerging FinOps open standards (FOCUS specification)
 
-## Qualifications
+### Qualifications
 
 - Bachelor's degree in Computer Science, Information Technology, or related field
 - 5+ years of experience in cloud engineering with at least 2 years focusing on FinOps

--- a/Roles/ai_governance/ai_governance_architect.md
+++ b/Roles/ai_governance/ai_governance_architect.md
@@ -45,7 +45,7 @@ The AI Governance Architect designs and governs the organisation's frameworks, p
 - Collaborate with the security team on AI-specific security threats: prompt injection, model inversion, adversarial attacks, and supply chain risks.
 - Report to board-level governance committees on AI risk posture and regulatory readiness.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -57,7 +57,7 @@ The AI Governance Architect designs and governs the organisation's frameworks, p
 | AI supplier assessment framework | HR and workforce AI policy (with HR/Legal) |
 | AI incident classification and response governance | AI system architectural design (with AI Platform Architect) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/ai_governance/ai_governance_engineer.md
+++ b/Roles/ai_governance/ai_governance_engineer.md
@@ -43,7 +43,7 @@ The AI Governance Engineer is an entry-level practitioner role responsible for i
 - Maintain the organisation's AI system inventory, tracking new AI system onboarding and periodic re-assessment schedules.
 - Attend and contribute to AI governance team meetings, learning from senior practitioners and contributing operational observations.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/ai_governance/ai_governance_product_owner.md
+++ b/Roles/ai_governance/ai_governance_product_owner.md
@@ -44,7 +44,7 @@ The AI Governance Product Owner owns the AI governance product backlog, managing
 - Coordinate AI governance reporting to risk committees and board-level governance bodies, working with the Architect on content.
 - Work with TAL (Technical Account Lead) and PAL (Platform Account Lead) on vendor governance tooling roadmaps and support agreements.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -44,7 +44,7 @@ The AI Governance Senior Engineer implements, operates, and continuously improve
 - Implement and maintain EU AI Act compliance controls: risk classification documentation, technical conformity assessment support, and post-market monitoring for high-risk AI systems
 - Contribute to improving AI governance processes, assessment templates, and technical controls
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/ai_governance/ai_platform_architect.md
+++ b/Roles/ai_governance/ai_platform_architect.md
@@ -44,7 +44,7 @@ The AI Platform Architect designs and governs the organisation's AI/ML platform 
 - Evaluate and select ML platform tooling: open-source (MLflow, Kubeflow, Ray, Feast) vs. managed cloud services (Azure AI Foundry, AWS SageMaker, Vertex AI).
 - Provide technical leadership for ML platform implementation teams and guide ML engineers on platform adoption.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -45,7 +45,7 @@ The AI Platform Engineer builds and operates the organisation's AI/ML platform i
 - Manage platform costs by implementing resource tagging, auto-scaling, and compute auto-suspend policies.
 - Document ML platform components, runbooks, and onboarding guides for data science teams.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/ai_governance/responsible_ai_engineer.md
+++ b/Roles/ai_governance/responsible_ai_engineer.md
@@ -45,7 +45,7 @@ The Responsible AI Engineer implements the technical tooling, testing processes,
 - Support AI supplier due diligence by assessing vendor model documentation, API safety controls, and data handling practices.
 - Document model limitations, known failure modes, and edge cases in standardised formats for governance records.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -57,7 +57,7 @@ The Responsible AI Engineer implements the technical tooling, testing processes,
 | Governance checks integrated into MLOps pipelines | MLOps pipeline architecture (MLOps Engineer) |
 | AI red teaming test execution and findings documentation | AI system approval / rejection decisions (Governance Architect + Risk) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -149,7 +149,7 @@ The Responsible AI Engineer implements the technical tooling, testing processes,
 - AI Governance Architect (after gaining framework and policy experience)
 - AI Platform Architect (MLOps and governance specialism)
 
-## Recommended Certifications and Learning Paths
+## Recommended Certifications & Learning Paths
 
 **Core Certifications:**
 

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -43,7 +43,7 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 - Provide technical leadership for API platform initiatives
 - Design API monitoring and observability architectures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -43,7 +43,7 @@ The API Platform Engineer implements and maintains API management solutions acro
 - Maintain API lifecycle management processes
 - Assist with API analytics and reporting
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -41,7 +41,7 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 - Manage API lifecycle, versioning, and deprecation strategies
 - Track and report on API adoption and value delivery metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -41,7 +41,7 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 - Plan and execute API platform upgrades and migrations
 - Provide technical mentorship to API Platform Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/api_strategy_architect.md
+++ b/Roles/app_platforms/api_strategy_architect.md
@@ -43,7 +43,7 @@ The API Strategy Architect defines and governs the organisation's end-to-end API
 - Govern the API contract testing strategy and integration with CI/CD pipelines — ensuring consumer-driven contract testing (Pact) is embedded in API delivery workflows.
 - Mentor senior engineers and platform architects on API strategy, governance, and API-as-a-product thinking.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -41,7 +41,7 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 - Evaluate new .NET technologies and frameworks
 - Provide technical leadership for .NET initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -41,7 +41,7 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 - Create and update technical documentation
 - Support application deployment and operations
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -41,7 +41,7 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 - Manage versioning and deprecation strategies for .NET components
 - Track and report on platform adoption and value delivery
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -41,7 +41,7 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 - Plan and execute .NET platform upgrades and migrations
 - Provide technical mentorship to .NET Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -41,7 +41,7 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 - Evaluate new Java technologies and frameworks
 - Provide technical leadership for Java platform initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -41,7 +41,7 @@ The Java Engineer implements and maintains Java-based applications and platform 
 - Create and update technical documentation
 - Support application deployment and operations
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -41,7 +41,7 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 - Manage versioning and deprecation strategies for Java components
 - Track and report on platform adoption and value delivery
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -41,7 +41,7 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 - Plan and execute Java platform upgrades and migrations
 - Provide technical mentorship to Java Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/c_suite/chief_executive_officer.md
+++ b/Roles/c_suite/chief_executive_officer.md
@@ -47,7 +47,7 @@ In some governance models — particularly in heavily regulated industries or wh
 - Set the cultural and ethical tone for the organisation, sponsoring inclusion, performance, and values-aligned behaviours at all levels
 - Drive digital transformation ambition at the enterprise level, ensuring technology investment is positioned as a source of competitive advantage and customer value
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -61,7 +61,7 @@ In some governance models — particularly in heavily regulated industries or wh
 | M&A strategy: target approval, investment rationale, and integration mandate | M&A execution and functional integration workstreams (owned by relevant function heads and integration leads) |
 | External representation with regulators, government, and key strategic partners | Technology, security, and operational detail in regulatory engagements (CTO / CIO / CISO / Legal-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -95,7 +95,7 @@ In some governance models — particularly in heavily regulated industries or wh
 | Cyber risk understanding (board-appropriate) | Awareness |
 | AI and emerging technology trends (strategic context) | Awareness |
 
-## Qualifications
+### Qualifications
 
 **Education:**
 

--- a/Roles/c_suite/chief_financial_officer.md
+++ b/Roles/c_suite/chief_financial_officer.md
@@ -47,7 +47,7 @@ The CFO's remit intersects closely with technology leadership: enterprise financ
 - Report to the CEO and Board (Audit Committee, Risk Committee) on financial performance, financial risk, capital adequacy, and compliance — providing transparent, decision-ready financial insight at all times
 - Build and develop the finance leadership team — including FP&A, Group Reporting, Treasury, Tax, and Internal Audit functions — maintaining a culture of financial integrity, commercial rigor, and continuous improvement
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -61,7 +61,7 @@ The CFO's remit intersects closely with technology leadership: enterprise financ
 | Tax strategy and regulatory financial compliance | Enterprise risk framework beyond financial risk dimensions (CRO-owned, where role exists) |
 | Finance leadership team structure, hiring, and development | Broader technology talent strategy and engineering organisation design (CTO-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -95,7 +95,7 @@ The CFO's remit intersects closely with technology leadership: enterprise financ
 | FinOps and cloud cost governance | Awareness |
 | Investor relations and financial communications | Proficient |
 
-## Qualifications
+### Qualifications
 
 **Education:**
 

--- a/Roles/c_suite/chief_information_officer.md
+++ b/Roles/c_suite/chief_information_officer.md
@@ -47,7 +47,7 @@ In some governance models the CISO reports to the CIO, particularly where securi
 - Build and develop the IT leadership team — including IT operations leads, enterprise application managers, and service management professionals — creating a culture of operational excellence and continuous improvement
 - Collaborate with the CTO (where both roles exist) on shared infrastructure strategy, cloud governance, and enterprise architecture alignment to ensure technology product and IT operations work cohesively
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -61,7 +61,7 @@ In some governance models the CISO reports to the CIO, particularly where securi
 | IT governance framework (ITIL, COBIT) and regulatory IT compliance posture | Enterprise risk appetite and board-level risk framework (CEO and CRO-owned) |
 | IT leadership team structure, hiring, and development | Broader technology talent strategy and engineering culture (CTO-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -94,7 +94,7 @@ In some governance models the CISO reports to the CIO, particularly where securi
 | Regulatory IT compliance (GDPR, DORA, sector-specific) | Proficient |
 | IT project portfolio management | Proficient |
 
-## Qualifications
+### Qualifications
 
 **Education:**
 

--- a/Roles/c_suite/chief_technology_officer.md
+++ b/Roles/c_suite/chief_technology_officer.md
@@ -47,7 +47,7 @@ In some governance models the CISO reports to the CTO, particularly where securi
 - Report to the CEO on technology product performance, engineering health, innovation pipeline, and technology risk at an executive level
 - Build and develop the senior engineering leadership team — including Product Area Leads, Technical Area Lead, and principal engineers — creating succession depth and a high-performance engineering culture
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -61,7 +61,7 @@ In some governance models the CISO reports to the CTO, particularly where securi
 | Senior engineering leadership hiring, structure, and succession planning | Broader executive appointments and HR policy (CEO and CPO-owned) |
 | External representation as technology spokesperson — investors, analysts, media, and strategic events | Corporate communications strategy and brand messaging (CMO-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -94,7 +94,7 @@ In some governance models the CISO reports to the CTO, particularly where securi
 | Budget management and financial governance | Proficient |
 | Security architecture principles (strategic) | Awareness |
 
-## Qualifications
+### Qualifications
 
 **Education:**
 

--- a/Roles/client_platform/client_platform_architect.md
+++ b/Roles/client_platform/client_platform_architect.md
@@ -63,7 +63,7 @@ This role operates at the intersection of engineering rigour and business strate
 | Client platform tooling selection and proof-of-concept outcomes (e.g., Jamf Pro, Fleet.dm) | Enterprise-wide tooling consolidation decisions (architecture review board) |
 | Domain boundary definitions between Client Platform, Endpoint Management, and Modern Workplace | Service desk support model and staffing (owned by Service Desk Lead) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -94,7 +94,7 @@ This role operates at the intersection of engineering rigour and business strate
 - **Working Knowledge required:** Fleet.dm cross-platform endpoint telemetry, Homebrew cask packaging, .deb/.rpm Linux packaging, Lenovo System Update and Lenovo Thin Installer for BIOS/firmware and driver deployment, MDT/WDS (legacy context for deprecation planning), Microsoft Intune and SCCM co-management integration patterns
 - **Awareness level expected:** Declarative Device Management (DDM) for macOS, Linux desktop management evolution (systemd-based provisioning), hardware attestation and Pluton/secure boot developments, emerging zero-touch models for Linux
 
-## Qualifications
+### Qualifications
 
 **Education:** Bachelor's degree in Computer Science, Information Technology, or a related field; or equivalent depth of professional experience.
 

--- a/Roles/client_platform/client_platform_engineer.md
+++ b/Roles/client_platform/client_platform_engineer.md
@@ -58,7 +58,7 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 | First-line resolution of escalated client platform tickets within the engineering tier | Patch ring strategy and scheduling (Senior Engineer/Architect-owned) |
 | Accuracy of estate telemetry data hygiene for assigned platforms | Tooling selection and platform strategy |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -88,7 +88,7 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 - **Working Knowledge required:** MSIX packaging basics, macOS .pkg creation, Jamf software update policies, WUfB patch compliance report interpretation, Windows event log and MDM log analysis for troubleshooting
 - **Awareness level expected:** Ansible basics for Linux configuration management, Homebrew cask authoring structure, MSIX Packaging Tool advanced features, CIS Benchmark client hardening concepts, Lenovo System Update and Thin Installer for BIOS/firmware management, Apple Silicon M-series application compatibility (Rosetta 2, Universal Binary)
 
-## Qualifications
+### Qualifications
 
 **Education:** Diploma or Bachelor's degree in IT, Computing, or a related field; or demonstrated equivalent practical experience in a desktop or endpoint support environment.
 

--- a/Roles/client_platform/client_platform_product_owner.md
+++ b/Roles/client_platform/client_platform_product_owner.md
@@ -67,7 +67,7 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 | Trade-off decisions between feature work, technical debt, and operational stability within the backlog | Budget envelope and headcount (Chapter Lead-owned) |
 | Rollout sequencing and communication plans for user-facing platform changes | UEM policy detail and endpoint security tooling (Endpoint Management/Security-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -95,7 +95,7 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 - **Working Knowledge required:** Windows Update for Business compliance concepts, Jamf Pro reporting basics, Microsoft Intune device compliance overview, agile ceremonies and delivery metrics (velocity, cycle time, lead time)
 - **Awareness level expected:** OS image build concepts (WIM, DISM, task sequences), zero-touch provisioning workflows (Autopilot, ABM), application packaging formats (MSIX, .pkg, .deb), CIS benchmark hardening concepts
 
-## Qualifications
+### Qualifications
 
 **Education:** Bachelor's degree in Business, Information Technology, or a related field; or equivalent professional experience in a product ownership or IT programme management role.
 

--- a/Roles/client_platform/client_platform_senior_engineer.md
+++ b/Roles/client_platform/client_platform_senior_engineer.md
@@ -60,7 +60,7 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 | Technical quality of engineering deliverables and peer review outcomes | Hardware specification and OEM selection (Architect/Procurement-owned) |
 | Escalated engineering investigations and root-cause analysis for client platform issues | Service desk knowledge base structure and support processes |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -89,7 +89,7 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 - **Working Knowledge required:** Jamf software update management, apt/dnf patch pipeline management, Python scripting for cross-platform automation, CIS Benchmark hardening implementation, Lenovo driver pack management and Lenovo System Update / Thin Installer workflows, hardware driver compatibility testing
 - **Awareness level expected:** Fleet.dm cross-platform telemetry, Declarative Device Management (DDM) for macOS, MDT/WDS legacy context, Microsoft Intune Autopatch advanced ring customisation
 
-## Qualifications
+### Qualifications
 
 **Education:** Bachelor's degree in IT, Computer Science, or related field; or equivalent industry experience.
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -42,7 +42,7 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 - Architect generative AI and ML workload deployments using Amazon Bedrock and SageMaker
 - Provide technical leadership for AWS migrations and modernization initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -41,7 +41,7 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 - Execute infrastructure as code deployments
 - Document AWS configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -41,7 +41,7 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 - Oversee AWS account structure and governance
 - Track and optimize cloud spending through FinOps practices
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -41,7 +41,7 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 - Optimize AWS resources for cost and performance
 - Provide technical mentorship to AWS Cloud Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -43,7 +43,7 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 - Design cloud architectures that comply with data residency and sovereignty requirements, leveraging Azure sovereign cloud offerings for regulated industries
 - Provide technical leadership for Azure migrations and modernization initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -41,7 +41,7 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 - Execute infrastructure as code deployments
 - Document Azure configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -41,7 +41,7 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 - Manage cloud resource allocation and subscription governance
 - Track cloud spending and optimize cost management practices
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -41,7 +41,7 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 - Optimize Azure resources for cost and performance
 - Provide technical mentorship to Azure Cloud Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -42,7 +42,7 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 - Translate Principal Cloud Architect strategy into actionable platform-specific guidance and roadmaps
 - Contribute to the multi-cloud strategy by providing deep implementation insight to inform higher-level direction
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -43,7 +43,7 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 - Act as final escalation point for architectural decisions that cannot be resolved at platform or lead level
 - Contribute to and influence industry communities, cloud provider advisory programs, and internal innovation initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -42,7 +42,7 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 - Evaluate new GCP services and technologies
 - Provide technical leadership for GCP initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -41,7 +41,7 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 - Execute infrastructure as code deployments
 - Document GCP configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -41,7 +41,7 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 - Manage GCP cost optimization and governance
 - Track and report on cloud performance, utilization, and cost metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -41,7 +41,7 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 - Plan and execute cloud migrations to GCP
 - Provide technical mentorship to GCP Cloud Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -44,7 +44,7 @@ The Data Engineer designs, builds, and maintains the data pipelines, transformat
 - Write clear data documentation, data contracts, and field-level lineage descriptions.
 - Participate in data platform design reviews and contribute to standards development.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Data Engineer designs, builds, and maintains the data pipelines, transformat
 | Data quality test coverage for owned pipelines | DataOps CI/CD process requirements |
 | Data documentation in the catalogue | Data governance classification decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -43,7 +43,7 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 - Evaluate new data platform capabilities and define adoption roadmap in collaboration with the Data Platform Architect.
 - Report on data platform KPIs and delivery metrics to CDO and IT leadership.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 | Data product SLA and quality threshold definition | ML and AI platform strategy (with MLOps/AI Platform Architect) |
 | Licensing strategy and commercial planning | Budget allocation (with Finance/CDO) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -45,7 +45,7 @@ The Data Mesh Architect designs and governs the organisation's data mesh archite
 - Align data mesh architecture with enterprise and cloud architecture standards in collaboration with the Enterprise Architect and Cloud Architect.
 - Define AI data product standards in coordination with the AI Governance Architect — ensuring ML training datasets, feature datasets, and inference outputs meet traceability and quality requirements.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -45,7 +45,7 @@ The Data Platform Architect designs and governs the organisation's enterprise da
 - Create reference architectures, patterns libraries, and data platform standards documentation.
 - Mentor data engineers and senior data engineers on platform design principles.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -57,7 +57,7 @@ The Data Platform Architect designs and governs the organisation's enterprise da
 | Data platform FinOps standards | Budget and procurement (with Finance) |
 | Ingestion and streaming architecture standards | Application integration patterns |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -45,7 +45,7 @@ The Data Platform Engineer builds, maintains, and optimises the shared data plat
 - Write and maintain technical documentation for platform components, deployment guides, and runbooks.
 - Participate in data platform architecture reviews and provide implementation feasibility feedback to the Data Platform Architect.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_engineering/data_senior_engineer.md
+++ b/Roles/data_engineering/data_senior_engineer.md
@@ -44,7 +44,7 @@ The Data Senior Engineer leads complex data engineering initiatives, drives data
 - Collaborate with DataOps engineers to improve CI/CD maturity and pipeline reliability.
 - Contribute to data governance by designing lineage tracking, business glossary, and data product ownership models.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Data Senior Engineer leads complex data engineering initiatives, drives data
 | Code review standards and technical quality gates for data team | Data governance policy (with CDO/Governance team) |
 | Performance and cost optimisation of owned data platform components | Tooling and platform procurement decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -45,7 +45,7 @@ The DataOps Specialist applies DevOps and agile engineering principles to data p
 - Coordinate with ML platform teams on orchestration patterns for ML feature engineering and training pipeline reliability.
 - Implement data lineage capture tooling to provide end-to-end traceability from source systems to data products.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -41,7 +41,7 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 - Collaborate on hybrid cloud storage solutions using Qumulo's cloud capabilities
 - Evaluate new Qumulo features and technologies for potential implementation
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -43,7 +43,7 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 - Perform Qumulo software upgrades and patching
 - Manage file shares and access controls
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -41,7 +41,7 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 - Manage storage capacity planning and procurement processes
 - Track and report on storage performance, utilization, and cost metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -41,7 +41,7 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 - Develop storage monitoring and alerting frameworks
 - Provide technical mentorship to Qumulo Storage Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -45,7 +45,7 @@ The Storage Architect is responsible for designing and governing the organisatio
 - Produce storage architecture documentation, standards, and patterns library.
 - Mentor senior storage engineers and provide governance on complex design decisions.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -57,7 +57,7 @@ The Storage Architect is responsible for designing and governing the organisatio
 | Performance standards and workload-to-tier mapping | Application storage requirements (with App and DB teams) |
 | Storage capacity planning models | Vendor commercial negotiations |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -41,7 +41,7 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 - Implement basic storage automation and scripting
 - Document storage configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -41,7 +41,7 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 - Manage storage capacity planning and procurement processes
 - Track and report on storage performance, utilization, and cost metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -41,7 +41,7 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 - Plan and execute storage migrations and technology refreshes
 - Provide technical mentorship to Storage Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -41,7 +41,7 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 - Create self-healing mechanisms for backup infrastructure
 - Lead post-incident reviews for backup failures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -41,7 +41,7 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 - Evaluate new Commvault features and capabilities for adoption
 - Provide technical leadership for Commvault implementation projects
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -41,7 +41,7 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 - Perform Commvault updates and patches
 - Document Commvault configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -43,7 +43,7 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 - Ensure proper documentation of service offerings and capabilities
 - Coordinate version upgrades and new feature implementations
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -41,7 +41,7 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 - Design enterprise-scale backup architectures and workflows
 - Provide technical mentorship to Commvault Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -41,7 +41,7 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 - Evaluate new HPE SimpliVity features and data protection capabilities
 - Provide technical leadership for SimpliVity-based data protection initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -41,7 +41,7 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 - Execute backup testing and validation procedures
 - Document SimpliVity backup configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -41,7 +41,7 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 - Manage capacity planning for SimpliVity backup resources
 - Track and report on backup success rates, recovery testing, and SLA compliance
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -41,7 +41,7 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 - Design SimpliVity replication topologies for disaster recovery
 - Provide technical mentorship to SimpliVity Backup Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -41,7 +41,7 @@ The Database Architect designs comprehensive data management strategies and arch
 - Evaluate new database technologies and approaches
 - Provide technical leadership for database initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -41,7 +41,7 @@ The Database Engineer implements and maintains database systems across the organ
 - Implement basic database scripts and procedures
 - Document database configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -41,7 +41,7 @@ The Database Product Owner manages the portfolio of database platforms and data 
 - Manage database licensing and capacity planning
 - Track and optimize database performance, availability, and cost metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -41,7 +41,7 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 - Lead incident response for database outages
 - Conduct post-incident reviews for database failures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -41,7 +41,7 @@ The Database Senior Engineer leads the implementation and optimization of comple
 - Implement data migration and integration strategies
 - Provide technical mentorship to Database Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -43,7 +43,7 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 - Write comprehensive documentation, usage guides, worked examples, and contribution guidelines for all published frameworks
 - Monitor framework adoption, defect rates, and consumer feedback; drive continuous improvement of the automation platform
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 | Backstage scaffolder plugins and software templates owned by the DevOps team | Developer experience portal strategy and information architecture (led by Developer Experience Engineer) |
 | Framework documentation, contribution guidelines, and deprecation notices | Test strategy and coverage targets for consuming application teams |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -84,7 +84,7 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 - **Working Knowledge required:** Docker and container registries (packaging and distributing automation tooling), Packer (machine image pipeline authoring), internal artifact registries (PyPI, Terraform Registry, GitHub Packages)
 - **Awareness level expected:** Kubernetes as automation workload runtime target, AI-assisted development tools (GitHub Copilot for framework and test scaffolding), Robot Framework and Playwright for UI automation
 
-## Qualifications
+### Qualifications
 
 - **Education:** Bachelor's degree in Computer Science, Software Engineering, or a related technical discipline; equivalent professional experience considered.
 - **Experience:** 3–5 years in DevOps, software engineering, or QA automation engineering, with at least 2 years focused on framework or library development rather than point-in-time automation delivery.

--- a/Roles/devops/developer_experience_engineer.md
+++ b/Roles/devops/developer_experience_engineer.md
@@ -43,7 +43,7 @@ The Developer Experience Engineer designs, builds, and operates internal develop
 - Maintain documentation, runbooks, and onboarding guides within the developer portal to support platform self-service adoption.
 - Participate in platform incident response for developer tooling and CI/CD infrastructure availability issues.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -42,7 +42,7 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 - Define strategies for integrating AI coding assistants and generative AI into delivery workflows
 - Provide technical leadership for DevOps initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -42,7 +42,7 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 - Document DevOps processes and pipeline configurations
 - Support development teams with CI/CD implementation
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -52,7 +52,7 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 | IaC template creation and maintenance for standard deployment environments | Infrastructure design and cloud architecture decisions |
 | Pipeline documentation, runbooks, and onboarding guides for application teams | Security scanning policy and vulnerability triage |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -41,7 +41,7 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 - Coordinate DevOps training and enablement initiatives
 - Establish service level objectives for DevOps platforms
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -51,7 +51,7 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 | DevOps tooling license and investment strategy | Security requirements for pipeline tooling (with Security PO) |
 | DORA metrics reporting and developer experience improvement backlog | Engineering team hiring and resourcing decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -97,7 +97,7 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 - Measurable improvement in software delivery metrics
 - Effectiveness of DevOps training and enablement programs
 
-## Key Technologies & Platforms
+## Key Technologies
 
 - CI/CD orchestration platforms
 - DevOps toolchain integration frameworks

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -43,7 +43,7 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 - Provide technical mentorship to DevOps Engineers
 - Evaluate new DevOps tools and approaches
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 | Deployment strategy selection (canary, blue/green, feature flags) for application teams | Application architecture and code structure |
 | DevSecOps toolchain integration and pipeline security gate design | Security policy and vulnerability remediation priorities (with Security team) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -43,7 +43,7 @@ The Platform Reliability Engineer applies site reliability engineering (SRE) pri
 - Drive a culture of reliability within the platform engineering team through runbook authorship, game day facilitation, and reliability review practices.
 - Maintain platform runbooks, incident playbooks, and reliability standards documentation.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -41,7 +41,7 @@ The Windows Active Directory Architect designs AD structure, security models, an
 - Develop authentication and authorization frameworks
 - Provide technical leadership for Active Directory initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -41,7 +41,7 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 - Implement basic PowerShell automation for AD management tasks
 - Document Active Directory configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -41,7 +41,7 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 - Manage capacity planning and resource allocation for directory services
 - Track and report on directory services health, performance, and security metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -41,7 +41,7 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 - Optimize Active Directory performance and replication
 - Provide technical mentorship to Active Directory Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/endpoint_management/endpoint_management_architect.md
+++ b/Roles/endpoint_management/endpoint_management_architect.md
@@ -43,7 +43,7 @@ The Endpoint Management Architect is responsible for the strategic design, gover
 - Create and maintain reference architectures, design patterns, and technical standards documents.
 - Mentor senior engineers and guide cross-functional teams on endpoint architecture decisions.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Endpoint Management Architect is responsible for the strategic design, gover
 | Integration architecture with Microsoft Entra ID, Defender, and Purview | Application portfolio rationalisation (with App teams) |
 | Endpoint compliance policy framework | Network segmentation impacts of endpoint control changes |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -44,7 +44,7 @@ The Endpoint Management Engineer administers and maintains the organisation's en
 - Maintain runbooks, SOPs, and endpoint management knowledge base articles.
 - Participate in change management processes for endpoint configuration changes.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The Endpoint Management Engineer administers and maintains the organisation's en
 | Compliance remediation actions for individual devices | Application packaging strategy |
 | Knowledge base and runbook maintenance | Automation and scripting approaches |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/endpoint_management/endpoint_management_product_owner.md
+++ b/Roles/endpoint_management/endpoint_management_product_owner.md
@@ -43,7 +43,7 @@ The Endpoint Management Product Owner (PO) owns the product vision, roadmap, and
 - Define success metrics for the endpoint platform and report against KPIs to leadership.
 - Drive prioritisation of co-management migration from SCCM to cloud-native Intune delivery.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The Endpoint Management Product Owner (PO) owns the product vision, roadmap, and
 | Stakeholder communication and expectation management | Licensing commercial negotiations (with Procurement) |
 | Acceptance criteria for platform features | Organisational onboarding and change management (with HR) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/endpoint_management/endpoint_management_senior_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_senior_engineer.md
@@ -45,7 +45,7 @@ The Endpoint Management Senior Engineer designs, implements, and maintains compl
 - Mentor junior engineers and contribute to team knowledge base and runbooks.
 - Participate in change management processes and ensure endpoint changes are properly documented.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Endpoint Management Senior Engineer designs, implements, and maintains compl
 | Intune scripting and automation solutions | Co-management workload migration timeline |
 | Patch ring design and testing | Licensing and tooling procurement |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -41,7 +41,7 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 - Troubleshoot SCCM-related issues
 - Maintain documentation for SCCM configurations and procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -41,7 +41,7 @@ The Enterprise Architect develops and maintains the overall technological vision
 - Establish architecture principles, policies, and AI governance frameworks
 - Mentor domain architects and ensure alignment across architectural domains
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -43,7 +43,7 @@ The Enterprise Architecture Senior Engineer operates at the intersection of tech
 - Maintain the business capability model, application portfolio inventory, and technology lifecycle records
 - Contribute to architecture community of practice activities: knowledge sharing sessions, architecture clinic facilitation, and onboarding guidance for new architects
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -45,7 +45,7 @@ The Solution Architect is responsible for designing end-to-end technical solutio
 - Participate in vendor selection and RFI/RFP processes as subject matter expert.
 - Mentor engineers and review technical designs produced by delivery teams.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -57,7 +57,7 @@ The Solution Architect is responsible for designing end-to-end technical solutio
 | RAID log and solution-level risk decisions | Security policy and organisational risk appetite (with CISO) |
 | Technical governance of delivery teams during build phase | Organisational change management (with Programme Management) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -41,7 +41,7 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 - Evaluate new technologies for infrastructure provisioning
 - Provide technical leadership for onboarding initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -41,7 +41,7 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 - Support self-service infrastructure provisioning portals
 - Collect metrics on provisioning performance and efficiency
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -42,7 +42,7 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 - Coordinate onboarding process standardization initiatives
 - Drive adoption of self-service provisioning capabilities
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -41,7 +41,7 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 - Optimize infrastructure onboarding for speed and reliability
 - Provide technical mentorship to Infrastructure Onboarding Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/integration_middleware/integration_architect.md
+++ b/Roles/integration_middleware/integration_architect.md
@@ -44,7 +44,7 @@ The Integration Architect designs and governs the organisation's enterprise inte
 - Provide technical governance through design review of integration solutions.
 - Mentor integration engineers and work with Solution Architects to embed integration best practices in project designs.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Integration Architect designs and governs the organisation's enterprise inte
 | Integration monitoring and SLA standards | Commercial licensing decisions (with Procurement) |
 | B2B and EDI integration standards | ERP configuration decisions (with ERP/Business Systems teams) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -43,7 +43,7 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 - Participate in change management processes for integration updates.
 - Escalate complex integration issues to senior engineers.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 | Integration monitoring response and incident first-response | API design and error handling strategy |
 | Integration documentation currency | Tooling and platform improvements |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -44,7 +44,7 @@ The Integration Product Owner owns the integration platform product backlog — 
 - Engage with consuming teams to manage expectations around integration platform capabilities, breaking changes, and deprecation timelines.
 - Drive integration technical debt reduction programmes: prioritising decommissioning of legacy point-to-point integrations in favour of governed platform patterns.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -44,7 +44,7 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 - Mentor integration engineers and guide the team on integration patterns and standards.
 - Maintain integration runbooks, operational documentation, and incident response procedures.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 | Integration monitoring and alerting configuration | B2B trading partner requirements (with Business/ERP teams) |
 | Code review standards and quality gates for integration team | Security policies for API access and credential management |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -41,7 +41,7 @@ The Application Configuration Management Architect designs comprehensive strateg
 - Evaluate new configuration management technologies
 - Provide technical leadership for configuration management initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -41,7 +41,7 @@ The Application Configuration Management Engineer implements and maintains confi
 - Maintain documentation for configuration procedures
 - Support application teams with configuration management requirements
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -41,7 +41,7 @@ The Application Configuration Management Senior Engineer leads the implementatio
 - Optimize configuration management for security and compliance
 - Provide technical mentorship to Configuration Management Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -44,7 +44,7 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 - Define ITSM platform integration requirements with monitoring, alerting, cloud platforms, and DevOps tooling.
 - Drive self-service adoption through service catalogue design and virtual agent/chatbot capabilities.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 | Acceptance criteria for platform changes | Organisational ITSM process adoption strategy |
 | CMDB scope definition and data quality KPIs | IT security policies applicable to ITSM platform |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -41,7 +41,7 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 - Ensure Kubernetes platforms meet security, compliance, and performance requirements
 - Define high-level technical roadmaps for Kubernetes infrastructure evolution
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -51,7 +51,7 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 | Container security framework: admission policies, network policies, image scanning standards | Cloud platform selection and underlying infrastructure design |
 | Service mesh strategy, API gateway pattern, and GitOps workflow design | DevOps pipeline design and CI/CD toolchain selection |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -42,7 +42,7 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 - Support application teams in deploying containerized workloads
 - Document Kubernetes operational procedures and configurations
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -52,7 +52,7 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 | Helm chart creation and Kubernetes manifest maintenance for standard workload patterns | Container security policy and network policy design |
 | Cluster monitoring alert response, node troubleshooting, and first-response incident triage | Cluster capacity planning and scaling strategy |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -41,7 +41,7 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 - Coordinate container platform adoption initiatives across teams
 - Develop and maintain service level objectives for the Kubernetes platform
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -51,7 +51,7 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 | Platform adoption programme strategy and application team onboarding sequencing | Container security policy requirements (with Security PO) |
 | Kubernetes platform SLA targets, service definitions, and acceptance criteria | Cloud infrastructure costs and resourcing decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -42,7 +42,7 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 - Provide technical mentorship to Kubernetes Engineers
 - Evaluate and prototype new Kubernetes features and extensions
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -52,7 +52,7 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 | Cluster automation tooling, GitOps pipeline implementation, and performance tuning | Application containerisation design and workload resource sizing |
 | Technical mentoring direction and capability development for Kubernetes Engineers | Container security policy definition (with Security team) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -47,7 +47,7 @@ The CISO sits above the PAL and TAL in the technology leadership hierarchy on ma
 - Engage with regulators, auditors, and industry security bodies as the executive accountable for the organisation's security obligations
 - Collaborate with the SVP of Technology and CTO/CIO on technology investment decisions where security risk, compliance, or architectural security principles are at stake
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -95,7 +95,7 @@ The CISO sits above the PAL and TAL in the technology leadership hierarchy on ma
 | DevSecOps and application security | Proficient |
 | Security culture and awareness programme leadership | Expert |
 
-## Qualifications
+### Qualifications
 
 - Degree in Computer Science, Information Security, Information Technology, or a related field; postgraduate qualification advantageous
 - 15+ years of progressive security leadership experience, with at least 5 years in a senior executive or CISO-level role

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -43,7 +43,7 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 - Own the infrastructure chapter roadmap — translating TAL/PAL strategic direction into chapter-level technical priorities and delivery commitments
 - Represent the chapter in enterprise-wide architecture forums, security governance bodies, and technology investment discussions
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 | Chapter roadmap and technical prioritisation within the infrastructure portfolio | Business strategy, enterprise roadmap sequencing, and cross-area investment trade-offs (TAL/PAL-owned) |
 | Platform consolidation and hardware refresh strategy within the infrastructure estate | Vendor contracts, procurement decisions, and enterprise supplier strategy (commercial and PAL-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -80,7 +80,7 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 - **Working Knowledge required:** Kubernetes at governance and platform strategy depth
 - **Awareness level expected:** FinOps tooling (Azure Cost Management, Cloudability) for chapter budget oversight
 
-## Qualifications
+### Qualifications
 
 - 10+ years of experience in infrastructure architecture, platform engineering, or senior infrastructure engineering roles
 - 3+ years in a Principal Architect, Lead Architect, or technical leadership role with cross-domain infrastructure scope

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -43,7 +43,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 - Own the chapter roadmap — translating TAL/PAL and CDO strategic direction into chapter-level data and AI technical priorities and delivery commitments
 - Represent the chapter in enterprise architecture forums, data governance boards, AI ethics committees, and regulatory compliance discussions
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 | Practitioner career decisions — promotions, development plans, performance management, and hiring bar for the chapter | Compensation bands, HR policy, and organisational structure (PAL and HR-owned) |
 | AI ethics framework implementation and model risk assessment standards | Enterprise AI ethics policy and regulatory reporting obligations (Legal, Risk, and CDO-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -80,7 +80,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 - **Working Knowledge required:** ML platforms (Azure ML, SageMaker) at strategic oversight
 - **Awareness level expected:** AI ethics and responsible AI frameworks (NIST AI RMF, EU AI Act)
 
-## Qualifications
+### Qualifications
 
 - 10+ years of experience in data architecture, data engineering, data platform, or AI/ML roles
 - 3+ years in a Principal Data Architect, Lead Data Engineer, or senior technical leadership role with cross-domain data scope

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -43,7 +43,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 - Own the chapter roadmap — translating TAL/PAL strategic direction into delivery toolchain and platform engineering priorities
 - Represent the chapter in enterprise architecture forums, cloud strategy forums, and financial governance discussions
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 | Practitioner career decisions — promotions, development plans, performance management, and hiring bar for the chapter | Compensation bands, HR policy, and organisational structure (PAL and HR-owned) |
 | DORA metrics target-setting and delivery performance improvement initiatives at chapter level | Cloud spend and FinOps governance (Cloud & Platform Infrastructure Chapter Lead-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -79,7 +79,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 - **Working Knowledge required:** DORA metrics tooling for chapter performance visibility
 - **Awareness level expected:** Integration platforms (Azure API Management, MuleSoft) at architecture depth
 
-## Qualifications
+### Qualifications
 
 - 10+ years of experience in DevOps engineering, platform engineering, software delivery, or integration architecture roles
 - 3+ years in a Principal Architect, Lead Architect, or senior technical leadership role with cross-domain delivery or platform scope

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -44,7 +44,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 - Own the modern workplace roadmap — translating business requirements for hybrid working, productivity, and employee experience into a technically sound and delivery-sequenced chapter plan
 - Represent the chapter in enterprise architecture forums, security governance discussions (for endpoint posture), and HR/People technology forums
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 | Practitioner career decisions — promotions, development plans, performance management, and hiring bar for the chapter | Compensation bands, HR policy, and organisational structure (PAL and HR-owned) |
 | Modern workplace roadmap and chapter technical priorities | Business strategy, hybrid working policy, and organisational change decisions (PAL, HR, and business leadership-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -81,7 +81,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 - **Working Knowledge required:** Collaboration analytics (Viva Insights, Teams analytics) for workplace metrics
 - **Awareness level expected:** ITSM platforms (ServiceNow) for end-user service governance
 
-## Qualifications
+### Qualifications
 
 - 10+ years of experience in endpoint management, Microsoft 365 architecture, modern workplace engineering, or senior end-user technology roles
 - 3+ years in a Principal Architect, Lead Architect, or senior technical leadership role with Microsoft 365 and endpoint management scope

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -43,7 +43,7 @@ The Engineering Practices Champion is a senior individual contributor and intern
 - Define and track team-level engineering practice KPIs, providing regular visibility of maturity trends to Engineering Directors and TALs
 - Identify systemic quality issues appearing across multiple teams — escalate architectural or tooling root causes and work with the appropriate function to resolve them at source
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Engineering Practices Champion is a senior individual contributor and intern
 | TDD/BDD, trunk-based development, and pair programming adoption guidance and coaching materials | Test automation framework architecture and long-term tooling investment (Automation Framework Engineer-owned) |
 | DoR and DoD workshop design, facilitation, and outcome documentation | Team-level Definition of Done final content (team and Product Owner-owned, with this role as facilitator) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Deep practical expertise in software engineering quality practices — TDD, BDD, pair programming, code review, trunk-based development, and continuous integration — with the ability to demonstrate and coach these practices hands-on, not just advocate for them
 - Proficiency with code quality and security tooling: SonarQube, GitHub Advanced Security, and the configuration of quality gates in modern CI pipelines (GitHub Actions, Azure DevOps, or equivalent)
@@ -89,7 +89,7 @@ The Engineering Practices Champion is a senior individual contributor and intern
 
 - Emerging engineering practice trends (Thoughtworks Technology Radar signals)
 
-## Qualifications
+### Qualifications
 
 - **Education:** Degree in Computer Science, Software Engineering, or a related discipline, or equivalent professional experience demonstrating depth in software quality and delivery practices
 - **Experience:** Typically 7+ years in software engineering, DevOps, or platform engineering roles, with a strong focus on quality practices and engineering excellence; at least 2–3 years of coaching, mentoring, or team enablement experience at Senior Engineer level or above

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -43,7 +43,7 @@ The Product Area Lead (PAL) is a senior IT management role responsible for the e
 - Own risk and compliance governance for the area, escalating material risks to IT leadership
 - Create a high-performing, inclusive team culture with clear career development pathways
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -43,7 +43,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 - Lead security toolchain governance — rationalising and standardising the security tooling portfolio (SIEM, EDR, CSPM, CNAPP, vulnerability management) across the estate
 - Represent the chapter in enterprise architecture forums, security governance bodies, risk committees, and regulatory compliance discussions
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 | Practitioner career decisions — promotions, development plans, performance management, and hiring bar for the chapter | Compensation bands, HR policy, and organisational structure (PAL and HR-owned) |
 | Security toolchain governance — tooling rationalisation, platform selection, and security technology radar | Vendor contracts, security product procurement, and supplier risk decisions (CISO and commercial-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -80,7 +80,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 - **Working Knowledge required:** Zero trust architecture frameworks and tooling
 - **Awareness level expected:** GRC platforms (ServiceNow GRC, Archer) for risk oversight
 
-## Qualifications
+### Qualifications
 
 - 10+ years of experience in security architecture, identity and access management, or senior security engineering roles
 - 3+ years in a Principal Security Architect, Lead Security Architect, or senior security leadership role with cross-domain scope

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -43,7 +43,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 - Lead IT compliance reporting — ensuring the organisation can accurately report on IT service metrics, configuration estate, and governance adherence to Risk, Audit, and regulatory stakeholders
 - Represent the chapter in cross-chapter governance forums, enterprise architecture reviews, and business-facing IT service accountability discussions
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 | Practitioner career decisions — promotions, development plans, performance management, and hiring bar for the chapter | Compensation bands, HR policy, and organisational structure (PAL and HR-owned) |
 | Infrastructure onboarding playbook standards and architecture gate criteria for new services | Technology investment decisions, programme governance, and business case approval (PAL and Finance-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -80,7 +80,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 - **Working Knowledge required:** Enterprise architecture tools (LeanIX, Ardoq) at governance depth
 - **Awareness level expected:** Power BI/Tableau for service performance reporting
 
-## Qualifications
+### Qualifications
 
 - 10+ years of experience in IT service management, enterprise architecture governance, configuration management, or senior IT operations roles
 - 3+ years in a Principal Architect, Lead ITSM Architect, or senior technical leadership role with cross-domain governance scope

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -45,7 +45,7 @@ The SVP of Technology sits above the Product Area Lead (PAL) and Technical Area 
 - Set the tone for technology risk appetite, ensuring the organisation's risk posture is appropriate, transparent, and governed effectively
 - Develop and retain the senior technology leadership team, building succession depth and a high-performance culture across the function
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -98,7 +98,7 @@ The SVP of Technology sits above the Product Area Lead (PAL) and Technical Area 
 | Vendor and partner executive management | Expert |
 | Emerging technology evaluation (AI, data, platforms) | Proficient |
 
-## Qualifications
+### Qualifications
 
 - Degree in Computer Science, Information Technology, Engineering, Business, or a related field; postgraduate qualification (MBA, MSc) advantageous
 - 15+ years of progressive technology leadership experience, with at least 5 years in a senior executive role (CTO, CIO, VP, or SVP level)

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -43,7 +43,7 @@ The Technical Area Lead (TAL) is the senior technical authority for a defined IT
 - Represent the area's technical interests in enterprise-wide architecture, security, and governance forums
 - Collaborate with the PAL on investment decisions, ensuring technical feasibility and sustainability of roadmap commitments
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -43,7 +43,7 @@ The Technical Community Leader is a senior individual contributor responsible fo
 - Identify emerging knowledge gaps across the organisation and design targeted community interventions — workshops, working groups, or learning sprints — to address them
 - Champion psychological safety and inclusive participation within technical communities, ensuring all voices contribute to shared standards and practices
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Technical Community Leader is a senior individual contributor responsible fo
 | Internal technical content calendar, format, and publication channels | Engineering headcount, team structure, and L&D budget allocation (PAL/HR-owned) |
 | Cross-domain peer review process and participation guidelines | Individual team delivery priorities and sprint planning (Delivery Lead and team-owned) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Demonstrated ability to facilitate technical communities, workshops, and peer forums with diverse practitioner audiences — combining structure with genuine curiosity and energy
 - Strong written and verbal communication skills, with the ability to distil complex technical topics into accessible newsletters, wiki articles, and reference guides for varied audiences
@@ -73,7 +73,7 @@ The Technical Community Leader is a senior individual contributor responsible fo
 - **Working Knowledge required:** Metrics and analytics tooling (survey platforms, community engagement dashboards)
 - **Awareness level expected:** AI-powered learning and content tools, community platform analytics
 
-## Qualifications
+### Qualifications
 
 - **Education:** Degree in Computer Science, Software Engineering, or a related technical discipline, or equivalent professional experience
 - **Experience:** Typically 7+ years in software or platform engineering roles, with at least 2–3 years of demonstrated leadership, mentoring, or community-building activity; experience at Senior Engineer or Architect level in at least one domain

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -45,7 +45,7 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 - Contribute to production readiness review checklists by defining resilience acceptance criteria.
 - Develop chaos engineering runbooks and experiment templates for engineering team self-service.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 | Experiment catalogue and findings tracking | Remediation implementation (engineering squads own fixes) |
 | Game day planning and facilitation | Error budget policy implications of identified gaps |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -30,7 +30,7 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 - Architect edge AI inference platforms: design deployment patterns for on-device AI model serving using NVIDIA Jetson, Azure IoT Edge AI modules, and Intel OpenVINO for latency-sensitive or bandwidth-constrained edge workloads.
 - Define edge AI governance standards: model versioning, OTA model update pipelines, performance monitoring for edge-deployed models, and alignment between edge and cloud AI governance frameworks.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -44,7 +44,7 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 - Maintain IaC for AI platform components and automate deployments through CI/CD
 - Document AI platform capabilities, patterns, and runbooks
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 | AI security controls implementation including prompt injection defenses, RBAC, and access logging | AI governance framework design and responsible AI policy development |
 | LLM inference cost optimization approach (caching, batching, quantization, model routing) | AI platform technology roadmap and long-term model selection decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 - Experience deploying and managing LLM APIs and model serving platforms
 - Knowledge of vector databases and embedding workflows

--- a/Roles/modern_infrastructure/infrastructure_automation_architect.md
+++ b/Roles/modern_infrastructure/infrastructure_automation_architect.md
@@ -44,7 +44,7 @@ The Infrastructure Automation Architect designs and governs the organisation's e
 - Mentor senior automation engineers and champion infrastructure automation culture across the organisation.
 - Design edge infrastructure automation strategies: IaC templates for edge node provisioning, automated edge deployment pipelines, and configuration drift detection and remediation at edge locations.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -46,7 +46,7 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 - Implement edge MLOps pipelines: automate model packaging, optimisation (ONNX, TinyML quantisation), and deployment to edge devices using OTA update frameworks and edge runtime platforms.
 - Monitor and maintain edge-deployed models: implement performance telemetry, drift detection, and rollback mechanisms for ML models running on resource-constrained edge hardware.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -46,7 +46,7 @@ The Observability Architect designs and governs the organisation's full-stack ob
 - Design edge observability architecture: distributed telemetry collection from edge nodes, OpenTelemetry Collector deployment patterns for resource-constrained edge environments, and KubeEdge workload monitoring integration.
 - Define observability strategies for disconnected and intermittently-connected edge sites, including local telemetry buffering, store-and-forward pipeline patterns, and edge-to-cloud telemetry aggregation.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -41,7 +41,7 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 - Troubleshoot issues with observability platforms and data collection
 - Document observability implementations and procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -51,7 +51,7 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 | Log collection policies, retention configuration, and metrics collection setup from infrastructure and applications | Monitoring standards and instrumentation guidelines for application development teams |
 | Alert threshold tuning, noise reduction processes, and monitoring runbooks | Digital experience monitoring (RUM) strategy and APM implementation for application teams |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -41,7 +41,7 @@ The Observability Product Owner manages the observability platform portfolio, de
 - Coordinate platform adoption and enablement initiatives
 - Track and report on observability platform value and metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -51,7 +51,7 @@ The Observability Product Owner manages the observability platform portfolio, de
 | Acceptance criteria and delivery scope for monitoring, alerting, and logging platform capabilities | Enterprise ITSM strategy and incident management integration approach |
 | Platform adoption strategy and team onboarding program design | Organization-wide SLO governance framework and reliability measurement standards |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -97,7 +97,7 @@ The Observability Product Owner manages the observability platform portfolio, de
 - Effectiveness of observability in improving system reliability
 - Clear demonstration of platform value to the business
 
-## Key Technologies & Tools
+## Key Technologies
 
 - Enterprise observability platforms (Datadog, New Relic, Dynatrace)
 - Open-source monitoring stacks (Prometheus, Grafana)

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -42,7 +42,7 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 - Mentor Observability Engineers on advanced techniques
 - Evaluate and prototype new observability tools and approaches
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -52,7 +52,7 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 | Performance optimization, high-cardinality telemetry management, and query efficiency for observability platforms | Application team instrumentation strategy, SLO framework design, and APM adoption |
 | Custom integration development, observability automation frameworks, and anomaly detection implementation | Vendor platform evaluation, AI/ML-driven observability approaches, and platform roadmap |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -98,7 +98,7 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 - Contribution to observability standards and patterns
 - Implementation of innovative monitoring approaches
 
-## Key Technologies & Tools
+## Key Technologies
 
 - Advanced observability platforms (Datadog, New Relic, Dynatrace)
 - Open source monitoring stacks (Prometheus, Grafana, Thanos)

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -45,7 +45,7 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 - Design edge platform deployment patterns, extending IDP golden paths to edge and IoT environments
 - Architect edge-aware self-service tooling and onboarding workflows for edge workloads
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -41,7 +41,7 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 - Implement observability for platform components
 - Support application teams in platform adoption
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -41,7 +41,7 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 - Establish metrics for measuring platform effectiveness
 - Track and report on platform adoption and value delivery
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -41,7 +41,7 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 - Create platform automation and CI/CD integration
 - Provide technical mentorship to Platform Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -41,7 +41,7 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 - Develop runbooks and playbooks for operational procedures
 - Implement chaos engineering practices to improve system resilience
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -45,7 +45,7 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 - Define and maintain on-call runbooks and playbooks for critical services.
 - Evaluate and adopt new reliability tooling and platform improvements.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -57,7 +57,7 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 | Chaos engineering experiment design and execution | Capacity investment decisions (with Infrastructure/Finance) |
 | SRE tooling and automation implementation | Incident prioritisation policy |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/modern_workplace/modern_workplace_architect.md
+++ b/Roles/modern_workplace/modern_workplace_architect.md
@@ -44,7 +44,7 @@ The Modern Workplace Architect is responsible for designing, governing, and evol
 - Create and maintain M365 architecture documentation, governance frameworks, and standards.
 - Mentor M365 senior engineers and provide technical governance.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Modern Workplace Architect is responsible for designing, governing, and evol
 | SharePoint information architecture and permissions model | Licensing strategy and commercial decisions (with Procurement) |
 | M365 Copilot readiness and deployment architecture | Change management and end-user training strategy |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -43,7 +43,7 @@ The Modern Workplace Engineer administers and supports the organisation's Micros
 - Maintain knowledge base articles and runbooks for M365 operational procedures.
 - Participate in M365 configuration changes following change management processes.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -53,7 +53,7 @@ The Modern Workplace Engineer administers and supports the organisation's Micros
 | Routine compliance and eDiscovery task execution | Risk decisions on external sharing or guest access |
 | Knowledge base and runbook maintenance | Licensing optimisation recommendations |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -43,7 +43,7 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 - Define success metrics for the M365 platform and report against them to IT and business leadership.
 - Own the relationship with Microsoft account team and FastTrack for strategic engagement.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 | M365 licensing strategy and tier recommendations | Commercial licensing negotiations (with Procurement) |
 | Stakeholder communication and digital workplace messaging | HR workload and change management capacity |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/modern_workplace/modern_workplace_senior_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_senior_engineer.md
@@ -45,7 +45,7 @@ The Modern Workplace Senior Engineer implements, manages, and optimises the orga
 - Mentor M365 engineers and provide guidance on complex administration scenarios.
 - Produce and maintain runbooks, SOPs, and technical documentation.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Modern Workplace Senior Engineer implements, manages, and optimises the orga
 | Defender for Office 365 policy tuning | Licensing structure (with Procurement/PO) |
 | Runbook and documentation maintenance | End-user training and adoption strategy |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -43,7 +43,7 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 - Design edge networking architectures: SD-WAN edge PoP topology, 5G and private 5G integration for industrial and IoT edge sites, and cloud edge compute connectivity patterns (Azure Edge Zones, AWS Wavelength, AWS Local Zones).
 - Define network security architecture for edge environments: micro-segmentation at edge PoPs, zero trust network access for edge workloads, and secure SD-WAN policy enforcement at distributed edge sites.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/network/network_automation_architect.md
+++ b/Roles/network/network_automation_architect.md
@@ -46,7 +46,7 @@ The Network Automation Architect designs and governs the strategy, tooling, and 
 - Design automated edge network provisioning frameworks: zero-touch provisioning (ZTP) pipelines for edge site routers, SD-WAN CPE, and network appliances at distributed edge locations.
 - Define edge network automation standards: automated configuration push, compliance validation, and telemetry collection for edge PoPs and remote/branch network infrastructure integrated into the central network-as-code framework.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -58,7 +58,7 @@ The Network Automation Architect designs and governs the strategy, tooling, and 
 | IBN and telemetry collection architecture | Security policy for network automation access credentials |
 | Network compliance automation framework design | Training and skilling programme for network operations team |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -41,7 +41,7 @@ The Network Automation Engineer specializes in developing and implementing autom
 - Create self-service tools for common network operations
 - Document automation processes and frameworks
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -41,7 +41,7 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 - Implement basic network automation and monitoring
 - Document network configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -41,7 +41,7 @@ The Network Product Owner manages the development and lifecycle of the organizat
 - Manage network capacity planning and investment strategy
 - Track and report on network performance, availability, and cost metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -41,7 +41,7 @@ The Network Senior Engineer leads the implementation and optimization of complex
 - Plan and execute network migrations and technology refreshes
 - Provide technical mentorship to Network Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security/devsecops_architect.md
+++ b/Roles/security/devsecops_architect.md
@@ -44,7 +44,7 @@ The DevSecOps Architect is responsible for designing and governing the strategy,
 - Collaborate with platform engineering on developer experience - ensuring security tooling is seamless, not friction-heavy.
 - Represent DevSecOps in architecture forums and provide input into enterprise security architecture strategy.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The DevSecOps Architect is responsible for designing and governing the strategy,
 | Container security baseline standards | Vendor licensing and commercial decisions |
 | SBOM strategy and software supply chain controls | Application architecture decisions (with Solution Architect) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -44,7 +44,7 @@ The DevSecOps Engineer implements and maintains the security tooling, automation
 - Support security champions in engineering teams with tooling guidance and training.
 - Participate in security incident response where pipeline or supply chain compromise is suspected.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The DevSecOps Engineer implements and maintains the security tooling, automation
 | Developer documentation and onboarding for security tools | Security policy thresholds and gate criteria |
 | SBOM generation pipeline maintenance | Application architecture choices |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -42,7 +42,7 @@ The Security Architect designs and implements security systems and frameworks th
 - Lead security architecture reviews and risk assessments
 - Collaborate on disaster recovery and business continuity planning
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -42,7 +42,7 @@ The Security Engineer implements and maintains security controls and technologie
 - Create and maintain security documentation
 - Support application security testing
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -49,7 +49,7 @@ The Security Product Owner manages the development and lifecycle of the organiza
 - Develop self-service security capabilities
 - Analyze and report on security management metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -41,7 +41,7 @@ The Security Senior Engineer leads the implementation and optimization of comple
 - Optimize security operations and monitoring
 - Provide technical mentorship to Security Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -43,7 +43,7 @@ The Cloud Security Posture Manager implements and operates Cloud Security Postur
 - Assess the security posture impact of proposed cloud architecture changes, providing input to cloud platform teams during design and review.
 - Monitor CSPM tooling cost with FinOps team and ensure platform coverage remains cost-efficient and within agreed budgets.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -43,7 +43,7 @@ The Security Automation Engineer builds and maintains the automated security too
 - Tune security scanning configurations to manage false positive rates — maintaining signal quality so that security gate failures reflect genuine risk rather than noise.
 - Monitor the operational health of security automation pipelines, alert on tooling failures or coverage gaps, and maintain runbooks for pipeline security tooling incidents.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Security Automation Engineer builds and maintains the automated security too
 | Security tooling integration into CI/CD pipelines and developer-facing toolchains | CI/CD pipeline architecture and developer platform design (owned by DevOps Architect) |
 | Runtime security rule configuration (Falco) and detection signal tuning | Threat modelling and broader detection strategy (owned by Security Architect) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -83,7 +83,7 @@ The Security Automation Engineer builds and maintains the automated security too
 - **Working Knowledge required:** OWASP ZAP (DAST), Wiz/Prisma Cloud
 - **Awareness level expected:** eBPF-based security tools, AI-driven security automation
 
-## Qualifications
+### Qualifications
 
 - **Education:** Bachelor's degree in Computer Science, Software Engineering, Cybersecurity, or a related field; or equivalent demonstrated experience.
 - **Experience:** 3–5 years of experience in DevOps engineering, security engineering, or software engineering with a strong security focus; at least 2 years of hands-on experience building and operating automated security tooling within CI/CD pipelines.

--- a/Roles/security_cross_platform/security_cross_platform_architect.md
+++ b/Roles/security_cross_platform/security_cross_platform_architect.md
@@ -41,7 +41,7 @@ The Security Cross-Platform Architect designs and develops comprehensive securit
 - Maintain awareness of emerging security threats and mitigation strategies applicable to multiple domains
 - Create reference architectures for common security patterns that span multiple platforms
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -41,7 +41,7 @@ The Security Cross-Platform Engineer implements and maintains security controls 
 - Participate in security assessments across different technology environments
 - Apply security patches and updates across multiple platform types
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -41,7 +41,7 @@ The Security Cross-Platform Product Owner manages the portfolio of security serv
 - Facilitate agile ceremonies for cross-platform security initiatives
 - Balance security requirements with operational needs and technology constraints across domains
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
@@ -41,7 +41,7 @@ The Security Cross-Platform Senior Engineer leads the technical implementation o
 - Develop integration patterns for connecting security systems across multiple platforms
 - Implement security monitoring and alerting that provides visibility across all domains
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -41,7 +41,7 @@ The Access Management Architect designs and oversees the organization's access m
 - Evaluate and recommend access management technologies
 - Provide technical leadership for access management initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -41,7 +41,7 @@ The Access Management Engineer implements and maintains access management system
 - Generate access reports and audit data
 - Document access management configurations and procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -68,7 +68,7 @@ The Access Management Product Owner manages the development and lifecycle of the
 - Self-service access implementations
 - Access reporting and analytics systems
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -41,7 +41,7 @@ The Access Management Senior Engineer leads the implementation and optimization 
 - Develop custom access management integrations and extensions
 - Provide technical mentorship to Access Management Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -43,7 +43,7 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 - Drive continuous improvement of IGA automation coverage — identifying manual identity administration processes still performed outside the IGA platform and building structured plans to automate them.
 - Collaborate with the Privileged Access Management Architect/Engineer to ensure privileged account entitlements are accurately represented in the IGA governance layer and subject to appropriate certification and SoD controls.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 | Role mining analysis, RBAC/ABAC role engineering recommendations, and IGA role model maintenance | Privileged account entitlement governance strategy (co-owned with PAM Architect/Engineer) |
 | IGA platform operational health: connector monitoring, provisioning queue management, and platform incident escalation | PAM vault and privileged session management configuration (owned by PAM Architect/Engineer) |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 
@@ -83,7 +83,7 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 - **Working Knowledge required:** Workday/SAP SuccessFactors (HR integration), CyberArk Identity (PAM-IGA)
 - **Awareness level expected:** Omada Identity, AI-driven identity governance tools
 
-## Qualifications
+### Qualifications
 
 - **Education:** Bachelor's degree in Information Security, Computer Science, Information Systems, or a related field; or equivalent demonstrated professional experience.
 - **Experience:** 5–7 years of experience in identity and access management, IAM engineering, or information security; at least 3 years with direct hands-on IGA platform operations (SailPoint, Saviynt, Omada, or Microsoft Entra ID Governance) in an enterprise environment.

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -41,7 +41,7 @@ The Identity Management Architect designs and oversees the organization's identi
 - Evaluate and recommend identity management technologies
 - Provide technical leadership for identity management initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -41,7 +41,7 @@ The Identity Management Engineer implements and maintains identity management sy
 - Generate identity reports and audit data
 - Document identity management configurations and procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -71,7 +71,7 @@ The Identity Management Product Owner manages the development and lifecycle of t
 - Identity technology modernization frameworks
 - Identity data quality management tools
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -41,7 +41,7 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 - Develop custom identity integrations and connectors
 - Provide technical mentorship to Identity Management Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/security_identity/privileged_access_management_architect.md
+++ b/Roles/security_identity/privileged_access_management_architect.md
@@ -44,7 +44,7 @@ The Privileged Access Management (PAM) Architect designs, governs, and evolves t
 - Provide technical governance over PAM platform operations and ensure platform availability and resilience.
 - Mentor PAM engineers and guide cross-domain teams on privileged access principles.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Privileged Access Management (PAM) Architect designs, governs, and evolves t
 | PAM governance framework and on-boarding standards | Organisational change management for JIT adoption |
 | Integration architecture with SIEM and identity platforms | Budget allocation for PAM tooling |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/security_identity/privileged_access_management_engineer.md
+++ b/Roles/security_identity/privileged_access_management_engineer.md
@@ -45,7 +45,7 @@ The Privileged Access Management (PAM) Engineer implements, operates, and mainta
 - Document PAM configurations, on-boarding procedures, and troubleshooting runbooks.
 - Participate in incident response when credential compromise or privileged access abuse is suspected.
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Privileged Access Management (PAM) Engineer implements, operates, and mainta
 | Platform monitoring and health maintenance | On-boarding priority for account categories |
 | Compliance report generation and audit artefact collection | Tooling procurement decisions |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -41,7 +41,7 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 - Evaluate new server technologies and platforms
 - Provide technical leadership for server infrastructure initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -41,7 +41,7 @@ The Server Hardware Engineer implements and maintains the physical server infras
 - Implement physical cable management in data centers
 - Support server lifecycle activities including decommissioning
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -58,7 +58,7 @@ The Server Hardware Product Owner manages the lifecycle of physical server infra
 - Total cost of ownership optimization frameworks
 - Physical infrastructure security and compliance tools
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -41,7 +41,7 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 - Evaluate new server technologies and hardware platforms
 - Provide technical mentorship to Server Hardware Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -41,7 +41,7 @@ The HPE Server Hardware Architect designs and oversees the organization's server
 - Develop server hardware lifecycle management strategies
 - Provide technical leadership for HPE server infrastructure initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -54,7 +54,7 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 - Supporting hardware maintenance activities
 - Implementing standard HPE server builds
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -41,7 +41,7 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 - Optimize server configurations for performance, efficiency, and availability
 - Provide technical mentorship to HPE Server Hardware Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -43,7 +43,7 @@ The Linux Server Architect designs and defines the strategic direction for the o
 - Ensure compliance with security policies and regulatory requirements
 - Optimize cost and performance of Linux infrastructure
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -41,7 +41,7 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 - Assist in implementing automation scripts and tools
 - Maintain documentation for Linux environments
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -41,7 +41,7 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 - Balance resources and capacity for the Linux server team
 - Establish and track metrics for Linux platform health and performance
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -41,7 +41,7 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 - Evaluate and test new Linux technologies and distributions
 - Contribute to Linux platform roadmap and strategy
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -43,7 +43,7 @@ The Windows Server Architect designs and defines the strategic direction for the
 - Ensure compliance with security policies and regulatory requirements
 - Optimize cost and performance of Windows infrastructure
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -41,7 +41,7 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 - Assist in server migrations and upgrades
 - Document configurations, procedures, and operational processes
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -41,7 +41,7 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 - Manage resource allocation and capacity planning for the Windows Server team
 - Track and report on key metrics and service level objectives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -41,7 +41,7 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 - Evaluate and test new Windows technologies and features
 - Support the Product Owner in backlog refinement and technical estimation
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -41,7 +41,7 @@ The Service Management Architect designs comprehensive strategies and architectu
 - Evaluate new service management technologies
 - Provide technical leadership for ITSM initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -41,7 +41,7 @@ The Service Management Engineer implements and maintains IT service management p
 - Troubleshoot and resolve ITSM platform issues
 - Maintain documentation for ITSM configurations and procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -41,7 +41,7 @@ The Service Management Product Owner manages the development and lifecycle of th
 - Manage service catalog and portfolio development
 - Track and report on service performance metrics
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -41,7 +41,7 @@ The Service Management Senior Engineer leads the implementation and optimization
 - Plan and execute ITSM platform upgrades and migrations
 - Provide technical mentorship to Service Management Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/specialized_computing/hpc_architect.md
+++ b/Roles/specialized_computing/hpc_architect.md
@@ -46,7 +46,7 @@ The High-Performance Computing (HPC) Architect leads the design, implementation,
 - Maintain comprehensive documentation of HPC architectures, standards, and procedures
 - Design edge-HPC convergence patterns: distributed edge inference for ML models, FPGA acceleration at edge locations, and low-latency compute at geographically distributed edge sites
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -46,7 +46,7 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 - Provide user training and develop clear documentation
 - Continuously seek opportunities for process and technology improvement
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -45,7 +45,7 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 - Lead change management and communication for HPC initiatives
 - Gather and act on continuous feedback from users and stakeholders
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -45,7 +45,7 @@ The HPC Senior Engineer leads the technical implementation, automation, and opti
 - Proactively identify and mitigate risks to HPC operations and security
 - Lead continuous improvement initiatives for HPC processes and technologies
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -44,7 +44,7 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 - Define migration strategies from other virtualization platforms to Hyper-V
 - Ensure security controls meet organizational standards within Hyper-V environments
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -54,7 +54,7 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 | Hyper-V disaster recovery and high availability design patterns (Hyper-V Replica, clustering, SRM) | Azure cloud integration, Azure Arc deployment strategy, and hybrid cloud architecture |
 | Hyper-V security architecture including Shielded VMs, VBS, and SDN security controls | Storage and networking architecture for virtualized workloads |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -45,7 +45,7 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 - Implement security controls and hardening for Hyper-V infrastructure
 - Assist with capacity planning and resource allocation
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 | Backup configuration, restoration testing, and recovery procedures for virtual machines | DR/HA design and capacity planning recommendations |
 | Operational documentation accuracy and change management execution for Hyper-V tasks | PowerShell automation improvements and platform optimization approaches |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -45,7 +45,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 - Manage dependencies with other technology domains (storage, networking, security)
 - Advocate for customer needs in virtualization service delivery
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -55,7 +55,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 | Acceptance criteria and delivery scope for Hyper-V platform capabilities and service catalog | Windows Server and cloud platform strategy, Azure integration roadmap |
 | Windows licensing governance, cost optimization approach, and vendor relationship management | Storage, network, and security platform investment decisions affecting virtualization |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -46,7 +46,7 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 - Conduct capacity planning and performance optimization
 - Support the Hyper-V Architect in design and architecture activities
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 
@@ -56,7 +56,7 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 | PowerShell automation and SCVMM orchestration standards for operational efficiency | Azure Arc integration strategy and hybrid cloud design considerations |
 | Hyper-V performance tuning, capacity optimization, and disaster recovery implementation | Storage architecture decisions, clustering design, and SDN configuration at the platform level |
 
-## Required Skills
+## Required Skills & Qualifications
 
 **Technical Skills:**
 

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -41,7 +41,7 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 - Develop automation strategies leveraging Nutanix APIs and tools
 - Provide technical leadership for Nutanix-related initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -41,7 +41,7 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 - Implement basic automation for Nutanix operations
 - Document Nutanix configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -41,7 +41,7 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 - Manage capacity planning and resource allocation for hyperconverged resources
 - Track and report on Nutanix platform metrics and service levels
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -41,7 +41,7 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 - Optimize resource allocation and infrastructure performance
 - Provide technical mentorship to Nutanix Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -41,7 +41,7 @@ The VMware Architect designs and oversees the organization's virtualization infr
 - Develop automation and orchestration strategies for VMware environments
 - Provide technical leadership for virtualization initiatives
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -41,7 +41,7 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 - Implement basic automation for repetitive virtualization tasks
 - Document VMware configurations and operational procedures
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -41,7 +41,7 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 - Manage capacity planning and resource allocation for virtualization resources
 - Track and report on virtualization platform metrics and service levels
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -41,7 +41,7 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 - Optimize resource allocation and virtual infrastructure performance
 - Provide technical mentorship to VMware Engineers
 
-## Key Decisions and Accountabilities
+## Key Decisions & Accountabilities
 
 > Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
 


### PR DESCRIPTION
## Summary

First of three passes on #122 — the mechanical one. `validate-roles.js` accepted several historical spellings so a genuinely missing section was reported rather than a cosmetic difference; #121 made that drift visible, and this removes it.

| Count | From | To |
|---|---|---|
| 203 | `## Key Decisions and Accountabilities` | `## Key Decisions & Accountabilities` |
| 67 | `## Required Skills` | `## Required Skills & Qualifications` |
| 4 | `## Key Technologies & Platforms` / `& Tools` | `## Key Technologies` |
| 1 | `## Recommended Certifications and Learning Paths` | `& Learning Paths` |
| 27 | `## Qualifications` | `### Qualifications` |

**207 of 222 files touched. Heading warnings: 275 → 0.**

## The Qualifications change is a demotion, not a move

27 files carried `## Qualifications` as a *sibling* section holding degree, experience and certification requirements — content the template folds into **Required Skills & Qualifications**. A blind rename of `## Required Skills` would have produced a file containing both `## Required Skills & Qualifications` **and** `## Qualifications`, which is worse than the drift.

I checked before transforming: in **all 27** files (25 with a bare `## Required Skills`, 2 already canonical) the Qualifications section sits *directly under* the skills section with no other heading between. So demoting it to `###` places it inside the canonical section **without relocating a single line of content** — no reflow, no risk of losing text.

## Test plan

- [x] Transform dry-run first; its counts matched the validator's independently derived numbers exactly (203/67/4/1/27) before anything was written
- [x] `npm test` — 143/143
- [x] `npm run validate` — **0 errors, 0 duplicate titles**; heading warnings 275 → 0
- [x] markdownlint config enables only MD012/MD022/MD032 — no heading-increment rule, and only heading *text* changed, in place, so blank-line structure is untouched. Spot-checked a demoted file's surrounding blank lines.
- [x] Diff is 302 insertions / 302 deletions — a pure line-for-line swap, no content added or removed

## What remains on #122

The other 391 warnings are **not** mechanical and are deliberately left for separate work:

- **191 Technology Proficiency Levels** — reformatting inline bullets into the template's sub-heading form requires splitting comma-separated lists whose items contain commas inside parentheses (`Azure Networking (Hub-spoke, vWAN, ExpressRoute, Azure Firewall)` is one item). Doable mechanically with a paren-aware split, but needs its own dry-run review.
- **200 Key Performance Indicators** — this one is not a formatting problem. Converting `Architecture design quality and effectiveness` into a `| Metric | Target | Frequency |` row requires **inventing a target and a cadence**. I will not fabricate ~1,600 numbers; see the issue for options.