### PR TITLE
docs: put Technology Proficiency levels in the template's sub-heading form

### DIFF
--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -67,10 +67,23 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** AWS Cost Explorer and Cost and Usage Report (CUR) for detailed billing analysis and waste identification, Azure Cost Management and Azure Advisor for rightsizing recommendations and anomaly investigation, Reserved instance, savings plan, and committed use discount mechanics across AWS, Azure, and GCP, Cloud resource tagging policy enforcement and non-compliant resource remediation workflows
-- **Proficient level required:** Multi-cloud cost management platforms (CloudHealth by VMware, Apptio Cloudability) for consolidated waste and coverage reporting, Python and PowerShell scripting for idle resource cleanup, tagging remediation, and optimisation automation, Spot instance platforms (Spot.io Elastigroup/Ocean) for cost-efficient workload scheduling and interruption management
-- **Working Knowledge required:** Cloud provider CLIs (AWS CLI, Azure CLI, gcloud) for bulk resource auditing and operational remediation tasks, GCP Billing Console and GCP Recommender for GCP-specific optimisation actions
-- **Awareness level expected:** Infracost for shift-left cost estimation integrated into IaC pipelines, Harness Cloud Cost Management (CCM) and Densify for AI-driven rightsizing and workload optimisation
+**Expert level required:**
+
+- AWS Cost Explorer and Cost and Usage Report (CUR) for detailed billing analysis and waste identification, Azure Cost Management and Azure Advisor for rightsizing recommendations and anomaly investigation, Reserved instance, savings plan, and committed use discount mechanics across AWS, Azure, and GCP, Cloud resource tagging policy enforcement and non-compliant resource remediation workflows
+
+**Proficient level required:**
+
+- Multi-cloud cost management platforms (CloudHealth by VMware, Apptio Cloudability) for consolidated waste and coverage reporting, Python and PowerShell scripting for idle resource cleanup, tagging remediation, and optimisation automation, Spot instance platforms (Spot.io Elastigroup/Ocean) for cost-efficient workload scheduling and interruption management
+
+**Working Knowledge required:**
+
+- Cloud provider CLIs (AWS CLI, Azure CLI, gcloud) for bulk resource auditing and operational remediation tasks
+- GCP Billing Console and GCP Recommender for GCP-specific optimisation actions
+
+**Awareness level expected:**
+
+- Infracost for shift-left cost estimation integrated into IaC pipelines
+- Harness Cloud Cost Management (CCM) and Densify for AI-driven rightsizing and workload optimisation
 
 ### Qualifications
 

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -67,10 +67,23 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Power BI for cloud cost dashboards, chargeback reports, and scheduled stakeholder reporting (including RLS-based multi-tenant views), Microsoft Excel for financial modelling, TCO templates, and budget variance workbooks, AWS Cost and Usage Report (CUR), Azure Cost Management exports, and GCP BigQuery Billing Export for multi-cloud billing data analysis, SQL (Azure Synapse Analytics, Google BigQuery, Amazon Athena) for billing data querying, transformation, and aggregation
-- **Proficient level required:** Tableau for executive visualisation and self-service cloud cost analytics portals, Python (Pandas, Matplotlib) for analytical scripting, billing pipeline automation, and ad hoc analysis, Apptio for IT financial management, TBM taxonomy, and cloud cost analytics
-- **Working Knowledge required:** Anodot for cloud cost anomaly detection and spend forecasting, FinOps Foundation Framework cost allocation methodologies and chargeback/showback design patterns
-- **Awareness level expected:** Cloud provider billing APIs (AWS Billing API, Azure Cost Management API, GCP Billing API) for automated data extraction pipelines, FOCUS (FinOps Open Cost and Usage Specification) standard for multi-cloud billing normalisation
+**Expert level required:**
+
+- Power BI for cloud cost dashboards, chargeback reports, and scheduled stakeholder reporting (including RLS-based multi-tenant views), Microsoft Excel for financial modelling, TCO templates, and budget variance workbooks, AWS Cost and Usage Report (CUR), Azure Cost Management exports, and GCP BigQuery Billing Export for multi-cloud billing data analysis, SQL (Azure Synapse Analytics, Google BigQuery, Amazon Athena) for billing data querying, transformation, and aggregation
+
+**Proficient level required:**
+
+- Tableau for executive visualisation and self-service cloud cost analytics portals, Python (Pandas, Matplotlib) for analytical scripting, billing pipeline automation, and ad hoc analysis, Apptio for IT financial management, TBM taxonomy, and cloud cost analytics
+
+**Working Knowledge required:**
+
+- Anodot for cloud cost anomaly detection and spend forecasting
+- FinOps Foundation Framework cost allocation methodologies and chargeback/showback design patterns
+
+**Awareness level expected:**
+
+- Cloud provider billing APIs (AWS Billing API, Azure Cost Management API, GCP Billing API) for automated data extraction pipelines
+- FOCUS (FinOps Open Cost and Usage Specification) standard for multi-cloud billing normalisation
 
 ### Qualifications
 

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -69,10 +69,28 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Multi-cloud cost management platforms (CloudHealth, Apptio Cloudability, Spot by NetApp) for governance and optimisation architecture, Cloud financial governance frameworks (FinOps Foundation Framework v2, FOCUS cost allocation standard), Cloud-native cost tools (AWS Cost Explorer, Azure Cost Management, GCP Billing & Recommender) for authoritative cost data, Showback/chargeback and cost allocation platform design including tagging taxonomy and allocation key definition
-- **Proficient level required:** Cloud resource optimization platforms (Densify, Turbonomic, CAST AI) for rightsizing and workload placement architecture, Infrastructure as Code cost estimation (Infracost) for shift-left cost governance integration into CI/CD pipelines, AI/LLM cost governance (token attribution, GPU reservation vs. spot cost modelling, prompt caching optimisation)
-- **Working Knowledge required:** Carbon footprint and sustainability reporting tools (Cloud Carbon Footprint, Azure Carbon Optimization, AWS Customer Carbon Footprint Tool, GCP Carbon Footprint), Enterprise architecture tooling (LeanIX, Sparx EA) for documenting cloud cost governance architecture
-- **Awareness level expected:** FinOps automation and workflow orchestration platforms (Spot Ocean, CAST AI auto-scaling) for emerging optimisation patterns, Technology Business Management (TBM) frameworks and unit economics benchmarking standards
+**Expert level required:**
+
+- Multi-cloud cost management platforms (CloudHealth, Apptio Cloudability, Spot by NetApp) for governance and optimisation architecture
+- Cloud financial governance frameworks (FinOps Foundation Framework v2, FOCUS cost allocation standard)
+- Cloud-native cost tools (AWS Cost Explorer, Azure Cost Management, GCP Billing & Recommender) for authoritative cost data
+- Showback/chargeback and cost allocation platform design including tagging taxonomy and allocation key definition
+
+**Proficient level required:**
+
+- Cloud resource optimization platforms (Densify, Turbonomic, CAST AI) for rightsizing and workload placement architecture
+- Infrastructure as Code cost estimation (Infracost) for shift-left cost governance integration into CI/CD pipelines
+- AI/LLM cost governance (token attribution, GPU reservation vs. spot cost modelling, prompt caching optimisation)
+
+**Working Knowledge required:**
+
+- Carbon footprint and sustainability reporting tools (Cloud Carbon Footprint, Azure Carbon Optimization, AWS Customer Carbon Footprint Tool, GCP Carbon Footprint)
+- Enterprise architecture tooling (LeanIX, Sparx EA) for documenting cloud cost governance architecture
+
+**Awareness level expected:**
+
+- FinOps automation and workflow orchestration platforms (Spot Ocean, CAST AI auto-scaling) for emerging optimisation patterns
+- Technology Business Management (TBM) frameworks and unit economics benchmarking standards
 
 ### Qualifications
 

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -69,10 +69,25 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Cloud cost monitoring and reporting tools (AWS Cost Explorer, Azure Cost Management, GCP Billing Console), Resource tagging implementation and cost allocation frameworks across AWS, Azure, and GCP, Budget alerting and anomaly detection configuration in cloud native and third-party FinOps platforms, Cloud provider billing systems and pricing models for accurate cost attribution
-- **Proficient level required:** BI and data visualization platforms (Power BI, Tableau, Looker Studio) for cloud cost dashboards and reports, Multi-cloud cost management platforms (CloudHealth by VMware, Apptio Cloudability) for consolidated reporting, Scripting for FinOps automation (Python, PowerShell) for optimization tasks and scheduled reporting
-- **Working Knowledge required:** Infrastructure as Code (Terraform, Bicep, CloudFormation) for understanding resource cost implications of IaC changes, Reserved instance and savings plan tracking tools for commitment coverage monitoring
-- **Awareness level expected:** FinOps Foundation Framework and maturity model for practice development context, AI/LLM cost attribution patterns and token-level cost management for emerging cloud consumption
+**Expert level required:**
+
+- Cloud cost monitoring and reporting tools (AWS Cost Explorer, Azure Cost Management, GCP Billing Console), Resource tagging implementation and cost allocation frameworks across AWS, Azure, and GCP, Budget alerting and anomaly detection configuration in cloud native and third-party FinOps platforms, Cloud provider billing systems and pricing models for accurate cost attribution
+
+**Proficient level required:**
+
+- BI and data visualization platforms (Power BI, Tableau, Looker Studio) for cloud cost dashboards and reports
+- Multi-cloud cost management platforms (CloudHealth by VMware, Apptio Cloudability) for consolidated reporting
+- Scripting for FinOps automation (Python, PowerShell) for optimization tasks and scheduled reporting
+
+**Working Knowledge required:**
+
+- Infrastructure as Code (Terraform, Bicep, CloudFormation) for understanding resource cost implications of IaC changes
+- Reserved instance and savings plan tracking tools for commitment coverage monitoring
+
+**Awareness level expected:**
+
+- FinOps Foundation Framework and maturity model for practice development context
+- AI/LLM cost attribution patterns and token-level cost management for emerging cloud consumption
 
 ### Qualifications
 

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -66,10 +66,25 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Agile product ownership tools (Jira, Confluence) for FinOps backlog management, roadmap tracking, and sprint ceremonies, FinOps Foundation Framework and methodology for cloud financial accountability governance and maturity assessment, Stakeholder reporting and communication platforms (Power BI, Microsoft Teams) for cloud cost transparency and executive briefings
-- **Proficient level required:** Cloud cost management portals (AWS Cost Explorer, Azure Cost Management, GCP Billing Console) for understanding cost drivers and initiative prioritisation, Chargeback and showback platforms for cost allocation model governance and reporting quality oversight, Cloud provider pricing models (AWS, Azure, GCP) for ROI analysis of FinOps optimisation initiatives
-- **Working Knowledge required:** FinOps tooling platforms (CloudHealth, Apptio Cloudability) for service catalogue definition and tool governance decisions, ITIL service management framework for aligning FinOps processes with IT service delivery and SLA management
-- **Awareness level expected:** FinOps automation and reserved capacity management platforms for technical roadmap and investment oversight, AI/LLM cost governance patterns and emerging cloud consumption models (spot GPU, token pricing, inference reservations)
+**Expert level required:**
+
+- Agile product ownership tools (Jira, Confluence) for FinOps backlog management, roadmap tracking, and sprint ceremonies, FinOps Foundation Framework and methodology for cloud financial accountability governance and maturity assessment, Stakeholder reporting and communication platforms (Power BI, Microsoft Teams) for cloud cost transparency and executive briefings
+
+**Proficient level required:**
+
+- Cloud cost management portals (AWS Cost Explorer, Azure Cost Management, GCP Billing Console) for understanding cost drivers and initiative prioritisation
+- Chargeback and showback platforms for cost allocation model governance and reporting quality oversight
+- Cloud provider pricing models (AWS, Azure, GCP) for ROI analysis of FinOps optimisation initiatives
+
+**Working Knowledge required:**
+
+- FinOps tooling platforms (CloudHealth, Apptio Cloudability) for service catalogue definition and tool governance decisions
+- ITIL service management framework for aligning FinOps processes with IT service delivery and SLA management
+
+**Awareness level expected:**
+
+- FinOps automation and reserved capacity management platforms for technical roadmap and investment oversight
+- AI/LLM cost governance patterns and emerging cloud consumption models (spot GPU, token pricing, inference reservations)
 
 ### Qualifications
 

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -67,10 +67,25 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Multi-cloud cost management platforms (CloudHealth, Apptio Cloudability) and custom API integrations, Advanced cloud cost automation (Python, PowerShell) for optimization pipeline development, Cloud provider billing APIs and SDKs (AWS, Azure, GCP) for data extraction and ETL pipelines, Reserved instance and committed use discount optimization strategy across all three major cloud providers
-- **Proficient level required:** Data visualization and analytics tools (Power BI, Tableau) for advanced cloud cost dashboards and executive reporting, Anomaly detection frameworks for identifying cost spikes, billing irregularities, and attribution errors, CI/CD pipeline integration for FinOps policy enforcement and automation deployment
-- **Working Knowledge required:** Cloud architecture principles across AWS, Azure, and GCP for evaluating the cost impact of design decisions, Machine learning concepts and tooling for cloud cost forecasting and anomaly prediction models
-- **Awareness level expected:** AI/LLM cost governance patterns (token attribution, GPU reservation management, prompt caching cost optimization), FinOps Foundation Framework maturity model and emerging FinOps open standards (FOCUS specification)
+**Expert level required:**
+
+- Multi-cloud cost management platforms (CloudHealth, Apptio Cloudability) and custom API integrations
+- Advanced cloud cost automation (Python, PowerShell) for optimization pipeline development
+- Cloud provider billing APIs and SDKs (AWS, Azure, GCP) for data extraction and ETL pipelines
+- Reserved instance and committed use discount optimization strategy across all three major cloud providers
+
+**Proficient level required:**
+
+- Data visualization and analytics tools (Power BI, Tableau) for advanced cloud cost dashboards and executive reporting, Anomaly detection frameworks for identifying cost spikes, billing irregularities, and attribution errors, CI/CD pipeline integration for FinOps policy enforcement and automation deployment
+
+**Working Knowledge required:**
+
+- Cloud architecture principles across AWS, Azure, and GCP for evaluating the cost impact of design decisions, Machine learning concepts and tooling for cloud cost forecasting and anomaly prediction models
+
+**Awareness level expected:**
+
+- AI/LLM cost governance patterns (token attribution, GPU reservation management, prompt caching cost optimization)
+- FinOps Foundation Framework maturity model and emerging FinOps open standards (FOCUS specification)
 
 ### Qualifications
 

--- a/Roles/ai_governance/ai_governance_architect.md
+++ b/Roles/ai_governance/ai_governance_architect.md
@@ -81,10 +81,30 @@ The AI Governance Architect designs and governs the organisation's frameworks, p
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure AI Content Safety, Microsoft Purview, EU AI Act compliance tooling, SHAP/LIME/Microsoft InterpretML
-- **Proficient level required:** Fairlearn/AI Fairness 360, MLflow, OWASP LLM Top 10/MITRE ATLAS, Presidio
-- **Working Knowledge required:** Azure Machine Learning, Responsible AI Dashboard, ISO/IEC 42001
-- **Awareness level expected:** NIST AI RMF, Microsoft Copilot Studio governance controls
+**Expert level required:**
+
+- Azure AI Content Safety
+- Microsoft Purview
+- EU AI Act compliance tooling
+- SHAP/LIME/Microsoft InterpretML
+
+**Proficient level required:**
+
+- Fairlearn/AI Fairness 360
+- MLflow
+- OWASP LLM Top 10/MITRE ATLAS
+- Presidio
+
+**Working Knowledge required:**
+
+- Azure Machine Learning
+- Responsible AI Dashboard
+- ISO/IEC 42001
+
+**Awareness level expected:**
+
+- NIST AI RMF
+- Microsoft Copilot Studio governance controls
 
 ## Interactions with Other Roles
 

--- a/Roles/ai_governance/ai_governance_engineer.md
+++ b/Roles/ai_governance/ai_governance_engineer.md
@@ -75,10 +75,30 @@ The AI Governance Engineer is an entry-level practitioner role responsible for i
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Fairlearn, Microsoft InterpretML, Azure AI Content Safety, MLflow
-- **Proficient level required:** IBM AI Fairness 360, NIST AI RMF tooling, Python/Jupyter notebooks, GRC platforms (ServiceNow GRC)
-- **Working Knowledge required:** AWS Bedrock Guardrails, Model card frameworks, Jira/Confluence
-- **Awareness level expected:** Azure Machine Learning, Microsoft Purview
+**Expert level required:**
+
+- Fairlearn
+- Microsoft InterpretML
+- Azure AI Content Safety
+- MLflow
+
+**Proficient level required:**
+
+- IBM AI Fairness 360
+- NIST AI RMF tooling
+- Python/Jupyter notebooks
+- GRC platforms (ServiceNow GRC)
+
+**Working Knowledge required:**
+
+- AWS Bedrock Guardrails
+- Model card frameworks
+- Jira/Confluence
+
+**Awareness level expected:**
+
+- Azure Machine Learning
+- Microsoft Purview
 
 ## Interactions with Other Roles
 

--- a/Roles/ai_governance/ai_governance_product_owner.md
+++ b/Roles/ai_governance/ai_governance_product_owner.md
@@ -75,10 +75,27 @@ The AI Governance Product Owner owns the AI governance product backlog, managing
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Jira/Confluence, ServiceNow GRC/Archer, Microsoft Purview
-- **Proficient level required:** Power BI/Tableau, Azure DevOps/GitHub Projects, AI compliance platforms (OneTrust)
-- **Working Knowledge required:** ProductBoard/Aha! (roadmap management), Microsoft Teams/SharePoint
-- **Awareness level expected:** Azure AI Content Safety, Responsible AI Dashboard
+**Expert level required:**
+
+- Jira/Confluence
+- ServiceNow GRC/Archer
+- Microsoft Purview
+
+**Proficient level required:**
+
+- Power BI/Tableau
+- Azure DevOps/GitHub Projects
+- AI compliance platforms (OneTrust)
+
+**Working Knowledge required:**
+
+- ProductBoard/Aha! (roadmap management)
+- Microsoft Teams/SharePoint
+
+**Awareness level expected:**
+
+- Azure AI Content Safety
+- Responsible AI Dashboard
 
 ## Interactions with Other Roles
 

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -68,10 +68,29 @@ The AI Governance Senior Engineer implements, operates, and continuously improve
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Fairlearn/AI Fairness 360, SHAP/LIME/Microsoft InterpretML, Azure AI Content Safety/Azure OpenAI content filtering, Microsoft Purview
-- **Proficient level required:** MLflow/Azure Machine Learning, OWASP LLM Top 10/MITRE ATLAS, Presidio, Python
-- **Working Knowledge required:** GRC platforms (ServiceNow GRC), Microsoft Copilot Admin Center/Microsoft 365 governance
-- **Awareness level expected:** Weights & Biases, EU AI Act compliance tooling
+**Expert level required:**
+
+- Fairlearn/AI Fairness 360
+- SHAP/LIME/Microsoft InterpretML
+- Azure AI Content Safety/Azure OpenAI content filtering
+- Microsoft Purview
+
+**Proficient level required:**
+
+- MLflow/Azure Machine Learning
+- OWASP LLM Top 10/MITRE ATLAS
+- Presidio
+- Python
+
+**Working Knowledge required:**
+
+- GRC platforms (ServiceNow GRC)
+- Microsoft Copilot Admin Center/Microsoft 365 governance
+
+**Awareness level expected:**
+
+- Weights & Biases
+- EU AI Act compliance tooling
 
 ## Interactions with Other Roles
 

--- a/Roles/ai_governance/ai_platform_architect.md
+++ b/Roles/ai_governance/ai_platform_architect.md
@@ -77,10 +77,30 @@ The AI Platform Architect designs and governs the organisation's AI/ML platform 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure AI Foundry/Azure Machine Learning, MLflow, Kubeflow Pipelines, AWS SageMaker
-- **Proficient level required:** Google Vertex AI, Apache Spark/Delta Lake, Ray/Ray Serve, KServe/Triton Inference Server
-- **Working Knowledge required:** Seldon Core/BentoML, Feast (feature store), DVC
-- **Awareness level expected:** Databricks Machine Learning, OWASP LLM Top 10
+**Expert level required:**
+
+- Azure AI Foundry/Azure Machine Learning
+- MLflow
+- Kubeflow Pipelines
+- AWS SageMaker
+
+**Proficient level required:**
+
+- Google Vertex AI
+- Apache Spark/Delta Lake
+- Ray/Ray Serve
+- KServe/Triton Inference Server
+
+**Working Knowledge required:**
+
+- Seldon Core/BentoML
+- Feast (feature store)
+- DVC
+
+**Awareness level expected:**
+
+- Databricks Machine Learning
+- OWASP LLM Top 10
 
 ## Interactions with Other Roles
 

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -79,10 +79,30 @@ The AI Platform Engineer builds and operates the organisation's AI/ML platform i
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure ML/Azure AI Foundry, MLflow, Docker/Kubernetes (AKS), Python
-- **Proficient level required:** Kubeflow Pipelines, Apache Airflow, GitHub Actions/GitLab CI, Terraform
-- **Working Knowledge required:** AWS SageMaker, Google Vertex AI, Feast (feature store)
-- **Awareness level expected:** Ray/Ray Serve, KServe/Triton Inference Server
+**Expert level required:**
+
+- Azure ML/Azure AI Foundry
+- MLflow
+- Docker/Kubernetes (AKS)
+- Python
+
+**Proficient level required:**
+
+- Kubeflow Pipelines
+- Apache Airflow
+- GitHub Actions/GitLab CI
+- Terraform
+
+**Working Knowledge required:**
+
+- AWS SageMaker
+- Google Vertex AI
+- Feast (feature store)
+
+**Awareness level expected:**
+
+- Ray/Ray Serve
+- KServe/Triton Inference Server
 
 ## Interactions with Other Roles
 

--- a/Roles/ai_governance/responsible_ai_engineer.md
+++ b/Roles/ai_governance/responsible_ai_engineer.md
@@ -81,10 +81,29 @@ The Responsible AI Engineer implements the technical tooling, testing processes,
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** SHAP/LIME/Microsoft InterpretML, Fairlearn/IBM AI Fairness 360, Azure AI Content Safety, Microsoft Purview AI Hub
-- **Proficient level required:** Azure Machine Learning/MLflow, Microsoft Presidio, garak/PyRIT (LLM red teaming), Great Expectations/Evidently AI
-- **Working Knowledge required:** Hugging Face model card toolkit, Weights and Biases
-- **Awareness level expected:** OWASP LLM Top 10, MITRE ATLAS
+**Expert level required:**
+
+- SHAP/LIME/Microsoft InterpretML
+- Fairlearn/IBM AI Fairness 360
+- Azure AI Content Safety
+- Microsoft Purview AI Hub
+
+**Proficient level required:**
+
+- Azure Machine Learning/MLflow
+- Microsoft Presidio
+- garak/PyRIT (LLM red teaming)
+- Great Expectations/Evidently AI
+
+**Working Knowledge required:**
+
+- Hugging Face model card toolkit
+- Weights and Biases
+
+**Awareness level expected:**
+
+- OWASP LLM Top 10
+- MITRE ATLAS
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -66,10 +66,30 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise API gateway platforms (Apigee, Kong, AWS API Gateway, or Azure APIM — topology design and policy architecture), API security frameworks (OAuth 2.0, OIDC, JWT validation, and threat management), OpenAPI/Swagger specification design and governance standards
-- **Proficient level required:** Service mesh technologies (Istio, Linkerd) for API traffic management, GraphQL schema design and federation architecture, API lifecycle management and developer portal strategy, Kubernetes for API gateway deployment
-- **Working Knowledge required:** Event-driven architectures and event brokers (Kafka, Azure Service Bus) as API integration patterns, APIOps methodologies and tooling, CI/CD pipeline design for API deployments
-- **Awareness level expected:** AsyncAPI specification for event-driven APIs, gRPC and Protocol Buffers for internal service APIs, AI-assisted API design and documentation generation tools
+**Expert level required:**
+
+- Enterprise API gateway platforms (Apigee, Kong, AWS API Gateway, or Azure APIM — topology design and policy architecture)
+- API security frameworks (OAuth 2.0, OIDC, JWT validation, and threat management)
+- OpenAPI/Swagger specification design and governance standards
+
+**Proficient level required:**
+
+- Service mesh technologies (Istio, Linkerd) for API traffic management
+- GraphQL schema design and federation architecture
+- API lifecycle management and developer portal strategy
+- Kubernetes for API gateway deployment
+
+**Working Knowledge required:**
+
+- Event-driven architectures and event brokers (Kafka, Azure Service Bus) as API integration patterns
+- APIOps methodologies and tooling
+- CI/CD pipeline design for API deployments
+
+**Awareness level expected:**
+
+- AsyncAPI specification for event-driven APIs
+- gRPC and Protocol Buffers for internal service APIs
+- AI-assisted API design and documentation generation tools
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -66,10 +66,30 @@ The API Platform Engineer implements and maintains API management solutions acro
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** API gateway configuration and policy management (Apigee, Kong, or Azure API Management), REST API design principles and OpenAPI/Swagger documentation, API authentication protocols (OAuth 2.0, JWT, API keys)
-- **Proficient level required:** Postman (API testing, documentation, and consumer support), API monitoring and alerting tools, CI/CD pipelines for API deployment, GraphQL implementation basics
-- **Working Knowledge required:** Developer portal content management and consumer onboarding, API transformation and mediation tools, version control for API artefacts (Git/GitHub)
-- **Awareness level expected:** AsyncAPI for event-driven API documentation, GraphQL Federation, gRPC fundamentals for high-performance service APIs
+**Expert level required:**
+
+- API gateway configuration and policy management (Apigee, Kong, or Azure API Management)
+- REST API design principles and OpenAPI/Swagger documentation
+- API authentication protocols (OAuth 2.0, JWT, API keys)
+
+**Proficient level required:**
+
+- Postman (API testing, documentation, and consumer support)
+- API monitoring and alerting tools
+- CI/CD pipelines for API deployment
+- GraphQL implementation basics
+
+**Working Knowledge required:**
+
+- Developer portal content management and consumer onboarding
+- API transformation and mediation tools
+- version control for API artefacts (Git/GitHub)
+
+**Awareness level expected:**
+
+- AsyncAPI for event-driven API documentation
+- GraphQL Federation
+- gRPC fundamentals for high-performance service APIs
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -64,10 +64,29 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** API platform backlog and roadmap management (Jira, Confluence), API lifecycle and deprecation governance, API adoption metrics and developer portal KPI reporting
-- **Proficient level required:** API management platform concepts (Apigee, Kong, or Azure APIM), API developer portal governance and consumer onboarding, OpenAPI/Swagger documentation standards and review
-- **Working Knowledge required:** API security protocol concepts (OAuth 2.0, OIDC) for requirements gathering, GraphQL and event-driven API concepts, CI/CD pipeline integration for API delivery
-- **Awareness level expected:** API monetisation platforms and partner API strategies, AsyncAPI specification for event-driven APIs, AI-assisted API design tooling trends
+**Expert level required:**
+
+- API platform backlog and roadmap management (Jira, Confluence)
+- API lifecycle and deprecation governance
+- API adoption metrics and developer portal KPI reporting
+
+**Proficient level required:**
+
+- API management platform concepts (Apigee, Kong, or Azure APIM)
+- API developer portal governance and consumer onboarding
+- OpenAPI/Swagger documentation standards and review
+
+**Working Knowledge required:**
+
+- API security protocol concepts (OAuth 2.0, OIDC) for requirements gathering
+- GraphQL and event-driven API concepts
+- CI/CD pipeline integration for API delivery
+
+**Awareness level expected:**
+
+- API monetisation platforms and partner API strategies
+- AsyncAPI specification for event-driven APIs
+- AI-assisted API design tooling trends
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -64,10 +64,30 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise API gateway platforms (Apigee, Kong, or Azure APIM — advanced configuration and policy design), OAuth 2.0/OIDC/JWT security implementation and rate limiting strategies, API performance optimisation and caching patterns
-- **Proficient level required:** GraphQL implementations and federation, OpenAPI specification tooling (Postman, Swagger UI), CI/CD automation patterns for API deployment and promotion pipelines, service mesh for API traffic management (Istio)
-- **Working Knowledge required:** API analytics and observability integration, event-driven API architectures (AsyncAPI, Kafka), API monetisation platform concepts
-- **Awareness level expected:** gRPC and Protocol Buffers for high-performance internal APIs, AI-assisted API design and documentation tools, WebAssembly edge API patterns
+**Expert level required:**
+
+- Enterprise API gateway platforms (Apigee, Kong, or Azure APIM — advanced configuration and policy design)
+- OAuth 2.0/OIDC/JWT security implementation and rate limiting strategies
+- API performance optimisation and caching patterns
+
+**Proficient level required:**
+
+- GraphQL implementations and federation
+- OpenAPI specification tooling (Postman, Swagger UI)
+- CI/CD automation patterns for API deployment and promotion pipelines
+- service mesh for API traffic management (Istio)
+
+**Working Knowledge required:**
+
+- API analytics and observability integration
+- event-driven API architectures (AsyncAPI, Kafka)
+- API monetisation platform concepts
+
+**Awareness level expected:**
+
+- gRPC and Protocol Buffers for high-performance internal APIs
+- AI-assisted API design and documentation tools
+- WebAssembly edge API patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/api_strategy_architect.md
+++ b/Roles/app_platforms/api_strategy_architect.md
@@ -77,10 +77,29 @@ The API Strategy Architect defines and governs the organisation's end-to-end API
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** OpenAPI/Swagger and AsyncAPI specification design and governance (Spectral linting and rule set authoring), API lifecycle management (versioning strategy, breaking change impact analysis, and deprecation workflows), API security governance standards (OAuth 2.0/OIDC flows, mTLS, JWT validation, and OWASP API Security Top 10)
-- **Proficient level required:** API gateway platforms (Azure API Management, AWS API Gateway, Kong, or Apigee — governance capability assessment and tiering standards), Pact and Pact Broker (consumer-driven contract testing integration in CI/CD pipelines), Backstage API catalogue (discoverability standards, metadata governance, and API catalogue management)
-- **Working Knowledge required:** GraphQL schema governance tooling (GraphQL Inspector, Apollo Studio), gRPC and Protocol Buffers (internal service API design standards and governance), API monetisation models and developer portal strategy design
-- **Awareness level expected:** AI-assisted API design and documentation generation tools, CNCF CloudEvents specification for event-driven API governance, WebAssembly edge API patterns and their impact on API governance frameworks
+**Expert level required:**
+
+- OpenAPI/Swagger and AsyncAPI specification design and governance (Spectral linting and rule set authoring)
+- API lifecycle management (versioning strategy, breaking change impact analysis, and deprecation workflows)
+- API security governance standards (OAuth 2.0/OIDC flows, mTLS, JWT validation, and OWASP API Security Top 10)
+
+**Proficient level required:**
+
+- API gateway platforms (Azure API Management, AWS API Gateway, Kong, or Apigee — governance capability assessment and tiering standards)
+- Pact and Pact Broker (consumer-driven contract testing integration in CI/CD pipelines)
+- Backstage API catalogue (discoverability standards, metadata governance, and API catalogue management)
+
+**Working Knowledge required:**
+
+- GraphQL schema governance tooling (GraphQL Inspector, Apollo Studio)
+- gRPC and Protocol Buffers (internal service API design standards and governance)
+- API monetisation models and developer portal strategy design
+
+**Awareness level expected:**
+
+- AI-assisted API design and documentation generation tools
+- CNCF CloudEvents specification for event-driven API governance
+- WebAssembly edge API patterns and their impact on API governance frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -64,10 +64,29 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ASP.NET Core and Web API (design patterns and enterprise reference architectures), C# and .NET 5+ (advanced language features and platform architecture), .NET security frameworks (identity, authentication, and authorisation patterns)
-- **Proficient level required:** Azure App Service and Azure Functions (cloud-native .NET deployment architectures), Entity Framework and data access patterns at scale, .NET containerization and Kubernetes deployment design
-- **Working Knowledge required:** .NET observability patterns (OpenTelemetry, Application Insights integration), API gateway and service mesh integration with .NET workloads, Azure DevOps CI/CD pipeline design for .NET
-- **Awareness level expected:** Blazor and WebAssembly for .NET web UI patterns, Dapr distributed application runtime, .NET MAUI for cross-platform mobile and desktop
+**Expert level required:**
+
+- ASP.NET Core and Web API (design patterns and enterprise reference architectures)
+- C# and .NET 5+ (advanced language features and platform architecture)
+- .NET security frameworks (identity, authentication, and authorisation patterns)
+
+**Proficient level required:**
+
+- Azure App Service and Azure Functions (cloud-native .NET deployment architectures)
+- Entity Framework and data access patterns at scale
+- .NET containerization and Kubernetes deployment design
+
+**Working Knowledge required:**
+
+- .NET observability patterns (OpenTelemetry, Application Insights integration)
+- API gateway and service mesh integration with .NET workloads
+- Azure DevOps CI/CD pipeline design for .NET
+
+**Awareness level expected:**
+
+- Blazor and WebAssembly for .NET web UI patterns
+- Dapr distributed application runtime
+- .NET MAUI for cross-platform mobile and desktop
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -64,10 +64,28 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** C# and .NET Core/.NET 5+ (feature implementation and OOP principles), ASP.NET MVC and Web API (endpoint and controller development), .NET testing frameworks (xUnit, NUnit, or MSTest — unit and integration testing)
-- **Proficient level required:** Entity Framework and ORM-based data access patterns, NuGet package management and dependency consumption, Git and Azure DevOps for version control and CI/CD, SQL Server or equivalent relational database
-- **Working Knowledge required:** HTML, CSS, and JavaScript (basic web development context), .NET CLI and MSBuild (build tooling and project management), dependency injection patterns in .NET applications
-- **Awareness level expected:** .NET containerization with Docker, Blazor/WebAssembly for front-end components, cloud deployment basics on Azure App Service
+**Expert level required:**
+
+- C# and .NET Core/.NET 5+ (feature implementation and OOP principles)
+- ASP.NET MVC and Web API (endpoint and controller development)
+- .NET testing frameworks (xUnit, NUnit, or MSTest — unit and integration testing)
+
+**Proficient level required:**
+
+- Entity Framework and ORM-based data access patterns
+- NuGet package management and dependency consumption
+- Git and Azure DevOps for version control and CI/CD
+- SQL Server or equivalent relational database
+
+**Working Knowledge required:**
+
+- HTML, CSS, and JavaScript (basic web development context), .NET CLI and MSBuild (build tooling and project management), dependency injection patterns in .NET applications
+
+**Awareness level expected:**
+
+- .NET containerization with Docker
+- Blazor/WebAssembly for front-end components
+- cloud deployment basics on Azure App Service
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -64,10 +64,29 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** .NET platform roadmap management and backlog prioritisation (Jira, Azure DevOps), NuGet ecosystem governance and package versioning strategy, developer adoption metrics and platform satisfaction scoring
-- **Proficient level required:** .NET application lifecycle management and version upgrade planning, Azure cloud deployment concepts for .NET workload hosting, .NET security scanning and compliance oversight frameworks
-- **Working Knowledge required:** .NET testing frameworks and code quality tooling (SonarQube), CI/CD pipeline concepts for .NET delivery, artifact repository management (NuGet Gallery, GitHub Packages)
-- **Awareness level expected:** .NET MAUI and cross-platform development expansion trends, AI-assisted .NET development tooling impacts (GitHub Copilot), Blazor/WebAssembly adoption for front-end patterns
+**Expert level required:**
+
+- .NET platform roadmap management and backlog prioritisation (Jira, Azure DevOps)
+- NuGet ecosystem governance and package versioning strategy
+- developer adoption metrics and platform satisfaction scoring
+
+**Proficient level required:**
+
+- .NET application lifecycle management and version upgrade planning
+- Azure cloud deployment concepts for .NET workload hosting
+- .NET security scanning and compliance oversight frameworks
+
+**Working Knowledge required:**
+
+- .NET testing frameworks and code quality tooling (SonarQube)
+- CI/CD pipeline concepts for .NET delivery
+- artifact repository management (NuGet Gallery, GitHub Packages)
+
+**Awareness level expected:**
+
+- .NET MAUI and cross-platform development expansion trends
+- AI-assisted .NET development tooling impacts (GitHub Copilot)
+- Blazor/WebAssembly adoption for front-end patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -64,10 +64,29 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ASP.NET Core and advanced Web API patterns (middleware, filters, authentication pipelines), C# advanced language features and .NET 5+ platform capabilities, .NET dependency injection architecture and service container design
-- **Proficient level required:** Entity Framework advanced data access and query optimisation, NuGet package authoring and lifecycle governance, .NET security libraries and OWASP mitigation patterns
-- **Working Knowledge required:** .NET containerization and Kubernetes deployment (CKAD patterns), Azure DevOps/GitHub Actions advanced CI/CD for .NET, .NET performance diagnostics and profiling tools
-- **Awareness level expected:** Blazor WebAssembly and .NET MAUI cross-platform trends, Dapr distributed application runtime, AI pair programming impacts on .NET framework quality
+**Expert level required:**
+
+- ASP.NET Core and advanced Web API patterns (middleware, filters, authentication pipelines)
+- C# advanced language features and .NET 5+ platform capabilities
+- .NET dependency injection architecture and service container design
+
+**Proficient level required:**
+
+- Entity Framework advanced data access and query optimisation
+- NuGet package authoring and lifecycle governance
+- .NET security libraries and OWASP mitigation patterns
+
+**Working Knowledge required:**
+
+- .NET containerization and Kubernetes deployment (CKAD patterns)
+- Azure DevOps/GitHub Actions advanced CI/CD for .NET
+- .NET performance diagnostics and profiling tools
+
+**Awareness level expected:**
+
+- Blazor WebAssembly and .NET MAUI cross-platform trends
+- Dapr distributed application runtime
+- AI pair programming impacts on .NET framework quality
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -64,10 +64,29 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Spring Framework ecosystem (Spring Boot, Spring Cloud, Spring Security — architecture standards and governance), Java/JVM performance tuning and profiling, microservices architecture patterns (service decomposition, circuit breaker, saga)
-- **Proficient level required:** Maven and Gradle (build tools, dependency governance, and multi-module project design), Java security frameworks and OWASP security patterns, containerization and Kubernetes deployment strategies for Java workloads
-- **Working Knowledge required:** Jakarta EE specifications and migration patterns, Java observability (OpenTelemetry, Micrometer, APM tools), API design and management for Java microservices
-- **Awareness level expected:** GraalVM native image compilation, Project Loom virtual threads, Quarkus and Micronaut cloud-native Java frameworks
+**Expert level required:**
+
+- Spring Framework ecosystem (Spring Boot, Spring Cloud, Spring Security — architecture standards and governance)
+- Java/JVM performance tuning and profiling
+- microservices architecture patterns (service decomposition, circuit breaker, saga)
+
+**Proficient level required:**
+
+- Maven and Gradle (build tools, dependency governance, and multi-module project design)
+- Java security frameworks and OWASP security patterns
+- containerization and Kubernetes deployment strategies for Java workloads
+
+**Working Knowledge required:**
+
+- Jakarta EE specifications and migration patterns
+- Java observability (OpenTelemetry, Micrometer, APM tools)
+- API design and management for Java microservices
+
+**Awareness level expected:**
+
+- GraalVM native image compilation
+- Project Loom virtual threads
+- Quarkus and Micronaut cloud-native Java frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -64,10 +64,30 @@ The Java Engineer implements and maintains Java-based applications and platform 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Java language (JDK 8-17) and object-oriented programming principles, Spring Framework (Spring Boot, Spring MVC, Spring Data), JUnit and Mockito (unit and integration testing)
-- **Proficient level required:** Maven or Gradle (build tools and dependency management), JPA/Hibernate for relational data access, RESTful API development (REST controllers, HTTP standards), SQL database connectivity (JDBC)
-- **Working Knowledge required:** Git version control and branching basics, CI/CD pipeline basics (Jenkins or GitLab CI), Docker container fundamentals for Java applications
-- **Awareness level expected:** Kubernetes for Java deployment targets, Spring Cloud for microservices patterns, reactive programming with Spring WebFlux
+**Expert level required:**
+
+- Java language (JDK 8-17) and object-oriented programming principles
+- Spring Framework (Spring Boot, Spring MVC, Spring Data)
+- JUnit and Mockito (unit and integration testing)
+
+**Proficient level required:**
+
+- Maven or Gradle (build tools and dependency management)
+- JPA/Hibernate for relational data access
+- RESTful API development (REST controllers, HTTP standards)
+- SQL database connectivity (JDBC)
+
+**Working Knowledge required:**
+
+- Git version control and branching basics
+- CI/CD pipeline basics (Jenkins or GitLab CI)
+- Docker container fundamentals for Java applications
+
+**Awareness level expected:**
+
+- Kubernetes for Java deployment targets
+- Spring Cloud for microservices patterns
+- reactive programming with Spring WebFlux
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -64,10 +64,29 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Java platform product backlog management and roadmap delivery (Jira, Confluence), Spring Framework adoption and stakeholder reporting for platform decisions, Java version lifecycle and upgrade governance
-- **Proficient level required:** Java build ecosystem (Maven/Gradle) for platform oversight and dependency governance, artifact repository management (Nexus/JFrog), Java security scanning and compliance monitoring
-- **Working Knowledge required:** Java testing frameworks and code quality metrics, cloud deployment services for Java workloads, CI/CD pipeline integration concepts for Java delivery workflows
-- **Awareness level expected:** Quarkus and Micronaut cloud-native Java framework adoption trends, GraalVM native compilation impacts, AI-assisted Java development tool effects on team productivity
+**Expert level required:**
+
+- Java platform product backlog management and roadmap delivery (Jira, Confluence)
+- Spring Framework adoption and stakeholder reporting for platform decisions
+- Java version lifecycle and upgrade governance
+
+**Proficient level required:**
+
+- Java build ecosystem (Maven/Gradle) for platform oversight and dependency governance
+- artifact repository management (Nexus/JFrog)
+- Java security scanning and compliance monitoring
+
+**Working Knowledge required:**
+
+- Java testing frameworks and code quality metrics
+- cloud deployment services for Java workloads
+- CI/CD pipeline integration concepts for Java delivery workflows
+
+**Awareness level expected:**
+
+- Quarkus and Micronaut cloud-native Java framework adoption trends
+- GraalVM native compilation impacts
+- AI-assisted Java development tool effects on team productivity
 
 ## Interactions with Other Roles
 

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -64,10 +64,30 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Spring Framework ecosystem (Spring Boot, Spring Cloud, Spring Security — advanced implementation and optimisation), Java/JVM performance tuning (GC analysis, heap profiling, thread contention), microservices design patterns (circuit breaker, saga, outbox)
-- **Proficient level required:** Java security configuration (OWASP dependency audit, SAST integration), Maven/Gradle advanced multi-module project management, Java containerization and Kubernetes deployment, TestContainers and integration testing strategies
-- **Working Knowledge required:** Cloud-native Java development patterns (AWS/Azure Java SDKs, GraalVM awareness), CI/CD pipeline integration for Java (GitHub Actions or Jenkins), Jakarta EE specifications and migration context
-- **Awareness level expected:** Project Loom virtual threads and structured concurrency, GraalVM native image for microservice performance, reactive programming patterns (Spring WebFlux/Project Reactor)
+**Expert level required:**
+
+- Spring Framework ecosystem (Spring Boot, Spring Cloud, Spring Security — advanced implementation and optimisation)
+- Java/JVM performance tuning (GC analysis, heap profiling, thread contention)
+- microservices design patterns (circuit breaker, saga, outbox)
+
+**Proficient level required:**
+
+- Java security configuration (OWASP dependency audit, SAST integration)
+- Maven/Gradle advanced multi-module project management
+- Java containerization and Kubernetes deployment
+- TestContainers and integration testing strategies
+
+**Working Knowledge required:**
+
+- Cloud-native Java development patterns (AWS/Azure Java SDKs, GraalVM awareness)
+- CI/CD pipeline integration for Java (GitHub Actions or Jenkins)
+- Jakarta EE specifications and migration context
+
+**Awareness level expected:**
+
+- Project Loom virtual threads and structured concurrency
+- GraalVM native image for microservice performance
+- reactive programming patterns (Spring WebFlux/Project Reactor)
 
 ## Interactions with Other Roles
 

--- a/Roles/client_platform/client_platform_architect.md
+++ b/Roles/client_platform/client_platform_architect.md
@@ -89,10 +89,36 @@ This role operates at the intersection of engineering rigour and business strate
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows 10/11 WIM/OSD pipeline design and DISM, Windows Autopilot zero-touch provisioning, Jamf Pro macOS fleet management and configuration profiles, PowerShell scripting for OS automation
-- **Proficient level required:** Apple Business Manager (ABM) and macOS MDM profile design, Linux desktop fleet management with Ansible or Puppet (Ubuntu LTS), MSIX and Win32 application packaging standards, CIS Benchmark and DISA STIG hardening for client OS, Windows Update for Business ring design and Autopatch architecture
-- **Working Knowledge required:** Fleet.dm cross-platform endpoint telemetry, Homebrew cask packaging, .deb/.rpm Linux packaging, Lenovo System Update and Lenovo Thin Installer for BIOS/firmware and driver deployment, MDT/WDS (legacy context for deprecation planning), Microsoft Intune and SCCM co-management integration patterns
-- **Awareness level expected:** Declarative Device Management (DDM) for macOS, Linux desktop management evolution (systemd-based provisioning), hardware attestation and Pluton/secure boot developments, emerging zero-touch models for Linux
+**Expert level required:**
+
+- Windows 10/11 WIM/OSD pipeline design and DISM
+- Windows Autopilot zero-touch provisioning
+- Jamf Pro macOS fleet management and configuration profiles
+- PowerShell scripting for OS automation
+
+**Proficient level required:**
+
+- Apple Business Manager (ABM) and macOS MDM profile design
+- Linux desktop fleet management with Ansible or Puppet (Ubuntu LTS)
+- MSIX and Win32 application packaging standards
+- CIS Benchmark and DISA STIG hardening for client OS
+- Windows Update for Business ring design and Autopatch architecture
+
+**Working Knowledge required:**
+
+- Fleet.dm cross-platform endpoint telemetry
+- Homebrew cask packaging
+- .deb/.rpm Linux packaging
+- Lenovo System Update and Lenovo Thin Installer for BIOS/firmware and driver deployment
+- MDT/WDS (legacy context for deprecation planning)
+- Microsoft Intune and SCCM co-management integration patterns
+
+**Awareness level expected:**
+
+- Declarative Device Management (DDM) for macOS
+- Linux desktop management evolution (systemd-based provisioning)
+- hardware attestation and Pluton/secure boot developments
+- emerging zero-touch models for Linux
 
 ### Qualifications
 

--- a/Roles/client_platform/client_platform_engineer.md
+++ b/Roles/client_platform/client_platform_engineer.md
@@ -83,10 +83,34 @@ The Engineer plays a critical role in the device lifecycle — from imaging new 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows 11 cumulative update integration via DISM, device setup and imaging workflows for Windows Autopilot and Apple Business Manager enrolment
-- **Proficient level required:** Win32 application packaging with Intune Content Prep Tool, Jamf Pro basic policy and package deployment, apt/dpkg package management on Ubuntu LTS, basic PowerShell scripting for Windows remediation tasks
-- **Working Knowledge required:** MSIX packaging basics, macOS .pkg creation, Jamf software update policies, WUfB patch compliance report interpretation, Windows event log and MDM log analysis for troubleshooting
-- **Awareness level expected:** Ansible basics for Linux configuration management, Homebrew cask authoring structure, MSIX Packaging Tool advanced features, CIS Benchmark client hardening concepts, Lenovo System Update and Thin Installer for BIOS/firmware management, Apple Silicon M-series application compatibility (Rosetta 2, Universal Binary)
+**Expert level required:**
+
+- Windows 11 cumulative update integration via DISM
+- device setup and imaging workflows for Windows Autopilot and Apple Business Manager enrolment
+
+**Proficient level required:**
+
+- Win32 application packaging with Intune Content Prep Tool
+- Jamf Pro basic policy and package deployment
+- apt/dpkg package management on Ubuntu LTS
+- basic PowerShell scripting for Windows remediation tasks
+
+**Working Knowledge required:**
+
+- MSIX packaging basics
+- macOS .pkg creation
+- Jamf software update policies
+- WUfB patch compliance report interpretation
+- Windows event log and MDM log analysis for troubleshooting
+
+**Awareness level expected:**
+
+- Ansible basics for Linux configuration management
+- Homebrew cask authoring structure
+- MSIX Packaging Tool advanced features
+- CIS Benchmark client hardening concepts
+- Lenovo System Update and Thin Installer for BIOS/firmware management
+- Apple Silicon M-series application compatibility (Rosetta 2, Universal Binary)
 
 ### Qualifications
 

--- a/Roles/client_platform/client_platform_product_owner.md
+++ b/Roles/client_platform/client_platform_product_owner.md
@@ -90,10 +90,31 @@ The Product Owner is accountable for ensuring the team delivers measurable outco
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Jira or Azure DevOps backlog management and sprint planning, stakeholder reporting and dashboard creation (Power BI or equivalent), hardware refresh planning and lifecycle budget management
-- **Proficient level required:** Client estate health reporting (Intune Endpoint Analytics, Jamf Pro dashboards, WUfB Reports), application packaging intake and triage process management, OS lifecycle roadmap management (Windows, macOS, Ubuntu LTS release cycles)
-- **Working Knowledge required:** Windows Update for Business compliance concepts, Jamf Pro reporting basics, Microsoft Intune device compliance overview, agile ceremonies and delivery metrics (velocity, cycle time, lead time)
-- **Awareness level expected:** OS image build concepts (WIM, DISM, task sequences), zero-touch provisioning workflows (Autopilot, ABM), application packaging formats (MSIX, .pkg, .deb), CIS benchmark hardening concepts
+**Expert level required:**
+
+- Jira or Azure DevOps backlog management and sprint planning
+- stakeholder reporting and dashboard creation (Power BI or equivalent)
+- hardware refresh planning and lifecycle budget management
+
+**Proficient level required:**
+
+- Client estate health reporting (Intune Endpoint Analytics, Jamf Pro dashboards, WUfB Reports)
+- application packaging intake and triage process management
+- OS lifecycle roadmap management (Windows, macOS, Ubuntu LTS release cycles)
+
+**Working Knowledge required:**
+
+- Windows Update for Business compliance concepts
+- Jamf Pro reporting basics
+- Microsoft Intune device compliance overview
+- agile ceremonies and delivery metrics (velocity, cycle time, lead time)
+
+**Awareness level expected:**
+
+- OS image build concepts (WIM, DISM, task sequences)
+- zero-touch provisioning workflows (Autopilot, ABM)
+- application packaging formats (MSIX, .pkg, .deb)
+- CIS benchmark hardening concepts
 
 ### Qualifications
 

--- a/Roles/client_platform/client_platform_senior_engineer.md
+++ b/Roles/client_platform/client_platform_senior_engineer.md
@@ -84,10 +84,36 @@ This role provides technical leadership and mentoring to Client Platform Enginee
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows 11 DISM/WIM build pipeline and monthly update integration, MSIX and Win32 application packaging for Intune, PowerShell scripting for OS automation and Graph API, Jamf Pro policy and configuration profile management
-- **Proficient level required:** Windows Autopilot (pre-provisioning and self-deploy), Apple Business Manager zero-touch enrolment, Ansible playbook and role authoring for Linux desktop (Ubuntu LTS), Homebrew cask and .deb packaging, Windows Update for Business ring management and Autopatch
-- **Working Knowledge required:** Jamf software update management, apt/dnf patch pipeline management, Python scripting for cross-platform automation, CIS Benchmark hardening implementation, Lenovo driver pack management and Lenovo System Update / Thin Installer workflows, hardware driver compatibility testing
-- **Awareness level expected:** Fleet.dm cross-platform telemetry, Declarative Device Management (DDM) for macOS, MDT/WDS legacy context, Microsoft Intune Autopatch advanced ring customisation
+**Expert level required:**
+
+- Windows 11 DISM/WIM build pipeline and monthly update integration
+- MSIX and Win32 application packaging for Intune
+- PowerShell scripting for OS automation and Graph API
+- Jamf Pro policy and configuration profile management
+
+**Proficient level required:**
+
+- Windows Autopilot (pre-provisioning and self-deploy)
+- Apple Business Manager zero-touch enrolment
+- Ansible playbook and role authoring for Linux desktop (Ubuntu LTS)
+- Homebrew cask and .deb packaging
+- Windows Update for Business ring management and Autopatch
+
+**Working Knowledge required:**
+
+- Jamf software update management
+- apt/dnf patch pipeline management
+- Python scripting for cross-platform automation
+- CIS Benchmark hardening implementation
+- Lenovo driver pack management and Lenovo System Update / Thin Installer workflows
+- hardware driver compatibility testing
+
+**Awareness level expected:**
+
+- Fleet.dm cross-platform telemetry
+- Declarative Device Management (DDM) for macOS
+- MDT/WDS legacy context
+- Microsoft Intune Autopatch advanced ring customisation
 
 ### Qualifications
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -72,10 +72,28 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** AWS Well-Architected Framework, AWS Control Tower and multi-account strategy (AWS Organizations), AWS networking (Transit Gateway, Direct Connect, PrivateLink, VPC design), AWS IAM and security services (GuardDuty, Security Hub, Config, Macie)
-- **Proficient level required:** Infrastructure as Code (CloudFormation, CDK, Terraform/OpenTofu), AWS monitoring and observability (CloudWatch, X-Ray, AWS Distro for OpenTelemetry), AWS cost management (Cost Explorer, Savings Plans, Reserved Instances, Trusted Advisor)
-- **Working Knowledge required:** Amazon EKS and container orchestration architecture, Amazon Bedrock and AWS GenAI services architecture
-- **Awareness level expected:** Amazon SageMaker AI/ML platform design patterns, AWS GovCloud and Digital Sovereignty Pledge compliance patterns for regulated industries
+**Expert level required:**
+
+- AWS Well-Architected Framework
+- AWS Control Tower and multi-account strategy (AWS Organizations)
+- AWS networking (Transit Gateway, Direct Connect, PrivateLink, VPC design)
+- AWS IAM and security services (GuardDuty, Security Hub, Config, Macie)
+
+**Proficient level required:**
+
+- Infrastructure as Code (CloudFormation, CDK, Terraform/OpenTofu)
+- AWS monitoring and observability (CloudWatch, X-Ray, AWS Distro for OpenTelemetry)
+- AWS cost management (Cost Explorer, Savings Plans, Reserved Instances, Trusted Advisor)
+
+**Working Knowledge required:**
+
+- Amazon EKS and container orchestration architecture
+- Amazon Bedrock and AWS GenAI services architecture
+
+**Awareness level expected:**
+
+- Amazon SageMaker AI/ML platform design patterns
+- AWS GovCloud and Digital Sovereignty Pledge compliance patterns for regulated industries
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -64,10 +64,23 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Amazon EC2, Auto Scaling groups, and Elastic Load Balancing for compute management, Amazon VPC, subnets, security groups, and route table configuration, AWS IAM (users, roles, policies, and service account management), Amazon S3 and core storage services (EBS, EFS, Glacier)
-- **Proficient level required:** AWS CloudFormation and AWS CDK for infrastructure deployment within approved patterns, Amazon CloudWatch for monitoring, alerting, and log management, AWS Systems Manager for patching, parameter store, and operational management
-- **Working Knowledge required:** Amazon RDS and managed database services (deployment, backup, parameter groups), AWS Backup and disaster recovery services for cloud resource protection
-- **Awareness level expected:** Amazon ECS and EKS for container-hosted workloads, AWS Lambda and serverless application patterns
+**Expert level required:**
+
+- Amazon EC2, Auto Scaling groups, and Elastic Load Balancing for compute management, Amazon VPC, subnets, security groups, and route table configuration, AWS IAM (users, roles, policies, and service account management), Amazon S3 and core storage services (EBS, EFS, Glacier)
+
+**Proficient level required:**
+
+- AWS CloudFormation and AWS CDK for infrastructure deployment within approved patterns, Amazon CloudWatch for monitoring, alerting, and log management, AWS Systems Manager for patching, parameter store, and operational management
+
+**Working Knowledge required:**
+
+- Amazon RDS and managed database services (deployment, backup, parameter groups)
+- AWS Backup and disaster recovery services for cloud resource protection
+
+**Awareness level expected:**
+
+- Amazon ECS and EKS for container-hosted workloads
+- AWS Lambda and serverless application patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -64,10 +64,23 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Agile product ownership tools (Jira, Confluence) for AWS platform backlog, sprint ceremonies, and roadmap management, FinOps Foundation Framework for cloud financial accountability, cost governance, and chargeback prioritisation, AWS service portfolio and AWS Cloud Adoption Framework for strategic roadmap planning and adoption sequencing
-- **Proficient level required:** AWS Cost Explorer, AWS Budgets, and Cost and Usage Report (CUR) for cost visibility, anomaly awareness, and governance decisions, Power BI or Tableau for cloud platform performance dashboards and stakeholder reporting, AWS Control Tower and multi-account governance concepts for product scope and compliance decision-making
-- **Working Knowledge required:** AWS landing zone design and account structure for informing governance and onboarding product decisions, AWS security services (GuardDuty, Security Hub, AWS Config) from a compliance posture and product strategy perspective
-- **Awareness level expected:** AWS AI/ML services (Bedrock, SageMaker) for evaluating future platform capability roadmap items, AWS GovCloud and Digital Sovereignty controls for regulated industry cloud adoption context
+**Expert level required:**
+
+- Agile product ownership tools (Jira, Confluence) for AWS platform backlog, sprint ceremonies, and roadmap management, FinOps Foundation Framework for cloud financial accountability, cost governance, and chargeback prioritisation, AWS service portfolio and AWS Cloud Adoption Framework for strategic roadmap planning and adoption sequencing
+
+**Proficient level required:**
+
+- AWS Cost Explorer, AWS Budgets, and Cost and Usage Report (CUR) for cost visibility, anomaly awareness, and governance decisions, Power BI or Tableau for cloud platform performance dashboards and stakeholder reporting, AWS Control Tower and multi-account governance concepts for product scope and compliance decision-making
+
+**Working Knowledge required:**
+
+- AWS landing zone design and account structure for informing governance and onboarding product decisions
+- AWS security services (GuardDuty, Security Hub, AWS Config) from a compliance posture and product strategy perspective
+
+**Awareness level expected:**
+
+- AWS AI/ML services (Bedrock, SageMaker) for evaluating future platform capability roadmap items
+- AWS GovCloud and Digital Sovereignty controls for regulated industry cloud adoption context
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -64,10 +64,28 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Infrastructure as Code (CloudFormation, CDK, Terraform) for complex AWS deployments, AWS networking (VPC, Transit Gateway, Direct Connect, PrivateLink, VPC peering), AWS security services (IAM, GuardDuty, Security Hub, AWS Config, Macie), AWS container services (ECS, EKS) and serverless (Lambda, API Gateway, Step Functions)
-- **Proficient level required:** AWS CI/CD services (CodePipeline, CodeBuild, CodeDeploy) and GitHub Actions integration, AWS monitoring and observability (CloudWatch, X-Ray, AWS Distro for OpenTelemetry), AWS cost management (Cost Explorer, Trusted Advisor, Service Control Policies)
-- **Working Knowledge required:** Multi-account AWS strategies (AWS Organizations, Control Tower, Account Factory), AWS hybrid cloud technologies (Direct Connect, Site-to-Site VPN, Outposts)
-- **Awareness level expected:** Amazon Bedrock and AWS GenAI services for AI workload deployments, AWS GovCloud and compliance frameworks (FedRAMP, PCI DSS, HIPAA on AWS)
+**Expert level required:**
+
+- Infrastructure as Code (CloudFormation, CDK, Terraform) for complex AWS deployments
+- AWS networking (VPC, Transit Gateway, Direct Connect, PrivateLink, VPC peering)
+- AWS security services (IAM, GuardDuty, Security Hub, AWS Config, Macie)
+- AWS container services (ECS, EKS) and serverless (Lambda, API Gateway, Step Functions)
+
+**Proficient level required:**
+
+- AWS CI/CD services (CodePipeline, CodeBuild, CodeDeploy) and GitHub Actions integration
+- AWS monitoring and observability (CloudWatch, X-Ray, AWS Distro for OpenTelemetry)
+- AWS cost management (Cost Explorer, Trusted Advisor, Service Control Policies)
+
+**Working Knowledge required:**
+
+- Multi-account AWS strategies (AWS Organizations, Control Tower, Account Factory)
+- AWS hybrid cloud technologies (Direct Connect, Site-to-Site VPN, Outposts)
+
+**Awareness level expected:**
+
+- Amazon Bedrock and AWS GenAI services for AI workload deployments
+- AWS GovCloud and compliance frameworks (FedRAMP, PCI DSS, HIPAA on AWS)
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -64,10 +64,25 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure Virtual Machines, VM Scale Sets, and compute services management, Azure Virtual Networks, subnets, NSGs, and route table configuration, Microsoft Entra ID and Azure RBAC for identity and access management, ARM Templates and Bicep for infrastructure deployment
-- **Proficient level required:** Azure CLI and PowerShell for resource provisioning and day-to-day operations, Azure Monitor and Log Analytics for monitoring configuration and alert management, Azure Storage (Blob, Files, Disks) and Azure Backup for data protection
-- **Working Knowledge required:** Azure Kubernetes Service (AKS) basics for supporting container workloads, Microsoft Defender for Cloud for security compliance visibility
-- **Awareness level expected:** Azure DevOps pipelines and GitHub Actions for CI/CD integration, Terraform for Azure as a multi-cloud IaC progression path
+**Expert level required:**
+
+- Azure Virtual Machines, VM Scale Sets, and compute services management, Azure Virtual Networks, subnets, NSGs, and route table configuration, Microsoft Entra ID and Azure RBAC for identity and access management, ARM Templates and Bicep for infrastructure deployment
+
+**Proficient level required:**
+
+- Azure CLI and PowerShell for resource provisioning and day-to-day operations
+- Azure Monitor and Log Analytics for monitoring configuration and alert management
+- Azure Storage (Blob, Files, Disks) and Azure Backup for data protection
+
+**Working Knowledge required:**
+
+- Azure Kubernetes Service (AKS) basics for supporting container workloads
+- Microsoft Defender for Cloud for security compliance visibility
+
+**Awareness level expected:**
+
+- Azure DevOps pipelines and GitHub Actions for CI/CD integration
+- Terraform for Azure as a multi-cloud IaC progression path
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -64,10 +64,23 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Agile product ownership tools (Jira, Confluence, Azure Boards) for Azure platform backlog, sprint planning, and roadmap tracking, FinOps Foundation Framework and Azure Cost Management for cloud financial accountability and cost governance, Microsoft Azure service portfolio and Azure Cloud Adoption Framework (CAF) for strategic roadmap planning and modernisation prioritisation
-- **Proficient level required:** Azure Cost Management, Azure Advisor, and Azure Budgets for cost visibility, governance decisions, and optimisation priority-setting, Power BI and Azure cost dashboards for platform performance reporting and stakeholder communication, Azure landing zone design and subscription governance concepts for informing product scope and compliance decisions
-- **Working Knowledge required:** Microsoft Entra ID and Microsoft Defender for Cloud from a security compliance posture and product strategy perspective, Azure DevOps and GitHub Actions for understanding CI/CD delivery pipeline capabilities relevant to acceptance criteria
-- **Awareness level expected:** Azure AI Foundry and Azure OpenAI Service for evaluating future platform capability roadmap items, Azure Arc and hybrid cloud patterns for cross-platform adoption product strategy
+**Expert level required:**
+
+- Agile product ownership tools (Jira, Confluence, Azure Boards) for Azure platform backlog, sprint planning, and roadmap tracking, FinOps Foundation Framework and Azure Cost Management for cloud financial accountability and cost governance, Microsoft Azure service portfolio and Azure Cloud Adoption Framework (CAF) for strategic roadmap planning and modernisation prioritisation
+
+**Proficient level required:**
+
+- Azure Cost Management, Azure Advisor, and Azure Budgets for cost visibility, governance decisions, and optimisation priority-setting, Power BI and Azure cost dashboards for platform performance reporting and stakeholder communication, Azure landing zone design and subscription governance concepts for informing product scope and compliance decisions
+
+**Working Knowledge required:**
+
+- Microsoft Entra ID and Microsoft Defender for Cloud from a security compliance posture and product strategy perspective
+- Azure DevOps and GitHub Actions for understanding CI/CD delivery pipeline capabilities relevant to acceptance criteria
+
+**Awareness level expected:**
+
+- Azure AI Foundry and Azure OpenAI Service for evaluating future platform capability roadmap items
+- Azure Arc and hybrid cloud patterns for cross-platform adoption product strategy
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -64,10 +64,23 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Infrastructure as Code (Terraform, Bicep, ARM templates) for complex Azure deployments, Advanced Azure networking (ExpressRoute, Virtual WAN, Azure Firewall, Private Endpoints), Azure security services (Microsoft Defender for Cloud, Microsoft Sentinel, Azure Key Vault), Microsoft Entra ID including PIM, Conditional Access, and hybrid identity
-- **Proficient level required:** Azure Kubernetes Service (AKS) and container services deployment and management, Azure DevOps and GitHub Actions for CI/CD pipeline implementation, Azure Monitor, Log Analytics, and Application Insights for full-stack observability
-- **Working Knowledge required:** Azure Policy and management groups for governance and compliance enforcement, Azure Cost Management and resource right-sizing tools
-- **Awareness level expected:** Azure Arc for hybrid and multi-cloud resource management, Azure AI services and Azure OpenAI Service deployment and integration patterns
+**Expert level required:**
+
+- Infrastructure as Code (Terraform, Bicep, ARM templates) for complex Azure deployments, Advanced Azure networking (ExpressRoute, Virtual WAN, Azure Firewall, Private Endpoints), Azure security services (Microsoft Defender for Cloud, Microsoft Sentinel, Azure Key Vault), Microsoft Entra ID including PIM, Conditional Access, and hybrid identity
+
+**Proficient level required:**
+
+- Azure Kubernetes Service (AKS) and container services deployment and management, Azure DevOps and GitHub Actions for CI/CD pipeline implementation, Azure Monitor, Log Analytics, and Application Insights for full-stack observability
+
+**Working Knowledge required:**
+
+- Azure Policy and management groups for governance and compliance enforcement
+- Azure Cost Management and resource right-sizing tools
+
+**Awareness level expected:**
+
+- Azure Arc for hybrid and multi-cloud resource management
+- Azure AI services and Azure OpenAI Service deployment and integration patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -66,10 +66,25 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure, AWS, and GCP architecture governance frameworks (CAF, WAF, AWS Well-Architected, GCP Architecture Framework), Cloud governance platforms (Azure Policy, AWS Service Control Policies, GCP Organization Policy Service), CSPM tooling (Microsoft Defender for Cloud, AWS Security Hub, GCP Security Command Center)
-- **Proficient level required:** Infrastructure as Code (Terraform/OpenTofu, Bicep, CloudFormation, Pulumi) across all three major cloud providers, Multi-cloud networking connectivity patterns (ExpressRoute, Direct Connect, Cloud Interconnect), Identity federation and cross-cloud IAM patterns (OIDC, SAML, workload identity federation)
-- **Working Knowledge required:** FinOps tooling and multi-cloud cost management platforms (CloudHealth, Apptio), Architecture documentation and diagramming tools (C4 model, draw.io, Lucidchart)
-- **Awareness level expected:** Cloud management platforms (Morpheus, Scalr, env0) for multi-cloud orchestration, Cloud-native application protection platform (CNAPP) and CIEM for emerging security posture management
+**Expert level required:**
+
+- Azure, AWS, and GCP architecture governance frameworks (CAF, WAF, AWS Well-Architected, GCP Architecture Framework), Cloud governance platforms (Azure Policy, AWS Service Control Policies, GCP Organization Policy Service), CSPM tooling (Microsoft Defender for Cloud, AWS Security Hub, GCP Security Command Center)
+
+**Proficient level required:**
+
+- Infrastructure as Code (Terraform/OpenTofu, Bicep, CloudFormation, Pulumi) across all three major cloud providers
+- Multi-cloud networking connectivity patterns (ExpressRoute, Direct Connect, Cloud Interconnect)
+- Identity federation and cross-cloud IAM patterns (OIDC, SAML, workload identity federation)
+
+**Working Knowledge required:**
+
+- FinOps tooling and multi-cloud cost management platforms (CloudHealth, Apptio)
+- Architecture documentation and diagramming tools (C4 model, draw.io, Lucidchart)
+
+**Awareness level expected:**
+
+- Cloud management platforms (Morpheus, Scalr, env0) for multi-cloud orchestration
+- Cloud-native application protection platform (CNAPP) and CIEM for emerging security posture management
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -67,10 +67,24 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Multi-cloud architecture strategy across Azure, AWS, and GCP at enterprise scale (landing zones, governance, AI/ML, networking, security), Cloud governance at scale: policy-as-code, CSPM, and multi-cloud management platforms, Enterprise architecture frameworks (TOGAF, Zachman, ArchiMate) applied to cloud strategy
-- **Proficient level required:** Infrastructure as Code at scale (Terraform Enterprise/Cloud, Pulumi Enterprise, platform engineering toolchains), AI/ML platform architecture across all three providers (Azure AI Foundry, AWS SageMaker, Google Vertex AI), Cloud security and identity federation (OIDC, SAML, workload identity federation)
-- **Working Knowledge required:** Cloud financial management strategy and FinOps tooling for multi-year cost modelling, Enterprise architecture tooling (LeanIX, Sparx EA, ArchiMate) for cloud strategy documentation
-- **Awareness level expected:** Emerging CNAPP, CIEM, and AIOps patterns for next-generation cloud security and operations, Cloud provider advisory programs (Microsoft MVP, AWS Hero, Google Developer Expert) and technology preview adoption signals
+**Expert level required:**
+
+- Multi-cloud architecture strategy across Azure, AWS, and GCP at enterprise scale (landing zones, governance, AI/ML, networking, security), Cloud governance at scale: policy-as-code, CSPM, and multi-cloud management platforms, Enterprise architecture frameworks (TOGAF, Zachman, ArchiMate) applied to cloud strategy
+
+**Proficient level required:**
+
+- Infrastructure as Code at scale (Terraform Enterprise/Cloud, Pulumi Enterprise, platform engineering toolchains)
+- AI/ML platform architecture across all three providers (Azure AI Foundry, AWS SageMaker, Google Vertex AI)
+- Cloud security and identity federation (OIDC, SAML, workload identity federation)
+
+**Working Knowledge required:**
+
+- Cloud financial management strategy and FinOps tooling for multi-year cost modelling
+- Enterprise architecture tooling (LeanIX, Sparx EA, ArchiMate) for cloud strategy documentation
+
+**Awareness level expected:**
+
+- Emerging CNAPP, CIEM, and AIOps patterns for next-generation cloud security and operations, Cloud provider advisory programs (Microsoft MVP, AWS Hero, Google Developer Expert) and technology preview adoption signals
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -65,10 +65,28 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** GCP Architecture Framework and landing zone design (resource hierarchy, folder/project structure), GCP networking (VPC, Cloud Interconnect, Cloud NAT, Network Connectivity Center), GCP IAM and security (IAM, Security Command Center, VPC Service Controls, Organization Policy Service), Google Kubernetes Engine (GKE) and Anthos for hybrid and multi-cloud
-- **Proficient level required:** Infrastructure as Code for GCP (Terraform/OpenTofu, Google Cloud Deployment Manager), BigQuery and data analytics architecture patterns, GCP governance and compliance services (Assured Workloads, Access Transparency)
-- **Working Knowledge required:** Google Vertex AI and Gemini API architecture for GenAI workloads, GCP cost optimization tools (Billing Console, Recommender, Committed Use Discounts)
-- **Awareness level expected:** AlloyDB and Cloud Spanner for enterprise database workloads, Google Sovereign Cloud and Assured Workloads patterns for government and regulated sectors
+**Expert level required:**
+
+- GCP Architecture Framework and landing zone design (resource hierarchy, folder/project structure)
+- GCP networking (VPC, Cloud Interconnect, Cloud NAT, Network Connectivity Center)
+- GCP IAM and security (IAM, Security Command Center, VPC Service Controls, Organization Policy Service)
+- Google Kubernetes Engine (GKE) and Anthos for hybrid and multi-cloud
+
+**Proficient level required:**
+
+- Infrastructure as Code for GCP (Terraform/OpenTofu, Google Cloud Deployment Manager)
+- BigQuery and data analytics architecture patterns
+- GCP governance and compliance services (Assured Workloads, Access Transparency)
+
+**Working Knowledge required:**
+
+- Google Vertex AI and Gemini API architecture for GenAI workloads
+- GCP cost optimization tools (Billing Console, Recommender, Committed Use Discounts)
+
+**Awareness level expected:**
+
+- AlloyDB and Cloud Spanner for enterprise database workloads
+- Google Sovereign Cloud and Assured Workloads patterns for government and regulated sectors
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -64,10 +64,22 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Google Compute Engine, managed instance groups, and instance lifecycle management, Google Kubernetes Engine (GKE) for container workload deployment and operations, Virtual Private Cloud (VPC) networking, firewall rules, Cloud NAT, and Cloud DNS, Cloud IAM and service accounts for resource access management
-- **Proficient level required:** Terraform and Google Cloud Deployment Manager for infrastructure as code deployments, Cloud Storage, Cloud SQL, and core GCP storage and database services, Google Cloud Monitoring, Cloud Logging, and Cloud Trace for observability
-- **Working Knowledge required:** Cloud Functions, Cloud Run, and App Engine for serverless and PaaS workloads, GCP cost management tools (Billing Console, Budget Alerts, GCP Recommender)
-- **Awareness level expected:** BigQuery and Vertex AI for data and ML workloads, GCP security services (Security Command Center, VPC Service Controls) for security posture awareness
+**Expert level required:**
+
+- Google Compute Engine, managed instance groups, and instance lifecycle management, Google Kubernetes Engine (GKE) for container workload deployment and operations, Virtual Private Cloud (VPC) networking, firewall rules, Cloud NAT, and Cloud DNS, Cloud IAM and service accounts for resource access management
+
+**Proficient level required:**
+
+- Terraform and Google Cloud Deployment Manager for infrastructure as code deployments, Cloud Storage, Cloud SQL, and core GCP storage and database services, Google Cloud Monitoring, Cloud Logging, and Cloud Trace for observability
+
+**Working Knowledge required:**
+
+- Cloud Functions, Cloud Run, and App Engine for serverless and PaaS workloads, GCP cost management tools (Billing Console, Budget Alerts, GCP Recommender)
+
+**Awareness level expected:**
+
+- BigQuery and Vertex AI for data and ML workloads
+- GCP security services (Security Command Center, VPC Service Controls) for security posture awareness
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -64,10 +64,23 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Agile product ownership tools (Jira, Confluence) for GCP platform backlog, sprint ceremonies, and roadmap management, FinOps Foundation Framework and GCP Billing Console for cloud financial accountability, cost governance, and optimisation prioritisation, GCP service portfolio (Compute Engine, GKE, BigQuery, data analytics, AI) for strategic roadmap planning and adoption sequencing
-- **Proficient level required:** GCP Billing Console, Budget Alerts, and GCP Recommender for cost governance, anomaly awareness, and optimisation priority-setting, Power BI, Looker Studio, or Tableau for cloud platform performance dashboards and stakeholder reporting, GCP organization hierarchy and project governance for product scope and compliance decision-making
-- **Working Knowledge required:** Cloud IAM and GCP Security Command Center from a compliance posture and product strategy perspective, Cloud Build and GitOps tools (ArgoCD, Flux) for understanding delivery pipeline capabilities relevant to acceptance criteria
-- **Awareness level expected:** Vertex AI and Gemini API services for evaluating future platform capability roadmap items, Google Assured Workloads and Sovereign Cloud for regulated industry cloud adoption strategy and product planning
+**Expert level required:**
+
+- Agile product ownership tools (Jira, Confluence) for GCP platform backlog, sprint ceremonies, and roadmap management, FinOps Foundation Framework and GCP Billing Console for cloud financial accountability, cost governance, and optimisation prioritisation, GCP service portfolio (Compute Engine, GKE, BigQuery, data analytics, AI) for strategic roadmap planning and adoption sequencing
+
+**Proficient level required:**
+
+- GCP Billing Console, Budget Alerts, and GCP Recommender for cost governance, anomaly awareness, and optimisation priority-setting, Power BI, Looker Studio, or Tableau for cloud platform performance dashboards and stakeholder reporting, GCP organization hierarchy and project governance for product scope and compliance decision-making
+
+**Working Knowledge required:**
+
+- Cloud IAM and GCP Security Command Center from a compliance posture and product strategy perspective
+- Cloud Build and GitOps tools (ArgoCD, Flux) for understanding delivery pipeline capabilities relevant to acceptance criteria
+
+**Awareness level expected:**
+
+- Vertex AI and Gemini API services for evaluating future platform capability roadmap items
+- Google Assured Workloads and Sovereign Cloud for regulated industry cloud adoption strategy and product planning
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -64,10 +64,28 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Google Kubernetes Engine (GKE) and Anthos for container management and hybrid deployments, GCP networking (VPC, Cloud Interconnect, Network Connectivity Center, Cloud Armor), Infrastructure as Code (Terraform, Google Cloud Deployment Manager) for GCP automation, GCP security services (IAM, Security Command Center, VPC Service Controls, Binary Authorization)
-- **Proficient level required:** CI/CD for GCP (Cloud Build, GitLab CI, Jenkins) and GitOps integration, GCP monitoring and observability (Cloud Monitoring, Cloud Logging, Cloud Trace, Cloud Profiler), GCP cost management and resource optimization (Billing Console, Recommender, Committed Use Discounts)
-- **Working Knowledge required:** Multi-project GCP strategies and organization hierarchy management (folder structure, Org Policy), GCP data services and analytics (BigQuery, Dataflow, Pub/Sub)
-- **Awareness level expected:** Vertex AI and Gemini APIs for ML and GenAI workload deployments, GCP Assured Workloads and compliance tooling for regulated industries
+**Expert level required:**
+
+- Google Kubernetes Engine (GKE) and Anthos for container management and hybrid deployments
+- GCP networking (VPC, Cloud Interconnect, Network Connectivity Center, Cloud Armor)
+- Infrastructure as Code (Terraform, Google Cloud Deployment Manager) for GCP automation
+- GCP security services (IAM, Security Command Center, VPC Service Controls, Binary Authorization)
+
+**Proficient level required:**
+
+- CI/CD for GCP (Cloud Build, GitLab CI, Jenkins) and GitOps integration
+- GCP monitoring and observability (Cloud Monitoring, Cloud Logging, Cloud Trace, Cloud Profiler)
+- GCP cost management and resource optimization (Billing Console, Recommender, Committed Use Discounts)
+
+**Working Knowledge required:**
+
+- Multi-project GCP strategies and organization hierarchy management (folder structure, Org Policy)
+- GCP data services and analytics (BigQuery, Dataflow, Pub/Sub)
+
+**Awareness level expected:**
+
+- Vertex AI and Gemini APIs for ML and GenAI workload deployments
+- GCP Assured Workloads and compliance tooling for regulated industries
 
 ## Interactions with Other Roles
 

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -77,10 +77,29 @@ The Data Engineer designs, builds, and maintains the data pipelines, transformat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Python and SQL (data pipeline development and complex transformation logic), dbt (transformation model development, testing strategies, and documentation), cloud data platforms (Databricks, Snowflake, BigQuery, or Azure Synapse — production pipeline development and optimisation)
-- **Proficient level required:** Apache Spark/PySpark (large-scale data processing and batch pipeline development), Apache Airflow or Dagster (pipeline orchestration, DAG design, and dependency management), data quality frameworks (dbt tests, Great Expectations, or Soda)
-- **Working Knowledge required:** Delta Lake or Apache Iceberg (lakehouse table formats, partitioning strategies, and compaction operations), REST API and JDBC-based ingestion pipeline development, data catalogue tooling (Databricks Unity Catalog or DataHub — lineage and documentation)
-- **Awareness level expected:** Kafka-based streaming ingestion patterns, Data Vault 2.0 modelling concepts, AI-assisted data engineering tools (GitHub Copilot for pipeline scaffolding)
+**Expert level required:**
+
+- Python and SQL (data pipeline development and complex transformation logic)
+- dbt (transformation model development, testing strategies, and documentation)
+- cloud data platforms (Databricks, Snowflake, BigQuery, or Azure Synapse — production pipeline development and optimisation)
+
+**Proficient level required:**
+
+- Apache Spark/PySpark (large-scale data processing and batch pipeline development)
+- Apache Airflow or Dagster (pipeline orchestration, DAG design, and dependency management)
+- data quality frameworks (dbt tests, Great Expectations, or Soda)
+
+**Working Knowledge required:**
+
+- Delta Lake or Apache Iceberg (lakehouse table formats, partitioning strategies, and compaction operations)
+- REST API and JDBC-based ingestion pipeline development
+- data catalogue tooling (Databricks Unity Catalog or DataHub — lineage and documentation)
+
+**Awareness level expected:**
+
+- Kafka-based streaming ingestion patterns
+- Data Vault 2.0 modelling concepts
+- AI-assisted data engineering tools (GitHub Copilot for pipeline scaffolding)
 
 ## Interactions with Other Roles
 

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -74,10 +74,29 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Data engineering backlog and sprint management (Jira, Azure DevOps), data platform roadmap governance and CDO stakeholder communication, data product SLA and quality threshold definition
-- **Proficient level required:** Databricks/Snowflake/BigQuery (platform familiarity for FinOps and adoption decisions), dbt Cloud usage dashboards and adoption metrics, data quality and observability tool reporting (Monte Carlo, Soda)
-- **Working Knowledge required:** Data catalogue tools (Databricks Unity Catalog, Collibra, DataHub — governance reporting level), data governance concepts (lineage, classification, data mesh), Power BI/Tableau for platform analytics
-- **Awareness level expected:** MLOps and AI feature pipeline concepts, streaming data platform concepts (Kafka, Kinesis), emerging data lakehouse technologies (Apache Iceberg, Apache Hudi)
+**Expert level required:**
+
+- Data engineering backlog and sprint management (Jira, Azure DevOps)
+- data platform roadmap governance and CDO stakeholder communication
+- data product SLA and quality threshold definition
+
+**Proficient level required:**
+
+- Databricks/Snowflake/BigQuery (platform familiarity for FinOps and adoption decisions)
+- dbt Cloud usage dashboards and adoption metrics
+- data quality and observability tool reporting (Monte Carlo, Soda)
+
+**Working Knowledge required:**
+
+- Data catalogue tools (Databricks Unity Catalog, Collibra, DataHub — governance reporting level)
+- data governance concepts (lineage, classification, data mesh)
+- Power BI/Tableau for platform analytics
+
+**Awareness level expected:**
+
+- MLOps and AI feature pipeline concepts
+- streaming data platform concepts (Kafka, Kinesis)
+- emerging data lakehouse technologies (Apache Iceberg, Apache Hudi)
 
 ## Interactions with Other Roles
 

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -80,10 +80,29 @@ The Data Mesh Architect designs and governs the organisation's data mesh archite
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Data mesh governance framework design (domain decomposition model, data product specifications, and federated computational governance model), data catalogue platforms (DataHub, Collibra, or OpenMetadata — federated metadata governance and cross-domain discoverability), Apache Iceberg (open table format governance and cross-engine interoperability standards)
-- **Proficient level required:** Data Contract CLI or Soda (data contract specification, validation, and schema change management), dbt (data product transformation layer standards, testing requirements, and documentation conventions), data observability tooling (Monte Carlo, Bigeye, or Great Expectations — automated quality monitoring and SLA breach alerting)
-- **Working Knowledge required:** Apache Kafka and Confluent Schema Registry (event streaming architecture for real-time data product publishing), Terraform (self-serve data infrastructure provisioning patterns), cloud data platform architectures (Databricks, Snowflake, or BigQuery — data product delivery alignment)
-- **Awareness level expected:** AI data product standards for ML training datasets and feature stores, emerging data mesh tooling (OpenMetadata, Apache Hudi), DataOps CI/CD patterns for domain data product pipelines
+**Expert level required:**
+
+- Data mesh governance framework design (domain decomposition model, data product specifications, and federated computational governance model)
+- data catalogue platforms (DataHub, Collibra, or OpenMetadata — federated metadata governance and cross-domain discoverability)
+- Apache Iceberg (open table format governance and cross-engine interoperability standards)
+
+**Proficient level required:**
+
+- Data Contract CLI or Soda (data contract specification, validation, and schema change management)
+- dbt (data product transformation layer standards, testing requirements, and documentation conventions)
+- data observability tooling (Monte Carlo, Bigeye, or Great Expectations — automated quality monitoring and SLA breach alerting)
+
+**Working Knowledge required:**
+
+- Apache Kafka and Confluent Schema Registry (event streaming architecture for real-time data product publishing)
+- Terraform (self-serve data infrastructure provisioning patterns)
+- cloud data platform architectures (Databricks, Snowflake, or BigQuery — data product delivery alignment)
+
+**Awareness level expected:**
+
+- AI data product standards for ML training datasets and feature stores
+- emerging data mesh tooling (OpenMetadata, Apache Hudi)
+- DataOps CI/CD patterns for domain data product pipelines
 
 ## Interactions with Other Roles
 

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -80,10 +80,29 @@ The Data Platform Engineer builds, maintains, and optimises the shared data plat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Databricks (Delta Lake, Unity Catalog, Workflows, cluster management, and workspace administration), Apache Spark/PySpark (job development, performance tuning, and large-scale transformation workloads), Terraform (infrastructure-as-code provisioning for data platform resources — storage, compute, and Kafka clusters)
-- **Proficient level required:** Delta Lake or Apache Iceberg (ACID transactions, time travel, OPTIMIZE, ZORDER, and VACUUM operations), dbt (transformation framework development, model testing, and deployment pipeline integration), managed ingestion platforms (Azure Data Factory, AWS Glue, or GCP Dataflow)
-- **Working Knowledge required:** Streaming data ingestion (Apache Kafka, Azure Event Hubs, or AWS Kinesis — platform-layer ingestion patterns), Python for Spark job scripting and pipeline automation, cloud platform fundamentals (Azure/AWS/GCP — data storage, compute, and networking)
-- **Awareness level expected:** Data mesh self-serve infrastructure patterns for domain data product enablement, AI/ML platform integration points for training data access patterns, data platform cost optimisation strategies (spot instances, auto-suspend, and storage tiering)
+**Expert level required:**
+
+- Databricks (Delta Lake, Unity Catalog, Workflows, cluster management, and workspace administration)
+- Apache Spark/PySpark (job development, performance tuning, and large-scale transformation workloads)
+- Terraform (infrastructure-as-code provisioning for data platform resources — storage, compute, and Kafka clusters)
+
+**Proficient level required:**
+
+- Delta Lake or Apache Iceberg (ACID transactions, time travel, OPTIMIZE, ZORDER, and VACUUM operations)
+- dbt (transformation framework development, model testing, and deployment pipeline integration)
+- managed ingestion platforms (Azure Data Factory, AWS Glue, or GCP Dataflow)
+
+**Working Knowledge required:**
+
+- Streaming data ingestion (Apache Kafka, Azure Event Hubs, or AWS Kinesis — platform-layer ingestion patterns)
+- Python for Spark job scripting and pipeline automation
+- cloud platform fundamentals (Azure/AWS/GCP — data storage, compute, and networking)
+
+**Awareness level expected:**
+
+- Data mesh self-serve infrastructure patterns for domain data product enablement
+- AI/ML platform integration points for training data access patterns
+- data platform cost optimisation strategies (spot instances, auto-suspend, and storage tiering)
 
 ## Interactions with Other Roles
 

--- a/Roles/data_engineering/data_senior_engineer.md
+++ b/Roles/data_engineering/data_senior_engineer.md
@@ -80,10 +80,29 @@ The Data Senior Engineer leads complex data engineering initiatives, drives data
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** dbt (advanced macro development, packages, exposure definitions, testing strategies, and performance tuning), Python and SQL (advanced data engineering, pipeline framework development, and complex transformation logic), Databricks or Snowflake (production-scale platform operations, advanced performance tuning, and cost optimisation)
-- **Proficient level required:** Apache Spark/PySpark (adaptive query execution, broadcast joins, and partitioning optimisation), Apache Kafka or Flink (streaming data pipeline design for near-real-time data products), data quality and observability frameworks (Great Expectations, Soda, or Monte Carlo)
-- **Working Knowledge required:** Delta Lake and Apache Iceberg (advanced features — schema evolution, time travel, and compaction strategies), data governance tooling (Databricks Unity Catalog, DataHub, or Collibra), Data Vault 2.0 and advanced dimensional modelling patterns
-- **Awareness level expected:** AI-assisted data engineering and feature engineering tools, real-time data mesh data product patterns, emerging lakehouse optimisation technologies (Apache Hudi)
+**Expert level required:**
+
+- dbt (advanced macro development, packages, exposure definitions, testing strategies, and performance tuning)
+- Python and SQL (advanced data engineering, pipeline framework development, and complex transformation logic)
+- Databricks or Snowflake (production-scale platform operations, advanced performance tuning, and cost optimisation)
+
+**Proficient level required:**
+
+- Apache Spark/PySpark (adaptive query execution, broadcast joins, and partitioning optimisation)
+- Apache Kafka or Flink (streaming data pipeline design for near-real-time data products)
+- data quality and observability frameworks (Great Expectations, Soda, or Monte Carlo)
+
+**Working Knowledge required:**
+
+- Delta Lake and Apache Iceberg (advanced features — schema evolution, time travel, and compaction strategies)
+- data governance tooling (Databricks Unity Catalog, DataHub, or Collibra)
+- Data Vault 2.0 and advanced dimensional modelling patterns
+
+**Awareness level expected:**
+
+- AI-assisted data engineering and feature engineering tools
+- real-time data mesh data product patterns
+- emerging lakehouse optimisation technologies (Apache Hudi)
 
 ## Interactions with Other Roles
 

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -81,10 +81,29 @@ The DataOps Specialist applies DevOps and agile engineering principles to data p
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** dbt (project structure, schema and singular tests, custom generic tests, documentation, and deployment strategies), data pipeline CI/CD (GitHub Actions or GitLab CI — templating, environment promotion, and automated testing gates), Apache Airflow or Dagster (DAG authoring, operators, sensors, connection management, and platform administration)
-- **Proficient level required:** Data quality frameworks (Great Expectations — expectations, checkpoints, and data docs; Soda — checks YAML and SLA monitoring), data observability platforms (Monte Carlo or Bigeye — automated anomaly detection and SLA breach alerting), Apache Spark and Databricks (large-scale batch and streaming pipeline development and optimisation)
-- **Working Knowledge required:** Terraform (data infrastructure provisioning for Databricks clusters, Spark jobs, and orchestration platforms), OpenLineage or Marquez (data lineage capture and end-to-end traceability), Delta Lake or Apache Iceberg (lakehouse table format operations for pipeline incident management)
-- **Awareness level expected:** AI-assisted data quality anomaly detection tooling, real-time streaming pipeline reliability patterns (Kafka/Flink), ML feature engineering pipeline orchestration and reliability alignment
+**Expert level required:**
+
+- dbt (project structure, schema and singular tests, custom generic tests, documentation, and deployment strategies)
+- data pipeline CI/CD (GitHub Actions or GitLab CI — templating, environment promotion, and automated testing gates)
+- Apache Airflow or Dagster (DAG authoring, operators, sensors, connection management, and platform administration)
+
+**Proficient level required:**
+
+- Data quality frameworks (Great Expectations — expectations, checkpoints, and data docs; Soda — checks YAML and SLA monitoring)
+- data observability platforms (Monte Carlo or Bigeye — automated anomaly detection and SLA breach alerting)
+- Apache Spark and Databricks (large-scale batch and streaming pipeline development and optimisation)
+
+**Working Knowledge required:**
+
+- Terraform (data infrastructure provisioning for Databricks clusters, Spark jobs, and orchestration platforms)
+- OpenLineage or Marquez (data lineage capture and end-to-end traceability)
+- Delta Lake or Apache Iceberg (lakehouse table format operations for pipeline incident management)
+
+**Awareness level expected:**
+
+- AI-assisted data quality anomaly detection tooling
+- real-time streaming pipeline reliability patterns (Kafka/Flink)
+- ML feature engineering pipeline orchestration and reliability alignment
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -64,10 +64,29 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Qumulo Core file system (cluster architecture, HA design, and performance standards), file protocols (NFS, SMB, S3 — multi-protocol access design and governance), Qumulo replication and snapshot architecture for data protection and DR
-- **Proficient level required:** Qumulo Shift for hybrid cloud data migration (AWS S3 and Azure Blob integration), Qumulo API and automation frameworks (REST API integration and management tooling), capacity planning and cluster scaling models for Qumulo deployments
-- **Working Knowledge required:** Storage networking technologies (Ethernet/TCP/IP for Qumulo cluster connectivity), data migration strategies to and from Qumulo, cloud storage platforms (AWS S3, Azure Blob) as Qumulo Shift targets
-- **Awareness level expected:** Competitive enterprise NAS platforms (NetApp ONTAP, Dell EMC PowerScale/Isilon), AI/ML unstructured data storage requirements and performance patterns, object storage protocol (S3-compatible NAS) adoption trends
+**Expert level required:**
+
+- Qumulo Core file system (cluster architecture, HA design, and performance standards)
+- file protocols (NFS, SMB, S3 — multi-protocol access design and governance)
+- Qumulo replication and snapshot architecture for data protection and DR
+
+**Proficient level required:**
+
+- Qumulo Shift for hybrid cloud data migration (AWS S3 and Azure Blob integration)
+- Qumulo API and automation frameworks (REST API integration and management tooling)
+- capacity planning and cluster scaling models for Qumulo deployments
+
+**Working Knowledge required:**
+
+- Storage networking technologies (Ethernet/TCP/IP for Qumulo cluster connectivity)
+- data migration strategies to and from Qumulo
+- cloud storage platforms (AWS S3, Azure Blob) as Qumulo Shift targets
+
+**Awareness level expected:**
+
+- Competitive enterprise NAS platforms (NetApp ONTAP, Dell EMC PowerScale/Isilon)
+- AI/ML unstructured data storage requirements and performance patterns
+- object storage protocol (S3-compatible NAS) adoption trends
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -68,10 +68,30 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Qumulo Core file system (cluster administration, web UI, CLI, and REST API operations), file protocols (NFS, SMB, and S3 — share provisioning, access controls, and client connectivity), Qumulo snapshot management and replication configuration
-- **Proficient level required:** Qumulo Analytics and cluster performance monitoring, Qumulo Shift for cloud data transfers, file system quota management and capacity monitoring, Qumulo software upgrades and patching procedures
-- **Working Knowledge required:** Network file system protocol troubleshooting (NFS/SMB connectivity issues), data migration tooling for Qumulo workloads, Python scripting for Qumulo REST API automation
-- **Awareness level expected:** Hybrid cloud storage integration patterns, object storage protocol trends (S3-compatible NAS), competitive enterprise NAS platforms (NetApp, Dell EMC Isilon)
+**Expert level required:**
+
+- Qumulo Core file system (cluster administration, web UI, CLI, and REST API operations)
+- file protocols (NFS, SMB, and S3 — share provisioning, access controls, and client connectivity)
+- Qumulo snapshot management and replication configuration
+
+**Proficient level required:**
+
+- Qumulo Analytics and cluster performance monitoring
+- Qumulo Shift for cloud data transfers
+- file system quota management and capacity monitoring
+- Qumulo software upgrades and patching procedures
+
+**Working Knowledge required:**
+
+- Network file system protocol troubleshooting (NFS/SMB connectivity issues)
+- data migration tooling for Qumulo workloads
+- Python scripting for Qumulo REST API automation
+
+**Awareness level expected:**
+
+- Hybrid cloud storage integration patterns
+- object storage protocol trends (S3-compatible NAS)
+- competitive enterprise NAS platforms (NetApp, Dell EMC Isilon)
 
 ## Key Technologies
 

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -72,10 +72,29 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Qumulo storage platform backlog management and technology roadmap governance (Jira, Confluence), Qumulo capacity planning and procurement decision-making, Qumulo service level definition and SLA performance reporting
-- **Proficient level required:** Qumulo platform capabilities and technology lifecycle management, cloud storage integration concepts for hybrid Qumulo strategies (Qumulo Shift), storage economics and cost-per-TB analysis for business cases
-- **Working Knowledge required:** Qumulo file protocol concepts (NFS, SMB, S3) for stakeholder requirement gathering, backup and data protection integration considerations, storage vendor relationship management
-- **Awareness level expected:** Competitive enterprise NAS and cloud-native file storage platforms, AI/ML storage requirement trends for unstructured data, software-defined storage market evolution
+**Expert level required:**
+
+- Qumulo storage platform backlog management and technology roadmap governance (Jira, Confluence)
+- Qumulo capacity planning and procurement decision-making
+- Qumulo service level definition and SLA performance reporting
+
+**Proficient level required:**
+
+- Qumulo platform capabilities and technology lifecycle management
+- cloud storage integration concepts for hybrid Qumulo strategies (Qumulo Shift)
+- storage economics and cost-per-TB analysis for business cases
+
+**Working Knowledge required:**
+
+- Qumulo file protocol concepts (NFS, SMB, S3) for stakeholder requirement gathering
+- backup and data protection integration considerations
+- storage vendor relationship management
+
+**Awareness level expected:**
+
+- Competitive enterprise NAS and cloud-native file storage platforms
+- AI/ML storage requirement trends for unstructured data
+- software-defined storage market evolution
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -72,10 +72,29 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Advanced Qumulo cluster configuration and performance tuning, Qumulo REST API and automation frameworks (scripting and integration development), data migration planning and execution for complex Qumulo workloads
-- **Proficient level required:** Qumulo Shift for hybrid cloud implementations and data transfers, Qumulo replication and DR solution design, Qumulo CloudStudio and custom monitoring and reporting solutions
-- **Working Knowledge required:** Cloud storage platforms (AWS S3, Azure Blob) as Qumulo Shift targets, Python scripting for Qumulo management automation, network storage troubleshooting (NFS, SMB, TCP/IP)
-- **Awareness level expected:** Machine learning workload storage patterns for large unstructured datasets, competitive NAS and object storage platforms, software-defined storage technology trends
+**Expert level required:**
+
+- Advanced Qumulo cluster configuration and performance tuning
+- Qumulo REST API and automation frameworks (scripting and integration development)
+- data migration planning and execution for complex Qumulo workloads
+
+**Proficient level required:**
+
+- Qumulo Shift for hybrid cloud implementations and data transfers
+- Qumulo replication and DR solution design
+- Qumulo CloudStudio and custom monitoring and reporting solutions
+
+**Working Knowledge required:**
+
+- Cloud storage platforms (AWS S3, Azure Blob) as Qumulo Shift targets
+- Python scripting for Qumulo management automation
+- network storage troubleshooting (NFS, SMB, TCP/IP)
+
+**Awareness level expected:**
+
+- Machine learning workload storage patterns for large unstructured datasets
+- competitive NAS and object storage platforms
+- software-defined storage technology trends
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -80,10 +80,29 @@ The Storage Architect is responsible for designing and governing the organisatio
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise SAN/NAS platforms (NetApp ONTAP, Pure Storage, Dell EMC PowerStore/PowerScale — architecture standards, HA design, and performance governance), storage protocols (FC, iSCSI, NFS, SMB/CIFS, NVMe-oF — design patterns and workload-to-protocol mapping), data tiering strategy (hot/warm/cold/archive across on-premises and cloud tiers with lifecycle management)
-- **Proficient level required:** Software-defined storage (VMware vSAN, Nutanix AOS, or Ceph — architecture and selection criteria), cloud object storage (Azure Blob, AWS S3, or GCP Cloud Storage — tiering, lifecycle policies, and hybrid storage patterns), storage replication and data protection architecture (NetApp SnapMirror, Pure ActiveDR, or Zerto)
-- **Working Knowledge required:** Kubernetes persistent storage (CSI drivers, StorageClass design, PVC patterns, and ReadWriteMany for containerised workloads), hybrid cloud storage solutions (Azure NetApp Files, AWS FSx, or Google Cloud Filestore), storage capacity planning and cost modelling methodologies
-- **Awareness level expected:** NVMe-oF protocol adoption and all-flash fabric architecture trends, Ceph and Rook-Ceph for cloud-native Kubernetes storage deployments, AI/ML workload storage performance requirements and high-throughput access patterns
+**Expert level required:**
+
+- Enterprise SAN/NAS platforms (NetApp ONTAP, Pure Storage, Dell EMC PowerStore/PowerScale — architecture standards, HA design, and performance governance)
+- storage protocols (FC, iSCSI, NFS, SMB/CIFS, NVMe-oF — design patterns and workload-to-protocol mapping)
+- data tiering strategy (hot/warm/cold/archive across on-premises and cloud tiers with lifecycle management)
+
+**Proficient level required:**
+
+- Software-defined storage (VMware vSAN, Nutanix AOS, or Ceph — architecture and selection criteria)
+- cloud object storage (Azure Blob, AWS S3, or GCP Cloud Storage — tiering, lifecycle policies, and hybrid storage patterns)
+- storage replication and data protection architecture (NetApp SnapMirror, Pure ActiveDR, or Zerto)
+
+**Working Knowledge required:**
+
+- Kubernetes persistent storage (CSI drivers, StorageClass design, PVC patterns, and ReadWriteMany for containerised workloads)
+- hybrid cloud storage solutions (Azure NetApp Files, AWS FSx, or Google Cloud Filestore)
+- storage capacity planning and cost modelling methodologies
+
+**Awareness level expected:**
+
+- NVMe-oF protocol adoption and all-flash fabric architecture trends
+- Ceph and Rook-Ceph for cloud-native Kubernetes storage deployments
+- AI/ML workload storage performance requirements and high-throughput access patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -64,10 +64,30 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise storage provisioning (SAN LUN masking, zoning, and NAS file share creation — Dell EMC, HPE, NetApp, or Pure Storage), storage networking (Fibre Channel and iSCSI connectivity and troubleshooting), RAID configuration and data protection implementation
-- **Proficient level required:** Storage management software (vendor GUI and CLI tools), thin provisioning and deduplication configuration, storage performance monitoring tools, cloud storage integration basics
-- **Working Knowledge required:** LUN masking and SAN zoning procedures, basic scripting for storage automation (Python or PowerShell), Kubernetes persistent volume fundamentals
-- **Awareness level expected:** Software-defined storage platforms (VMware vSAN, Ceph basics), NVMe-oF for high-performance storage, object storage platforms (S3-compatible)
+**Expert level required:**
+
+- Enterprise storage provisioning (SAN LUN masking, zoning, and NAS file share creation — Dell EMC, HPE, NetApp, or Pure Storage)
+- storage networking (Fibre Channel and iSCSI connectivity and troubleshooting)
+- RAID configuration and data protection implementation
+
+**Proficient level required:**
+
+- Storage management software (vendor GUI and CLI tools)
+- thin provisioning and deduplication configuration
+- storage performance monitoring tools
+- cloud storage integration basics
+
+**Working Knowledge required:**
+
+- LUN masking and SAN zoning procedures
+- basic scripting for storage automation (Python or PowerShell)
+- Kubernetes persistent volume fundamentals
+
+**Awareness level expected:**
+
+- Software-defined storage platforms (VMware vSAN, Ceph basics)
+- NVMe-oF for high-performance storage
+- object storage platforms (S3-compatible)
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -64,10 +64,29 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Storage platform product backlog management and technology lifecycle roadmap (Jira, Confluence), storage capacity planning and procurement governance, storage service level acceptance criteria and vendor SLA management
-- **Proficient level required:** Enterprise storage platform concepts (SAN, NAS, object storage), software-defined storage strategies and adoption roadmaps, cloud storage services and hybrid storage design concepts
-- **Working Knowledge required:** Storage automation and orchestration concepts, data lifecycle management and tiering policies, storage QoS and performance analytics for cost optimisation
-- **Awareness level expected:** NVMe-oF and next-generation flash storage technology trends, AI/ML unstructured data storage requirements, storage-as-a-service delivery model evolution
+**Expert level required:**
+
+- Storage platform product backlog management and technology lifecycle roadmap (Jira, Confluence)
+- storage capacity planning and procurement governance
+- storage service level acceptance criteria and vendor SLA management
+
+**Proficient level required:**
+
+- Enterprise storage platform concepts (SAN, NAS, object storage)
+- software-defined storage strategies and adoption roadmaps
+- cloud storage services and hybrid storage design concepts
+
+**Working Knowledge required:**
+
+- Storage automation and orchestration concepts
+- data lifecycle management and tiering policies
+- storage QoS and performance analytics for cost optimisation
+
+**Awareness level expected:**
+
+- NVMe-oF and next-generation flash storage technology trends
+- AI/ML unstructured data storage requirements
+- storage-as-a-service delivery model evolution
 
 ## Interactions with Other Roles
 

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -64,10 +64,29 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise storage arrays (Dell EMC, HPE, NetApp, or Pure Storage — advanced configuration, performance tuning, and replication), SAN fabric switches and directors (Fibre Channel zoning, VSAN, and ISL design), storage performance analysis and optimisation (IOPS, throughput, queue depth)
-- **Proficient level required:** Software-defined storage (VMware vSAN, Nutanix, or Ceph), data replication and mirroring solutions (NetApp SnapMirror, Pure ActiveDR, Zerto), storage automation frameworks (Ansible, Terraform for storage provisioning)
-- **Working Knowledge required:** Cloud storage integration technologies (Azure Blob, AWS S3, hybrid storage solutions), storage capacity planning and analytics tools, Kubernetes persistent storage and CSI driver configuration
-- **Awareness level expected:** NVMe-oF protocol and all-flash fabric architecture, Ceph and Rook-Ceph for cloud-native storage, AI/ML workload storage patterns for high-throughput environments
+**Expert level required:**
+
+- Enterprise storage arrays (Dell EMC, HPE, NetApp, or Pure Storage — advanced configuration, performance tuning, and replication)
+- SAN fabric switches and directors (Fibre Channel zoning, VSAN, and ISL design)
+- storage performance analysis and optimisation (IOPS, throughput, queue depth)
+
+**Proficient level required:**
+
+- Software-defined storage (VMware vSAN, Nutanix, or Ceph)
+- data replication and mirroring solutions (NetApp SnapMirror, Pure ActiveDR, Zerto)
+- storage automation frameworks (Ansible, Terraform for storage provisioning)
+
+**Working Knowledge required:**
+
+- Cloud storage integration technologies (Azure Blob, AWS S3, hybrid storage solutions)
+- storage capacity planning and analytics tools
+- Kubernetes persistent storage and CSI driver configuration
+
+**Awareness level expected:**
+
+- NVMe-oF protocol and all-flash fabric architecture
+- Ceph and Rook-Ceph for cloud-native storage
+- AI/ML workload storage patterns for high-throughput environments
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -64,10 +64,27 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Commvault Complete Backup & Recovery, Prometheus/Grafana (monitoring), Ansible/PowerShell (automation)
-- **Proficient level required:** Veeam/Veritas (backup platforms), Jenkins/GitLab CI (CI/CD for backup testing), PagerDuty/OpsGenie
-- **Working Knowledge required:** Chaos engineering tools, backup validation frameworks
-- **Awareness level expected:** Synthetic transaction monitoring, AI-driven backup analytics
+**Expert level required:**
+
+- Commvault Complete Backup & Recovery
+- Prometheus/Grafana (monitoring)
+- Ansible/PowerShell (automation)
+
+**Proficient level required:**
+
+- Veeam/Veritas (backup platforms)
+- Jenkins/GitLab CI (CI/CD for backup testing)
+- PagerDuty/OpsGenie
+
+**Working Knowledge required:**
+
+- Chaos engineering tools
+- backup validation frameworks
+
+**Awareness level expected:**
+
+- Synthetic transaction monitoring
+- AI-driven backup analytics
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -64,10 +64,27 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Commvault Complete Data Protection suite, Commvault HyperScale, Commvault Disaster Recovery
-- **Proficient level required:** Commvault Activate (data governance), Commvault Orchestrate, enterprise storage platforms (NetApp/Pure Storage)
-- **Working Knowledge required:** Cloud storage/cloud-native backup (Metallic SaaS), database protection technologies
-- **Awareness level expected:** , NIST CSF compliance reporting, tape/long-term archival solutions
+**Expert level required:**
+
+- Commvault Complete Data Protection suite
+- Commvault HyperScale
+- Commvault Disaster Recovery
+
+**Proficient level required:**
+
+- Commvault Activate (data governance)
+- Commvault Orchestrate
+- enterprise storage platforms (NetApp/Pure Storage)
+
+**Working Knowledge required:**
+
+- Cloud storage/cloud-native backup (Metallic SaaS)
+- database protection technologies
+
+**Awareness level expected:**
+
+- NIST CSF compliance reporting
+- tape/long-term archival solutions
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -64,10 +64,28 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Commvault CommCell/CommCell Console, Commvault Command Center, Commvault backup/recovery operations
-- **Proficient level required:** Commvault storage policies, Commvault clients/agents, VM backup/recovery tools
-- **Working Knowledge required:** Commvault deduplication, Commvault OnePass, Commvault workflow automation
-- **Awareness level expected:** Cloud backup targets (Metallic SaaS), GDPR compliance reporting
+**Expert level required:**
+
+- Commvault CommCell/CommCell Console
+- Commvault Command Center
+- Commvault backup/recovery operations
+
+**Proficient level required:**
+
+- Commvault storage policies
+- Commvault clients/agents
+- VM backup/recovery tools
+
+**Working Knowledge required:**
+
+- Commvault deduplication
+- Commvault OnePass
+- Commvault workflow automation
+
+**Awareness level expected:**
+
+- Cloud backup targets (Metallic SaaS)
+- GDPR compliance reporting
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -68,10 +68,27 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Commvault Complete Backup & Recovery, Metallic SaaS, Jira/Azure DevOps
-- **Proficient level required:** CommCell Console, Power BI (metrics/reporting), ServiceNow (ITSM integration)
-- **Working Knowledge required:** GDPR compliance reporting, storage management platforms
-- **Awareness level expected:** Cloud backup strategies, DR orchestration tools
+**Expert level required:**
+
+- Commvault Complete Backup & Recovery
+- Metallic SaaS
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- CommCell Console
+- Power BI (metrics/reporting)
+- ServiceNow (ITSM integration)
+
+**Working Knowledge required:**
+
+- GDPR compliance reporting
+- storage management platforms
+
+**Awareness level expected:**
+
+- Cloud backup strategies
+- DR orchestration tools
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -64,10 +64,27 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Commvault Complete Backup & Recovery, Commvault HyperScale, Commvault REST APIs/automation
-- **Proficient level required:** Commvault Orchestrate, enterprise storage integration (SAN/NAS), DR orchestration
-- **Working Knowledge required:** Cloud storage/Metallic SaaS backup targets, database backup technologies
-- **Awareness level expected:** Tape library management, GDPR compliance reporting
+**Expert level required:**
+
+- Commvault Complete Backup & Recovery
+- Commvault HyperScale
+- Commvault REST APIs/automation
+
+**Proficient level required:**
+
+- Commvault Orchestrate
+- enterprise storage integration (SAN/NAS)
+- DR orchestration
+
+**Working Knowledge required:**
+
+- Cloud storage/Metallic SaaS backup targets
+- database backup technologies
+
+**Awareness level expected:**
+
+- Tape library management
+- GDPR compliance reporting
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -64,10 +64,27 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPE SimpliVity hyperconverged infrastructure, SimpliVity RapidDR, vSphere/vCenter (VMware integration)
-- **Proficient level required:** SimpliVity DVP (Data Virtualization Platform), SimpliVity policy-based management, SimpliVity replication (multi-site)
-- **Working Knowledge required:** SimpliVity API/automation frameworks, DR orchestration tools
-- **Awareness level expected:** NetApp/Pure Storage (enterprise storage), , NIST CSF compliance for backup
+**Expert level required:**
+
+- HPE SimpliVity hyperconverged infrastructure
+- SimpliVity RapidDR
+- vSphere/vCenter (VMware integration)
+
+**Proficient level required:**
+
+- SimpliVity DVP (Data Virtualization Platform)
+- SimpliVity policy-based management
+- SimpliVity replication (multi-site)
+
+**Working Knowledge required:**
+
+- SimpliVity API/automation frameworks
+- DR orchestration tools
+
+**Awareness level expected:**
+
+- NetApp/Pure Storage (enterprise storage)
+- NIST CSF compliance for backup
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -64,10 +64,27 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPE SimpliVity hyperconverged infrastructure, SimpliVity OmniStack software, VMware vSphere integration
-- **Proficient level required:** SimpliVity backup/recovery operations, SimpliVity policy management, SimpliVity OmniCube Management
-- **Working Knowledge required:** SimpliVity replication, backup monitoring/reporting tools
-- **Awareness level expected:** VMware Data Protection, HPE OneView
+**Expert level required:**
+
+- HPE SimpliVity hyperconverged infrastructure
+- SimpliVity OmniStack software
+- VMware vSphere integration
+
+**Proficient level required:**
+
+- SimpliVity backup/recovery operations
+- SimpliVity policy management
+- SimpliVity OmniCube Management
+
+**Working Knowledge required:**
+
+- SimpliVity replication
+- backup monitoring/reporting tools
+
+**Awareness level expected:**
+
+- VMware Data Protection
+- HPE OneView
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -64,10 +64,27 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPE SimpliVity, vSphere/vCenter, Jira/Azure DevOps
-- **Proficient level required:** SimpliVity RapidDR, Power BI (metrics/reporting), ServiceNow (ITSM integration)
-- **Working Knowledge required:** VMware Data Protection, storage management platforms
-- **Awareness level expected:** DR orchestration tools, cloud backup strategies
+**Expert level required:**
+
+- HPE SimpliVity
+- vSphere/vCenter
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- SimpliVity RapidDR
+- Power BI (metrics/reporting)
+- ServiceNow (ITSM integration)
+
+**Working Knowledge required:**
+
+- VMware Data Protection
+- storage management platforms
+
+**Awareness level expected:**
+
+- DR orchestration tools
+- cloud backup strategies
 
 ## Interactions with Other Roles
 

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -64,10 +64,27 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPE SimpliVity (advanced configurations), SimpliVity RapidDR, SimpliVity REST API integration
-- **Proficient level required:** SimpliVity policy-based backup automation, multi-site SimpliVity replication, VMware vSphere/vCenter
-- **Working Knowledge required:** Integration with enterprise backup solutions (Veeam/Commvault), advanced backup monitoring/analytics
-- **Awareness level expected:** HPE OneView, DR orchestration platforms
+**Expert level required:**
+
+- HPE SimpliVity (advanced configurations)
+- SimpliVity RapidDR
+- SimpliVity REST API integration
+
+**Proficient level required:**
+
+- SimpliVity policy-based backup automation
+- multi-site SimpliVity replication
+- VMware vSphere/vCenter
+
+**Working Knowledge required:**
+
+- Integration with enterprise backup solutions (Veeam/Commvault)
+- advanced backup monitoring/analytics
+
+**Awareness level expected:**
+
+- HPE OneView
+- DR orchestration platforms
 
 ## Interactions with Other Roles
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -64,10 +64,29 @@ The Database Architect designs comprehensive data management strategies and arch
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Relational database architecture (Oracle, SQL Server, or PostgreSQL — design patterns, HA/DR, and query performance tuning), data modelling (dimensional, normalised, and data vault patterns for enterprise workloads), database security framework design (encryption, access control, and compliance controls)
-- **Proficient level required:** NoSQL database platforms (MongoDB, Cassandra, or Couchbase — architecture patterns and use case selection), Database-as-a-Service platforms (Azure SQL, AWS RDS/Aurora, GCP Cloud SQL — migration and adoption strategy), database migration tools and cloud database modernisation approaches
-- **Working Knowledge required:** In-memory database technologies (Redis, Memcached — caching and session store patterns), distributed database architectures (CockroachDB, Spanner — for globally consistent workloads), data replication and synchronisation technologies
-- **Awareness level expected:** NewSQL and HTAP database trends, AI-assisted query optimisation tools, database DevOps and schema-as-code practices (Flyway, Liquibase)
+**Expert level required:**
+
+- Relational database architecture (Oracle, SQL Server, or PostgreSQL — design patterns, HA/DR, and query performance tuning)
+- data modelling (dimensional, normalised, and data vault patterns for enterprise workloads)
+- database security framework design (encryption, access control, and compliance controls)
+
+**Proficient level required:**
+
+- NoSQL database platforms (MongoDB, Cassandra, or Couchbase — architecture patterns and use case selection)
+- Database-as-a-Service platforms (Azure SQL, AWS RDS/Aurora, GCP Cloud SQL — migration and adoption strategy)
+- database migration tools and cloud database modernisation approaches
+
+**Working Knowledge required:**
+
+- In-memory database technologies (Redis, Memcached — caching and session store patterns)
+- distributed database architectures (CockroachDB, Spanner — for globally consistent workloads)
+- data replication and synchronisation technologies
+
+**Awareness level expected:**
+
+- NewSQL and HTAP database trends
+- AI-assisted query optimisation tools
+- database DevOps and schema-as-code practices (Flyway, Liquibase)
 
 ## Interactions with Other Roles
 

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -72,10 +72,29 @@ The Database Engineer implements and maintains database systems across the organ
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Relational database administration (Oracle, SQL Server, or PostgreSQL — instance management, backup/recovery, and patching), SQL and query language proficiency (DML, DDL, stored procedures, and views), database security controls (access management, RBAC, and auditing configuration)
-- **Proficient level required:** Database backup and recovery procedure execution and restoration testing, database performance monitoring tools (execution plans, query analysis, and space utilisation), database provisioning and standard configuration management
-- **Working Knowledge required:** High availability concepts (SQL Server Always On AG, Oracle RAC basics, or PostgreSQL streaming replication), cloud database services (Azure SQL, AWS RDS basics), database migration and upgrade tooling
-- **Awareness level expected:** NoSQL database platforms (MongoDB, Redis fundamentals), database automation scripting (Python/PowerShell), container-based database deployments
+**Expert level required:**
+
+- Relational database administration (Oracle, SQL Server, or PostgreSQL — instance management, backup/recovery, and patching)
+- SQL and query language proficiency (DML, DDL, stored procedures, and views)
+- database security controls (access management, RBAC, and auditing configuration)
+
+**Proficient level required:**
+
+- Database backup and recovery procedure execution and restoration testing
+- database performance monitoring tools (execution plans, query analysis, and space utilisation)
+- database provisioning and standard configuration management
+
+**Working Knowledge required:**
+
+- High availability concepts (SQL Server Always On AG, Oracle RAC basics, or PostgreSQL streaming replication)
+- cloud database services (Azure SQL, AWS RDS basics)
+- database migration and upgrade tooling
+
+**Awareness level expected:**
+
+- NoSQL database platforms (MongoDB, Redis fundamentals)
+- database automation scripting (Python/PowerShell)
+- container-based database deployments
 
 ## Interactions with Other Roles
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -72,10 +72,29 @@ The Database Product Owner manages the portfolio of database platforms and data 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Database platform product backlog management and technology roadmap (Jira, Confluence), database licensing governance and TCO optimisation, database service level management and stakeholder performance reporting
-- **Proficient level required:** Relational and NoSQL database platform concepts (Oracle, SQL Server, PostgreSQL, MongoDB), Database-as-a-Service adoption governance (Azure SQL, AWS RDS/Aurora, GCP Cloud SQL), database lifecycle and version upgrade planning
-- **Working Knowledge required:** Database automation and DevOps tooling concepts, database security and compliance framework oversight, cloud database cost management and FinOps reporting
-- **Awareness level expected:** NewSQL and HTAP database trends, AI-assisted database administration tools, database-as-code and schema migration practices (Flyway, Liquibase)
+**Expert level required:**
+
+- Database platform product backlog management and technology roadmap (Jira, Confluence)
+- database licensing governance and TCO optimisation
+- database service level management and stakeholder performance reporting
+
+**Proficient level required:**
+
+- Relational and NoSQL database platform concepts (Oracle, SQL Server, PostgreSQL, MongoDB)
+- Database-as-a-Service adoption governance (Azure SQL, AWS RDS/Aurora, GCP Cloud SQL)
+- database lifecycle and version upgrade planning
+
+**Working Knowledge required:**
+
+- Database automation and DevOps tooling concepts
+- database security and compliance framework oversight
+- cloud database cost management and FinOps reporting
+
+**Awareness level expected:**
+
+- NewSQL and HTAP database trends
+- AI-assisted database administration tools
+- database-as-code and schema migration practices (Flyway, Liquibase)
 
 ## Interactions with Other Roles
 

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -64,10 +64,29 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Database observability and monitoring automation (Prometheus/Grafana for database SLO/SLI tracking, Datadog or Percona Monitoring), automated failover and self-healing mechanisms for database HA configurations, database performance profiling and query optimisation automation
-- **Proficient level required:** SRE principles applied to databases (error budget management, SLO definitions, toil elimination), chaos engineering for databases (Gremlin or LitmusChaos for database failure injection), HA/DR configurations (SQL Server Always On AG, Oracle Data Guard, or PostgreSQL streaming replication)
-- **Working Knowledge required:** Cloud database services reliability patterns (AWS RDS Multi-AZ, Azure SQL Business Critical, GCP Cloud SQL HA), incident management platforms (PagerDuty, Opsgenie) for database on-call routing, Terraform/Ansible for database automation and IaC
-- **Awareness level expected:** AI-assisted database performance anomaly detection, HTAP and distributed database reliability patterns, eBPF-based database observability tooling
+**Expert level required:**
+
+- Database observability and monitoring automation (Prometheus/Grafana for database SLO/SLI tracking, Datadog or Percona Monitoring)
+- automated failover and self-healing mechanisms for database HA configurations
+- database performance profiling and query optimisation automation
+
+**Proficient level required:**
+
+- SRE principles applied to databases (error budget management, SLO definitions, toil elimination)
+- chaos engineering for databases (Gremlin or LitmusChaos for database failure injection)
+- HA/DR configurations (SQL Server Always On AG, Oracle Data Guard, or PostgreSQL streaming replication)
+
+**Working Knowledge required:**
+
+- Cloud database services reliability patterns (AWS RDS Multi-AZ, Azure SQL Business Critical, GCP Cloud SQL HA)
+- incident management platforms (PagerDuty, Opsgenie) for database on-call routing
+- Terraform/Ansible for database automation and IaC
+
+**Awareness level expected:**
+
+- AI-assisted database performance anomaly detection
+- HTAP and distributed database reliability patterns
+- eBPF-based database observability tooling
 
 ## Interactions with Other Roles
 

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -72,10 +72,29 @@ The Database Senior Engineer leads the implementation and optimization of comple
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Advanced relational database performance tuning (Oracle, SQL Server, or PostgreSQL — execution plans, advanced indexing, and buffer pool optimisation), database HA and DR implementation (SQL Server Always On AG, Oracle Data Guard, or PostgreSQL streaming replication), database automation and Infrastructure as Code for database deployments
-- **Proficient level required:** NoSQL database platforms at production scale (MongoDB, Cassandra — administration and tuning), cloud database migration strategies (on-prem to AWS RDS, Azure SQL, or GCP Cloud SQL), data replication technologies (logical replication and CDC patterns)
-- **Working Knowledge required:** Advanced backup and recovery strategies (point-in-time recovery and cross-region backup), database security hardening (TDE, column encryption, row-level security), containerised database deployment patterns
-- **Awareness level expected:** NewSQL and distributed database patterns (CockroachDB, TiDB), AI-assisted query tuning tools, database DevOps and schema migration practices (Flyway, Liquibase)
+**Expert level required:**
+
+- Advanced relational database performance tuning (Oracle, SQL Server, or PostgreSQL — execution plans, advanced indexing, and buffer pool optimisation)
+- database HA and DR implementation (SQL Server Always On AG, Oracle Data Guard, or PostgreSQL streaming replication)
+- database automation and Infrastructure as Code for database deployments
+
+**Proficient level required:**
+
+- NoSQL database platforms at production scale (MongoDB, Cassandra — administration and tuning)
+- cloud database migration strategies (on-prem to AWS RDS, Azure SQL, or GCP Cloud SQL)
+- data replication technologies (logical replication and CDC patterns)
+
+**Working Knowledge required:**
+
+- Advanced backup and recovery strategies (point-in-time recovery and cross-region backup)
+- database security hardening (TDE, column encryption, row-level security)
+- containerised database deployment patterns
+
+**Awareness level expected:**
+
+- NewSQL and distributed database patterns (CockroachDB, TiDB)
+- AI-assisted query tuning tools
+- database DevOps and schema migration practices (Flyway, Liquibase)
 
 ## Interactions with Other Roles
 

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -79,10 +79,27 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Python and Go (framework and library development), GitHub Actions (reusable workflows, composite actions, and custom JavaScript/Docker actions), Terraform and Pulumi (IaC module authoring and provider development)
-- **Proficient level required:** pytest, Testinfra, and Terratest (infrastructure and IaC test automation), Ansible (roles, collections, and runbook automation), Backstage (scaffolder plugins and software templates)
-- **Working Knowledge required:** Docker and container registries (packaging and distributing automation tooling), Packer (machine image pipeline authoring), internal artifact registries (PyPI, Terraform Registry, GitHub Packages)
-- **Awareness level expected:** Kubernetes as automation workload runtime target, AI-assisted development tools (GitHub Copilot for framework and test scaffolding), Robot Framework and Playwright for UI automation
+**Expert level required:**
+
+- Python and Go (framework and library development)
+- GitHub Actions (reusable workflows, composite actions, and custom JavaScript/Docker actions)
+- Terraform and Pulumi (IaC module authoring and provider development)
+
+**Proficient level required:**
+
+- pytest, Testinfra, and Terratest (infrastructure and IaC test automation), Ansible (roles, collections, and runbook automation), Backstage (scaffolder plugins and software templates)
+
+**Working Knowledge required:**
+
+- Docker and container registries (packaging and distributing automation tooling)
+- Packer (machine image pipeline authoring)
+- internal artifact registries (PyPI, Terraform Registry, GitHub Packages)
+
+**Awareness level expected:**
+
+- Kubernetes as automation workload runtime target
+- AI-assisted development tools (GitHub Copilot for framework and test scaffolding)
+- Robot Framework and Playwright for UI automation
 
 ### Qualifications
 

--- a/Roles/devops/developer_experience_engineer.md
+++ b/Roles/devops/developer_experience_engineer.md
@@ -75,10 +75,29 @@ The Developer Experience Engineer designs, builds, and operates internal develop
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Backstage (CNCF developer portal, software catalogue, and scaffolding template development), GitHub Actions or GitLab CI (golden path pipeline template authoring and pipeline-as-code patterns), DORA metrics tracking and SPACE framework instrumentation
-- **Proficient level required:** ArgoCD or Flux (GitOps-based application delivery and IDP self-service integration), Crossplane (Kubernetes-native self-service infrastructure provisioning), Terraform or Pulumi (IaC modules for golden path infrastructure)
-- **Working Knowledge required:** Helm (Kubernetes application packaging for golden path templates), OPA or Kyverno (policy-as-code enforcement in self-service workflows), CLI tooling development (Go, Python, or TypeScript-based internal developer tools)
-- **Awareness level expected:** Port and Cortex (alternative IDP and developer scorecard platforms), AI-assisted developer experience automation patterns, eBPF-based platform observability tooling
+**Expert level required:**
+
+- Backstage (CNCF developer portal, software catalogue, and scaffolding template development)
+- GitHub Actions or GitLab CI (golden path pipeline template authoring and pipeline-as-code patterns)
+- DORA metrics tracking and SPACE framework instrumentation
+
+**Proficient level required:**
+
+- ArgoCD or Flux (GitOps-based application delivery and IDP self-service integration)
+- Crossplane (Kubernetes-native self-service infrastructure provisioning)
+- Terraform or Pulumi (IaC modules for golden path infrastructure)
+
+**Working Knowledge required:**
+
+- Helm (Kubernetes application packaging for golden path templates)
+- OPA or Kyverno (policy-as-code enforcement in self-service workflows)
+- CLI tooling development (Go, Python, or TypeScript-based internal developer tools)
+
+**Awareness level expected:**
+
+- Port and Cortex (alternative IDP and developer scorecard platforms)
+- AI-assisted developer experience automation patterns
+- eBPF-based platform observability tooling
 
 ## Interactions with Other Roles
 

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -73,10 +73,30 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** CI/CD tools (GitHub Actions, GitLab CI, or Azure DevOps — pipeline implementation and maintenance), Git and GitHub/GitLab (version control and branching strategies), scripting languages (Bash, PowerShell, Python — pipeline automation)
-- **Proficient level required:** Docker/Containerd (containerization and image management), Terraform/OpenTofu (IaC template creation and management), Ansible (configuration management), artifact repositories (Nexus, Artifactory, or GitHub Packages)
-- **Working Knowledge required:** ArgoCD/Flux (GitOps deployment), automated testing framework integration in pipelines, security scanning tools (SBOM generation, Sigstore/Cosign)
-- **Awareness level expected:** Supply chain security standards (SLSA verification), AI-assisted development tools (GitHub Copilot), Kubernetes as a pipeline deployment target
+**Expert level required:**
+
+- CI/CD tools (GitHub Actions, GitLab CI, or Azure DevOps — pipeline implementation and maintenance)
+- Git and GitHub/GitLab (version control and branching strategies)
+- scripting languages (Bash, PowerShell, Python — pipeline automation)
+
+**Proficient level required:**
+
+- Docker/Containerd (containerization and image management)
+- Terraform/OpenTofu (IaC template creation and management)
+- Ansible (configuration management)
+- artifact repositories (Nexus, Artifactory, or GitHub Packages)
+
+**Working Knowledge required:**
+
+- ArgoCD/Flux (GitOps deployment)
+- automated testing framework integration in pipelines
+- security scanning tools (SBOM generation, Sigstore/Cosign)
+
+**Awareness level expected:**
+
+- Supply chain security standards (SLSA verification)
+- AI-assisted development tools (GitHub Copilot)
+- Kubernetes as a pipeline deployment target
 
 ## Interactions with Other Roles
 

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -72,10 +72,29 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Agile product ownership tooling (Jira/Azure DevOps — backlog management, sprint ceremonies, roadmap communication), DORA metrics platforms and delivery performance measurement, DevOps platform service roadmap and adoption governance
-- **Proficient level required:** CI/CD orchestration platform concepts (GitHub Actions, Azure DevOps, GitLab CI), deployment pipeline management and governance frameworks, feature flag management systems and rollout strategies
-- **Working Knowledge required:** Container registry and artifact management concepts, value stream management tooling, code quality and security scanning pipeline integrations
-- **Awareness level expected:** AI-assisted development toolchain impacts on DevOps adoption metrics, FinOps tooling for DevOps platform cost management, platform engineering maturity model frameworks
+**Expert level required:**
+
+- Agile product ownership tooling (Jira/Azure DevOps — backlog management, sprint ceremonies, roadmap communication)
+- DORA metrics platforms and delivery performance measurement
+- DevOps platform service roadmap and adoption governance
+
+**Proficient level required:**
+
+- CI/CD orchestration platform concepts (GitHub Actions, Azure DevOps, GitLab CI)
+- deployment pipeline management and governance frameworks
+- feature flag management systems and rollout strategies
+
+**Working Knowledge required:**
+
+- Container registry and artifact management concepts
+- value stream management tooling
+- code quality and security scanning pipeline integrations
+
+**Awareness level expected:**
+
+- AI-assisted development toolchain impacts on DevOps adoption metrics
+- FinOps tooling for DevOps platform cost management
+- platform engineering maturity model frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -75,10 +75,31 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** GitHub Actions / Azure DevOps / GitLab CI (advanced pipeline design, reusable templates, and composite actions), Terraform/Pulumi (advanced IaC patterns and reusable module libraries), ArgoCD/Flux (GitOps framework implementation and progressive delivery)
-- **Proficient level required:** Kubernetes/Docker Swarm (container orchestration and microservice deployment), OPA/Sentinel (policy as code frameworks), DevSecOps toolchain integration (SAST, DAST, SBOM scanners), Ansible/Puppet (configuration management)
-- **Working Knowledge required:** Istio/Linkerd (service mesh implementation), canary and Blue/Green deployment tooling, observability platform integration with CI/CD, Artifactory/Nexus (artifact management)
-- **Awareness level expected:** eBPF-based security and observability tooling, SLSA supply chain security standards, WebAssembly for serverless pipeline patterns
+**Expert level required:**
+
+- GitHub Actions / Azure DevOps / GitLab CI (advanced pipeline design, reusable templates, and composite actions)
+- Terraform/Pulumi (advanced IaC patterns and reusable module libraries)
+- ArgoCD/Flux (GitOps framework implementation and progressive delivery)
+
+**Proficient level required:**
+
+- Kubernetes/Docker Swarm (container orchestration and microservice deployment)
+- OPA/Sentinel (policy as code frameworks)
+- DevSecOps toolchain integration (SAST, DAST, SBOM scanners)
+- Ansible/Puppet (configuration management)
+
+**Working Knowledge required:**
+
+- Istio/Linkerd (service mesh implementation)
+- canary and Blue/Green deployment tooling
+- observability platform integration with CI/CD
+- Artifactory/Nexus (artifact management)
+
+**Awareness level expected:**
+
+- eBPF-based security and observability tooling
+- SLSA supply chain security standards
+- WebAssembly for serverless pipeline patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -75,10 +75,29 @@ The Platform Reliability Engineer applies site reliability engineering (SRE) pri
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Prometheus and Grafana (SLO/SLI framework implementation, burn-rate dashboards, and alerting for platform services), LitmusChaos or Chaos Mesh (Kubernetes-native chaos engineering experiment design and execution), blameless post-incident review facilitation and platform error budget management
-- **Proficient level required:** Kubernetes (platform workload reliability debugging and failure mode analysis), OpenTelemetry (platform service instrumentation and distributed tracing), PagerDuty or Opsgenie (on-call routing, escalation configuration, and incident alerting)
-- **Working Knowledge required:** Helm (platform service deployment and release management), Alertmanager (Prometheus-integrated alert routing and grouping), Grafana Loki (log aggregation and analysis for platform incident response)
-- **Awareness level expected:** eBPF-based observability tooling for Kubernetes platform services, incident management platforms (incident.io, Statuspage), AI-assisted incident correlation and anomaly detection tools
+**Expert level required:**
+
+- Prometheus and Grafana (SLO/SLI framework implementation, burn-rate dashboards, and alerting for platform services)
+- LitmusChaos or Chaos Mesh (Kubernetes-native chaos engineering experiment design and execution)
+- blameless post-incident review facilitation and platform error budget management
+
+**Proficient level required:**
+
+- Kubernetes (platform workload reliability debugging and failure mode analysis)
+- OpenTelemetry (platform service instrumentation and distributed tracing)
+- PagerDuty or Opsgenie (on-call routing, escalation configuration, and incident alerting)
+
+**Working Knowledge required:**
+
+- Helm (platform service deployment and release management)
+- Alertmanager (Prometheus-integrated alert routing and grouping)
+- Grafana Loki (log aggregation and analysis for platform incident response)
+
+**Awareness level expected:**
+
+- eBPF-based observability tooling for Kubernetes platform services
+- incident management platforms (incident.io, Statuspage)
+- AI-assisted incident correlation and anomaly detection tools
 
 ## Interactions with Other Roles
 

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -64,10 +64,27 @@ The Windows Active Directory Architect designs AD structure, security models, an
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Active Directory (AD DS/AD FS), Group Policy Objects (GPO), AD Certificate Services (AD CS)
-- **Proficient level required:** Microsoft Entra Connect (hybrid identity), LDAP/Kerberos, PowerShell (AD automation)
-- **Working Knowledge required:** AD security/auditing tools, DNS/DHCP for Active Directory
-- **Awareness level expected:** Microsoft Entra ID (Azure AD), Zero Trust identity architectures
+**Expert level required:**
+
+- Windows Active Directory (AD DS/AD FS)
+- Group Policy Objects (GPO)
+- AD Certificate Services (AD CS)
+
+**Proficient level required:**
+
+- Microsoft Entra Connect (hybrid identity)
+- LDAP/Kerberos
+- PowerShell (AD automation)
+
+**Working Knowledge required:**
+
+- AD security/auditing tools
+- DNS/DHCP for Active Directory
+
+**Awareness level expected:**
+
+- Microsoft Entra ID (Azure AD)
+- Zero Trust identity architectures
 
 ## Interactions with Other Roles
 

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -64,10 +64,28 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Active Directory (AD DS), Group Policy Management, PowerShell (AD administration)
-- **Proficient level required:** DNS/DHCP (AD-integrated), Microsoft Entra Connect, AD Certificate Services
-- **Working Knowledge required:** AD backup/recovery tools, Windows Server security for DCs, WSUS
-- **Awareness level expected:** Microsoft Entra ID (Azure AD), AD FS (federation)
+**Expert level required:**
+
+- Windows Active Directory (AD DS)
+- Group Policy Management
+- PowerShell (AD administration)
+
+**Proficient level required:**
+
+- DNS/DHCP (AD-integrated)
+- Microsoft Entra Connect
+- AD Certificate Services
+
+**Working Knowledge required:**
+
+- AD backup/recovery tools
+- Windows Server security for DCs
+- WSUS
+
+**Awareness level expected:**
+
+- Microsoft Entra ID (Azure AD)
+- AD FS (federation)
 
 ## Interactions with Other Roles
 

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -64,10 +64,27 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Active Directory, Microsoft Entra ID (hybrid identity), Jira/Azure DevOps
-- **Proficient level required:** Group Policy management, Power BI (AD metrics/reporting), ServiceNow (ITSM integration)
-- **Working Knowledge required:** Microsoft Entra Connect, PowerShell (AD automation)
-- **Awareness level expected:** DNS/DHCP management, AD Certificate Services
+**Expert level required:**
+
+- Windows Active Directory
+- Microsoft Entra ID (hybrid identity)
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- Group Policy management
+- Power BI (AD metrics/reporting)
+- ServiceNow (ITSM integration)
+
+**Working Knowledge required:**
+
+- Microsoft Entra Connect
+- PowerShell (AD automation)
+
+**Awareness level expected:**
+
+- DNS/DHCP management
+- AD Certificate Services
 
 ## Interactions with Other Roles
 

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -64,10 +64,27 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Active Directory (advanced configurations), Group Policy (advanced management), PowerShell automation
-- **Proficient level required:** AD FS (federation), AD Certificate Services/PKI, Microsoft Entra Connect
-- **Working Knowledge required:** ADMT (Active Directory Migration Tool), AD replication/site topology
-- **Awareness level expected:** Microsoft Entra ID (Azure AD), LDAP/Kerberos advanced configurations
+**Expert level required:**
+
+- Windows Active Directory (advanced configurations)
+- Group Policy (advanced management)
+- PowerShell automation
+
+**Proficient level required:**
+
+- AD FS (federation)
+- AD Certificate Services/PKI
+- Microsoft Entra Connect
+
+**Working Knowledge required:**
+
+- ADMT (Active Directory Migration Tool)
+- AD replication/site topology
+
+**Awareness level expected:**
+
+- Microsoft Entra ID (Azure AD)
+- LDAP/Kerberos advanced configurations
 
 ## Interactions with Other Roles
 

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -75,10 +75,27 @@ The Endpoint Management Engineer administers and maintains the organisation's en
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Intune configuration profiles, compliance policies, and app deployment, Windows Autopilot device registration and enrolment workflows, PowerShell scripting for endpoint remediation tasks
-- **Proficient level required:** Microsoft Endpoint Configuration Manager (MECM) software distribution and collections, Microsoft Entra ID device registration and Hybrid Join, Windows Update for Business and Autopatch
-- **Working Knowledge required:** Apple Business Manager and iOS/macOS MDM management, Microsoft Defender for Endpoint basics, Microsoft 365 service integration
-- **Awareness level expected:** Zero Trust endpoint security concepts, Windows 365 Cloud PC, Microsoft Intune Suite advanced features
+**Expert level required:**
+
+- Microsoft Intune configuration profiles, compliance policies, and app deployment, Windows Autopilot device registration and enrolment workflows, PowerShell scripting for endpoint remediation tasks
+
+**Proficient level required:**
+
+- Microsoft Endpoint Configuration Manager (MECM) software distribution and collections
+- Microsoft Entra ID device registration and Hybrid Join
+- Windows Update for Business and Autopatch
+
+**Working Knowledge required:**
+
+- Apple Business Manager and iOS/macOS MDM management
+- Microsoft Defender for Endpoint basics
+- Microsoft 365 service integration
+
+**Awareness level expected:**
+
+- Zero Trust endpoint security concepts
+- Windows 365 Cloud PC
+- Microsoft Intune Suite advanced features
 
 ## Interactions with Other Roles
 

--- a/Roles/endpoint_management/endpoint_management_product_owner.md
+++ b/Roles/endpoint_management/endpoint_management_product_owner.md
@@ -73,10 +73,30 @@ The Endpoint Management Product Owner (PO) owns the product vision, roadmap, and
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Intune platform concepts and feature roadmap, Jira/Azure DevOps backlog and sprint management, device compliance frameworks and reporting metrics
-- **Proficient level required:** MECM/SCCM co-management concepts, Microsoft Entra ID and Conditional Access concepts, Windows Autopilot provisioning workflows, Zero Trust endpoint security frameworks
-- **Working Knowledge required:** Apple Business Manager and macOS management concepts, Power BI and Intune compliance dashboards, Microsoft 365 licensing tiers
-- **Awareness level expected:** Microsoft Intune Suite advanced add-ons, Windows 365 Cloud PC, AI-assisted endpoint management capabilities
+**Expert level required:**
+
+- Microsoft Intune platform concepts and feature roadmap
+- Jira/Azure DevOps backlog and sprint management
+- device compliance frameworks and reporting metrics
+
+**Proficient level required:**
+
+- MECM/SCCM co-management concepts
+- Microsoft Entra ID and Conditional Access concepts
+- Windows Autopilot provisioning workflows
+- Zero Trust endpoint security frameworks
+
+**Working Knowledge required:**
+
+- Apple Business Manager and macOS management concepts
+- Power BI and Intune compliance dashboards
+- Microsoft 365 licensing tiers
+
+**Awareness level expected:**
+
+- Microsoft Intune Suite advanced add-ons
+- Windows 365 Cloud PC
+- AI-assisted endpoint management capabilities
 
 ## Interactions with Other Roles
 

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -64,10 +64,31 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** SCCM/ConfigMgr application packaging and deployment, SCCM operating system deployment (OSD) and task sequences, software update management via SCCM, SCCM collection management and queries
-- **Proficient level required:** Windows Deployment Services (WDS) and Microsoft Deployment Toolkit (MDT), PowerShell scripting for endpoint tasks, Group Policy administration, Windows Server infrastructure basics
-- **Working Knowledge required:** Microsoft SQL Server for SCCM site database administration, Microsoft Intune basics and co-management concepts, PKI and certificate management for SCCM
-- **Awareness level expected:** Modern management migration to Intune cloud-native delivery, Windows Autopilot integration, Microsoft Configuration Manager cloud attach features
+**Expert level required:**
+
+- SCCM/ConfigMgr application packaging and deployment
+- SCCM operating system deployment (OSD) and task sequences
+- software update management via SCCM
+- SCCM collection management and queries
+
+**Proficient level required:**
+
+- Windows Deployment Services (WDS) and Microsoft Deployment Toolkit (MDT)
+- PowerShell scripting for endpoint tasks
+- Group Policy administration
+- Windows Server infrastructure basics
+
+**Working Knowledge required:**
+
+- Microsoft SQL Server for SCCM site database administration
+- Microsoft Intune basics and co-management concepts
+- PKI and certificate management for SCCM
+
+**Awareness level expected:**
+
+- Modern management migration to Intune cloud-native delivery
+- Windows Autopilot integration
+- Microsoft Configuration Manager cloud attach features
 
 ## Interactions with Other Roles
 

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -64,10 +64,27 @@ The Enterprise Architect develops and maintains the overall technological vision
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ArchiMate/LeanIX/Bizzdesign (EA modeling), TOGAF, Azure/AWS/GCP (cloud architecture)
-- **Proficient level required:** Azure Integration Services/Kafka (enterprise integration), Azure APIM (API management), business capability mapping frameworks
-- **Working Knowledge required:** Enterprise AI governance frameworks, technology portfolio management tools
-- **Awareness level expected:** ArchiMate advanced modeling, innovation management systems
+**Expert level required:**
+
+- ArchiMate/LeanIX/Bizzdesign (EA modeling)
+- TOGAF
+- Azure/AWS/GCP (cloud architecture)
+
+**Proficient level required:**
+
+- Azure Integration Services/Kafka (enterprise integration)
+- Azure APIM (API management)
+- business capability mapping frameworks
+
+**Working Knowledge required:**
+
+- Enterprise AI governance frameworks
+- technology portfolio management tools
+
+**Awareness level expected:**
+
+- ArchiMate advanced modeling
+- innovation management systems
 
 ## Interactions with Other Roles
 

--- a/Roles/enterprise_architecture/enterprise_architecture_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_engineer.md
@@ -69,10 +69,25 @@ The Enterprise Architecture Engineer supports the enterprise architecture functi
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Confluence/SharePoint (documentation), Miro/draw.io (diagramming)
-- **Proficient level required:** LeanIX/Bizzdesign/ARIS (repository data entry), ArchiMate/C4 notation basics
-- **Working Knowledge required:** Excel/Power BI (data-quality reporting), Git/Azure DevOps (version control for artefacts)
-- **Awareness level expected:** TOGAF framework concepts, cloud architecture fundamentals (Azure/AWS/GCP)
+**Expert level required:**
+
+- Confluence/SharePoint (documentation)
+- Miro/draw.io (diagramming)
+
+**Proficient level required:**
+
+- LeanIX/Bizzdesign/ARIS (repository data entry)
+- ArchiMate/C4 notation basics
+
+**Working Knowledge required:**
+
+- Excel/Power BI (data-quality reporting)
+- Git/Azure DevOps (version control for artefacts)
+
+**Awareness level expected:**
+
+- TOGAF framework concepts
+- cloud architecture fundamentals (Azure/AWS/GCP)
 
 ## Interactions with Other Roles
 

--- a/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
@@ -69,10 +69,25 @@ The Enterprise Architecture Product Owner owns the backlog for the enterprise ar
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Practice backlog and sprint/kanban management (Jira, Confluence)
-- **Proficient level required:** LeanIX/Bizzdesign/ARIS enterprise architecture platform capabilities, architecture review board workflow tooling
-- **Working Knowledge required:** TOGAF framework concepts, technology radar tooling, Power BI or equivalent for tooling health reporting
-- **Awareness level expected:** ArchiMate/C4 modelling notation, AI-assisted architecture documentation tools
+**Expert level required:**
+
+- Practice backlog and sprint/kanban management (Jira, Confluence)
+
+**Proficient level required:**
+
+- LeanIX/Bizzdesign/ARIS enterprise architecture platform capabilities
+- architecture review board workflow tooling
+
+**Working Knowledge required:**
+
+- TOGAF framework concepts
+- technology radar tooling
+- Power BI or equivalent for tooling health reporting
+
+**Awareness level expected:**
+
+- ArchiMate/C4 modelling notation
+- AI-assisted architecture documentation tools
 
 ## Interactions with Other Roles
 

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -67,10 +67,27 @@ The Enterprise Architecture Senior Engineer operates at the intersection of tech
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ArchiMate/Structurizr C4 model (architecture modeling), LeanIX/Bizzdesign (EA platforms), Miro/draw.io/Lucidchart (diagramming)
-- **Proficient level required:** Confluence/SharePoint (documentation), Git/Azure DevOps (version control), Power BI (reporting)
-- **Working Knowledge required:** ServiceNow CMDB (ITSM integration), Azure/AWS/GCP (conceptual cloud awareness)
-- **Awareness level expected:** Technology radar tooling, AI-assisted architecture tools
+**Expert level required:**
+
+- ArchiMate/Structurizr C4 model (architecture modeling)
+- LeanIX/Bizzdesign (EA platforms)
+- Miro/draw.io/Lucidchart (diagramming)
+
+**Proficient level required:**
+
+- Confluence/SharePoint (documentation)
+- Git/Azure DevOps (version control)
+- Power BI (reporting)
+
+**Working Knowledge required:**
+
+- ServiceNow CMDB (ITSM integration)
+- Azure/AWS/GCP (conceptual cloud awareness)
+
+**Awareness level expected:**
+
+- Technology radar tooling
+- AI-assisted architecture tools
 
 ## Interactions with Other Roles
 

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -81,10 +81,27 @@ The Solution Architect is responsible for designing end-to-end technical solutio
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure (design/integration), Structurizr C4/Lucidchart (solution architecture modeling), Azure Integration Services/MuleSoft
-- **Proficient level required:** Kubernetes/Docker/AKS (containerization), Azure APIM/AWS API Gateway (API management), Microsoft Entra ID/OAuth 2.0/OIDC
-- **Working Knowledge required:** Terraform/Bicep (IaC design review), AWS/GCP (cross-cloud design awareness)
-- **Awareness level expected:** ArchiMate (EA modeling), serverless architectures (Azure Functions/AWS Lambda)
+**Expert level required:**
+
+- Azure (design/integration)
+- Structurizr C4/Lucidchart (solution architecture modeling)
+- Azure Integration Services/MuleSoft
+
+**Proficient level required:**
+
+- Kubernetes/Docker/AKS (containerization)
+- Azure APIM/AWS API Gateway (API management)
+- Microsoft Entra ID/OAuth 2.0/OIDC
+
+**Working Knowledge required:**
+
+- Terraform/Bicep (IaC design review)
+- AWS/GCP (cross-cloud design awareness)
+
+**Awareness level expected:**
+
+- ArchiMate (EA modeling)
+- serverless architectures (Azure Functions/AWS Lambda)
 
 ## Interactions with Other Roles
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -64,10 +64,27 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Terraform/Ansible (IaC/automation), ServiceNow (ITSM/service catalog), Azure (IaaS architecture)
-- **Proficient level required:** CI/CD pipeline design (Azure DevOps), API gateway/integration patterns, workflow orchestration platforms
-- **Working Knowledge required:** Windows Server/Linux (administration), Azure Monitor (monitoring)
-- **Awareness level expected:** Kubernetes (container orchestration), infrastructure abstraction models
+**Expert level required:**
+
+- Terraform/Ansible (IaC/automation)
+- ServiceNow (ITSM/service catalog)
+- Azure (IaaS architecture)
+
+**Proficient level required:**
+
+- CI/CD pipeline design (Azure DevOps)
+- API gateway/integration patterns
+- workflow orchestration platforms
+
+**Working Knowledge required:**
+
+- Windows Server/Linux (administration)
+- Azure Monitor (monitoring)
+
+**Awareness level expected:**
+
+- Kubernetes (container orchestration)
+- infrastructure abstraction models
 
 ## Interactions with Other Roles
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -64,10 +64,28 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Terraform/Ansible (infrastructure automation), ServiceNow/Remedy (ITSM), PowerShell/Python (scripting)
-- **Proficient level required:** CI/CD pipeline integration (Azure DevOps/Jenkins), CMDB management, Windows Server/Linux administration
-- **Working Knowledge required:** Azure (IaaS), self-service portal configuration, monitoring integration (Azure Monitor)
-- **Awareness level expected:** Kubernetes (container orchestration), Terraform Cloud
+**Expert level required:**
+
+- Terraform/Ansible (infrastructure automation)
+- ServiceNow/Remedy (ITSM)
+- PowerShell/Python (scripting)
+
+**Proficient level required:**
+
+- CI/CD pipeline integration (Azure DevOps/Jenkins)
+- CMDB management
+- Windows Server/Linux administration
+
+**Working Knowledge required:**
+
+- Azure (IaaS)
+- self-service portal configuration
+- monitoring integration (Azure Monitor)
+
+**Awareness level expected:**
+
+- Kubernetes (container orchestration)
+- Terraform Cloud
 
 ## Interactions with Other Roles
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -65,10 +65,27 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (service catalog), Jira/Azure DevOps (backlog management), Power BI (reporting)
-- **Proficient level required:** ITIL v4, workflow visualization tools, SLA monitoring/tracking systems
-- **Working Knowledge required:** Terraform/Ansible (automation awareness), Windows Server/Linux (awareness)
-- **Awareness level expected:** Azure IaaS, onboarding workflow automation
+**Expert level required:**
+
+- ServiceNow (service catalog)
+- Jira/Azure DevOps (backlog management)
+- Power BI (reporting)
+
+**Proficient level required:**
+
+- ITIL v4
+- workflow visualization tools
+- SLA monitoring/tracking systems
+
+**Working Knowledge required:**
+
+- Terraform/Ansible (automation awareness)
+- Windows Server/Linux (awareness)
+
+**Awareness level expected:**
+
+- Azure IaaS
+- onboarding workflow automation
 
 ## Interactions with Other Roles
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -64,10 +64,28 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Terraform/Ansible (infrastructure automation), ServiceNow (ITSM/service catalog), Azure DevOps/Jenkins (CI/CD)
-- **Proficient level required:** Windows Server/Linux administration, Azure (IaaS), workflow automation platforms
-- **Working Knowledge required:** API integration frameworks, infrastructure monitoring (Azure Monitor), CMDB management
-- **Awareness level expected:** Kubernetes, infrastructure governance frameworks
+**Expert level required:**
+
+- Terraform/Ansible (infrastructure automation)
+- ServiceNow (ITSM/service catalog)
+- Azure DevOps/Jenkins (CI/CD)
+
+**Proficient level required:**
+
+- Windows Server/Linux administration
+- Azure (IaaS)
+- workflow automation platforms
+
+**Working Knowledge required:**
+
+- API integration frameworks
+- infrastructure monitoring (Azure Monitor)
+- CMDB management
+
+**Awareness level expected:**
+
+- Kubernetes
+- infrastructure governance frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/integration_middleware/integration_architect.md
+++ b/Roles/integration_middleware/integration_architect.md
@@ -79,10 +79,30 @@ The Integration Architect designs and governs the organisation's enterprise inte
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** MuleSoft Anypoint Platform (integration architecture and governance) or Azure Integration Services (APIM, Logic Apps, Service Bus, Event Grid), Apache Kafka/Confluent Platform (event streaming architecture and schema governance), API gateway configuration (Azure APIM, Kong, or AWS API Gateway — routing, policies, OAuth 2.0/JWT)
-- **Proficient level required:** OpenAPI 3.x and AsyncAPI (API specification and standards governance), B2B/EDI integration protocols (AS2, SFTP, X12, EDIFACT), Confluent Schema Registry or AWS Glue Schema Registry, Boomi or Informatica (iPaaS alternatives)
-- **Working Knowledge required:** Integration monitoring tools (Dynatrace, Datadog, Azure Application Insights — end-to-end correlation), ESB/iPaaS pattern selection and trade-off analysis, saga and outbox patterns for distributed transaction management
-- **Awareness level expected:** Dapr for event-driven microservice integration, AI-assisted integration mapping and transformation tools, CNCF CloudEvents specification
+**Expert level required:**
+
+- MuleSoft Anypoint Platform (integration architecture and governance) or Azure Integration Services (APIM, Logic Apps, Service Bus, Event Grid)
+- Apache Kafka/Confluent Platform (event streaming architecture and schema governance)
+- API gateway configuration (Azure APIM, Kong, or AWS API Gateway — routing, policies, OAuth 2.0/JWT)
+
+**Proficient level required:**
+
+- OpenAPI 3.x and AsyncAPI (API specification and standards governance)
+- B2B/EDI integration protocols (AS2, SFTP, X12, EDIFACT)
+- Confluent Schema Registry or AWS Glue Schema Registry
+- Boomi or Informatica (iPaaS alternatives)
+
+**Working Knowledge required:**
+
+- Integration monitoring tools (Dynatrace, Datadog, Azure Application Insights — end-to-end correlation)
+- ESB/iPaaS pattern selection and trade-off analysis
+- saga and outbox patterns for distributed transaction management
+
+**Awareness level expected:**
+
+- Dapr for event-driven microservice integration
+- AI-assisted integration mapping and transformation tools
+- CNCF CloudEvents specification
 
 ## Interactions with Other Roles
 

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -73,10 +73,27 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** MuleSoft Anypoint Studio/Runtime Manager or Azure Logic Apps (integration flow implementation and monitoring), REST API concepts (HTTP methods, status codes, JSON/XML transformation), OAuth 2.0 and API key authentication configuration
-- **Proficient level required:** Message routing, transformation, and error handling within integration platforms, SFTP file exchange and scheduled file processing patterns, Postman (API testing and integration validation)
-- **Working Knowledge required:** Azure Service Bus or RabbitMQ (message queue fundamentals), basic scripting for transformations (DataWeave, JavaScript, or Python), Git version control for integration artefacts
-- **Awareness level expected:** Apache Kafka fundamentals, advanced B2B/EDI protocols (AS2, X12, EDIFACT), microservices integration patterns and event-driven architecture concepts
+**Expert level required:**
+
+- MuleSoft Anypoint Studio/Runtime Manager or Azure Logic Apps (integration flow implementation and monitoring)
+- REST API concepts (HTTP methods, status codes, JSON/XML transformation)
+- OAuth 2.0 and API key authentication configuration
+
+**Proficient level required:**
+
+- Message routing, transformation, and error handling within integration platforms, SFTP file exchange and scheduled file processing patterns, Postman (API testing and integration validation)
+
+**Working Knowledge required:**
+
+- Azure Service Bus or RabbitMQ (message queue fundamentals)
+- basic scripting for transformations (DataWeave, JavaScript, or Python)
+- Git version control for integration artefacts
+
+**Awareness level expected:**
+
+- Apache Kafka fundamentals
+- advanced B2B/EDI protocols (AS2, X12, EDIFACT)
+- microservices integration patterns and event-driven architecture concepts
 
 ## Interactions with Other Roles
 

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -75,10 +75,30 @@ The Integration Product Owner owns the integration platform product backlog — 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Integration platform product backlog and sprint management (Jira, Confluence), API developer portal governance and API lifecycle deprecation communications, integration service SLA definition and performance reporting
-- **Proficient level required:** Azure API Management concepts and developer portal management, MuleSoft Anypoint Platform integration service capabilities, Apache Kafka/Confluent Platform event streaming concepts, RabbitMQ/IBM MQ messaging broker patterns
-- **Working Knowledge required:** Azure Service Bus messaging broker patterns and backlog capacity planning, TIBCO/IBM MQ legacy integration governance, integration platform FinOps and cost reporting (Power BI dashboards)
-- **Awareness level expected:** AsyncAPI specification for event-driven API governance, CNCF CloudEvents standard, AI-assisted integration mapping and transformation tools
+**Expert level required:**
+
+- Integration platform product backlog and sprint management (Jira, Confluence)
+- API developer portal governance and API lifecycle deprecation communications
+- integration service SLA definition and performance reporting
+
+**Proficient level required:**
+
+- Azure API Management concepts and developer portal management
+- MuleSoft Anypoint Platform integration service capabilities
+- Apache Kafka/Confluent Platform event streaming concepts
+- RabbitMQ/IBM MQ messaging broker patterns
+
+**Working Knowledge required:**
+
+- Azure Service Bus messaging broker patterns and backlog capacity planning
+- TIBCO/IBM MQ legacy integration governance
+- integration platform FinOps and cost reporting (Power BI dashboards)
+
+**Awareness level expected:**
+
+- AsyncAPI specification for event-driven API governance
+- CNCF CloudEvents standard
+- AI-assisted integration mapping and transformation tools
 
 ## Interactions with Other Roles
 

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -78,10 +78,29 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** MuleSoft Anypoint Platform or Azure Integration Services (complex integration flow design, Logic Apps, Service Bus, and Function-based patterns), Apache Kafka (producer/consumer development, topic design, and offset management), API gateway configuration (Azure APIM or AWS API Gateway — OAuth 2.0, rate limiting, and transformation policies)
-- **Proficient level required:** OpenAPI 3.x specification and REST API design standards, error handling patterns (DLQ, retry policies, idempotency, and saga compensation), B2B/EDI integration protocols (AS2, SFTP, X12, EDIFACT)
-- **Working Knowledge required:** Azure Event Grid or AWS EventBridge (event-driven integration patterns), DataWeave or JavaScript/Python scripting for message transformation, integration monitoring and end-to-end correlation tracing
-- **Awareness level expected:** Dapr for event-driven microservice integration patterns, schema registry tooling (Confluent Schema Registry, AWS Glue Schema Registry), CNCF CloudEvents specification
+**Expert level required:**
+
+- MuleSoft Anypoint Platform or Azure Integration Services (complex integration flow design, Logic Apps, Service Bus, and Function-based patterns)
+- Apache Kafka (producer/consumer development, topic design, and offset management)
+- API gateway configuration (Azure APIM or AWS API Gateway — OAuth 2.0, rate limiting, and transformation policies)
+
+**Proficient level required:**
+
+- OpenAPI 3.x specification and REST API design standards
+- error handling patterns (DLQ, retry policies, idempotency, and saga compensation)
+- B2B/EDI integration protocols (AS2, SFTP, X12, EDIFACT)
+
+**Working Knowledge required:**
+
+- Azure Event Grid or AWS EventBridge (event-driven integration patterns)
+- DataWeave or JavaScript/Python scripting for message transformation
+- integration monitoring and end-to-end correlation tracing
+
+**Awareness level expected:**
+
+- Dapr for event-driven microservice integration patterns
+- schema registry tooling (Confluent Schema Registry, AWS Glue Schema Registry)
+- CNCF CloudEvents specification
 
 ## Interactions with Other Roles
 

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -64,10 +64,27 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (ITSM/CMDB), HashiCorp Vault/Azure Key Vault (secrets management), Configuration-as-Code (Ansible/Chef/Puppet)
-- **Proficient level required:** Azure DevOps/Git (configuration versioning), configuration deployment orchestration, ITIL v4
-- **Working Knowledge required:** CI/CD pipeline integration, API-driven configuration management
-- **Awareness level expected:** Terraform (IaC for configuration), configuration drift detection tools
+**Expert level required:**
+
+- ServiceNow (ITSM/CMDB)
+- HashiCorp Vault/Azure Key Vault (secrets management)
+- Configuration-as-Code (Ansible/Chef/Puppet)
+
+**Proficient level required:**
+
+- Azure DevOps/Git (configuration versioning)
+- configuration deployment orchestration
+- ITIL v4
+
+**Working Knowledge required:**
+
+- CI/CD pipeline integration
+- API-driven configuration management
+
+**Awareness level expected:**
+
+- Terraform (IaC for configuration)
+- configuration drift detection tools
 
 ## Interactions with Other Roles
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -64,10 +64,27 @@ The Application Configuration Management Engineer implements and maintains confi
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow/Remedy (ITSM/CMDB), Ansible/Chef/Puppet (configuration management), Git (version control)
-- **Proficient level required:** PowerShell/Python (configuration deployment scripts), CI/CD pipeline integration, configuration validation tools
-- **Working Knowledge required:** Azure Key Vault/HashiCorp Vault (secrets management), ITIL v4
-- **Awareness level expected:** Terraform (IaC), configuration drift detection tools
+**Expert level required:**
+
+- ServiceNow/Remedy (ITSM/CMDB)
+- Ansible/Chef/Puppet (configuration management)
+- Git (version control)
+
+**Proficient level required:**
+
+- PowerShell/Python (configuration deployment scripts)
+- CI/CD pipeline integration
+- configuration validation tools
+
+**Working Knowledge required:**
+
+- Azure Key Vault/HashiCorp Vault (secrets management)
+- ITIL v4
+
+**Awareness level expected:**
+
+- Terraform (IaC)
+- configuration drift detection tools
 
 ## Interactions with Other Roles
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -64,10 +64,28 @@ The Application Configuration Management Senior Engineer leads the implementatio
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Ansible/Chef/Puppet (enterprise config management), HashiCorp Vault/Azure Key Vault (secrets), Configuration-as-Code frameworks
-- **Proficient level required:** ServiceNow/Remedy (ITSM), CI/CD pipeline integration (Azure DevOps), configuration drift detection
-- **Working Knowledge required:** Git (version control), ITIL v4, configuration auditing/compliance tools
-- **Awareness level expected:** Terraform (IaC), AI-driven configuration management
+**Expert level required:**
+
+- Ansible/Chef/Puppet (enterprise config management)
+- HashiCorp Vault/Azure Key Vault (secrets)
+- Configuration-as-Code frameworks
+
+**Proficient level required:**
+
+- ServiceNow/Remedy (ITSM)
+- CI/CD pipeline integration (Azure DevOps)
+- configuration drift detection
+
+**Working Knowledge required:**
+
+- Git (version control)
+- ITIL v4
+- configuration auditing/compliance tools
+
+**Awareness level expected:**
+
+- Terraform (IaC)
+- AI-driven configuration management
 
 ## Interactions with Other Roles
 

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -75,10 +75,27 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (ITSM/ITOM/HRSD), Jira/Azure DevOps (backlog management), Power BI/ServiceNow dashboards
-- **Proficient level required:** ServiceNow Discovery/CMDB, ServiceNow Virtual Agent/Now Assist AI, ITIL v4
-- **Working Knowledge required:** PagerDuty/Dynatrace/Prometheus (ITSM integrations), PowerShell automation
-- **Awareness level expected:** AI-driven ITSM automation, ServiceNow App Engine
+**Expert level required:**
+
+- ServiceNow (ITSM/ITOM/HRSD)
+- Jira/Azure DevOps (backlog management)
+- Power BI/ServiceNow dashboards
+
+**Proficient level required:**
+
+- ServiceNow Discovery/CMDB
+- ServiceNow Virtual Agent/Now Assist AI
+- ITIL v4
+
+**Working Knowledge required:**
+
+- PagerDuty/Dynatrace/Prometheus (ITSM integrations)
+- PowerShell automation
+
+**Awareness level expected:**
+
+- AI-driven ITSM automation
+- ServiceNow App Engine
 
 ## Interactions with Other Roles
 

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -73,10 +73,26 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Kubernetes cluster operations (kubectl, namespaces, Deployments, StatefulSets, DaemonSets, RBAC), Container runtime technologies (Docker, containerd, CRI-O) and image management, Kubernetes networking (CNI plugins, Services, Ingress controllers, NetworkPolicies), Helm for application package management and chart creation and maintenance
-- **Proficient level required:** Kubernetes storage (PersistentVolumes, PVCs, CSI drivers, StorageClasses), Prometheus and Grafana for cluster monitoring, alerting, and dashboards, Kubernetes security (Pod Security Standards, RBAC, Secrets management, image scanning)
-- **Working Knowledge required:** GitOps deployment tools (ArgoCD, Flux) for declarative workload delivery, Linux system administration and container OS fundamentals (cgroups, namespaces, systemd)
-- **Awareness level expected:** Service mesh concepts (Istio, Linkerd) for advanced traffic management and mTLS, Cloud-managed Kubernetes platforms (AKS, EKS, GKE) for cloud-specific deployment and operations
+**Expert level required:**
+
+- Kubernetes cluster operations (kubectl, namespaces, Deployments, StatefulSets, DaemonSets, RBAC)
+- Container runtime technologies (Docker, containerd, CRI-O) and image management
+- Kubernetes networking (CNI plugins, Services, Ingress controllers, NetworkPolicies)
+- Helm for application package management and chart creation and maintenance
+
+**Proficient level required:**
+
+- Kubernetes storage (PersistentVolumes, PVCs, CSI drivers, StorageClasses), Prometheus and Grafana for cluster monitoring, alerting, and dashboards, Kubernetes security (Pod Security Standards, RBAC, Secrets management, image scanning)
+
+**Working Knowledge required:**
+
+- GitOps deployment tools (ArgoCD, Flux) for declarative workload delivery
+- Linux system administration and container OS fundamentals (cgroups, namespaces, systemd)
+
+**Awareness level expected:**
+
+- Service mesh concepts (Istio, Linkerd) for advanced traffic management and mTLS
+- Cloud-managed Kubernetes platforms (AKS, EKS, GKE) for cloud-specific deployment and operations
 
 ## Interactions with Other Roles
 

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -72,10 +72,22 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Agile product ownership tools (Jira, Confluence) for Kubernetes platform backlog, roadmap, and sprint management, Kubernetes platform concepts (namespaces, workloads, resource quotas, RBAC, admission policies) for product decision-making, Container platform service catalogue and SLA definition for internal platform consumers
-- **Proficient level required:** GitOps deployment model (ArgoCD, Flux) for understanding platform delivery patterns and acceptance criteria, Container monitoring and availability dashboards (Prometheus, Grafana) for SLA tracking and stakeholder reporting, Power BI or Tableau for container platform adoption, cost, and usage metrics
-- **Working Knowledge required:** Kubernetes governance tools (OPA, Kyverno, Gatekeeper) for informing policy product decisions, Cloud-managed Kubernetes services (AKS, EKS, GKE) from a service catalogue and cost perspective
-- **Awareness level expected:** Service mesh capabilities (Istio, Linkerd) for evaluating advanced platform feature roadmap items, FinOps tooling for Kubernetes cost visibility, namespace-level chargeback, and reserved capacity
+**Expert level required:**
+
+- Agile product ownership tools (Jira, Confluence) for Kubernetes platform backlog, roadmap, and sprint management, Kubernetes platform concepts (namespaces, workloads, resource quotas, RBAC, admission policies) for product decision-making, Container platform service catalogue and SLA definition for internal platform consumers
+
+**Proficient level required:**
+
+- GitOps deployment model (ArgoCD, Flux) for understanding platform delivery patterns and acceptance criteria, Container monitoring and availability dashboards (Prometheus, Grafana) for SLA tracking and stakeholder reporting, Power BI or Tableau for container platform adoption, cost, and usage metrics
+
+**Working Knowledge required:**
+
+- Kubernetes governance tools (OPA, Kyverno, Gatekeeper) for informing policy product decisions
+- Cloud-managed Kubernetes services (AKS, EKS, GKE) from a service catalogue and cost perspective
+
+**Awareness level expected:**
+
+- Service mesh capabilities (Istio, Linkerd) for evaluating advanced platform feature roadmap items, FinOps tooling for Kubernetes cost visibility, namespace-level chargeback, and reserved capacity
 
 ## Interactions with Other Roles
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -74,10 +74,25 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Advanced Kubernetes (CRDs, Operators, admission controllers, API extension mechanisms), Service mesh implementations (Istio, Linkerd, Consul) for traffic management, mTLS, and observability, GitOps tools (ArgoCD, Flux, Fleet) for declarative multi-cluster management, Policy engines (OPA/Gatekeeper, Kyverno) for admission control and governance enforcement
-- **Proficient level required:** Container security platforms (Aqua Security, Prisma Cloud, NeuVector) for runtime protection, Observability stacks (Prometheus, Grafana, OpenTelemetry, Jaeger) for full-stack cluster visibility, CNI plugins (Calico, Cilium, Multus) for advanced Kubernetes networking
-- **Working Knowledge required:** Infrastructure as Code (Terraform, Pulumi) for cluster provisioning and lifecycle management, Multi-cluster management platforms (Rancher, VMware Tanzu, Red Hat OpenShift)
-- **Awareness level expected:** eBPF-based networking and security (Cilium, Hubble, Tetragon) for next-generation cluster observability, WASM and container-native computing patterns for edge and serverless Kubernetes workloads
+**Expert level required:**
+
+- Advanced Kubernetes (CRDs, Operators, admission controllers, API extension mechanisms), Service mesh implementations (Istio, Linkerd, Consul) for traffic management, mTLS, and observability, GitOps tools (ArgoCD, Flux, Fleet) for declarative multi-cluster management, Policy engines (OPA/Gatekeeper, Kyverno) for admission control and governance enforcement
+
+**Proficient level required:**
+
+- Container security platforms (Aqua Security, Prisma Cloud, NeuVector) for runtime protection
+- Observability stacks (Prometheus, Grafana, OpenTelemetry, Jaeger) for full-stack cluster visibility
+- CNI plugins (Calico, Cilium, Multus) for advanced Kubernetes networking
+
+**Working Knowledge required:**
+
+- Infrastructure as Code (Terraform, Pulumi) for cluster provisioning and lifecycle management
+- Multi-cluster management platforms (Rancher, VMware Tanzu, Red Hat OpenShift)
+
+**Awareness level expected:**
+
+- eBPF-based networking and security (Cilium, Hubble, Tetragon) for next-generation cluster observability
+- WASM and container-native computing patterns for edge and serverless Kubernetes workloads
 
 ## Interactions with Other Roles
 

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -75,10 +75,21 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure/AWS/GCP at architectural governance depth
-- **Proficient level required:** Terraform/IaC tooling for standards oversight
-- **Working Knowledge required:** Kubernetes at governance and platform strategy depth
-- **Awareness level expected:** FinOps tooling (Azure Cost Management, Cloudability) for chapter budget oversight
+**Expert level required:**
+
+- Azure/AWS/GCP at architectural governance depth
+
+**Proficient level required:**
+
+- Terraform/IaC tooling for standards oversight
+
+**Working Knowledge required:**
+
+- Kubernetes at governance and platform strategy depth
+
+**Awareness level expected:**
+
+- FinOps tooling (Azure Cost Management, Cloudability) for chapter budget oversight
 
 ### Qualifications
 

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -75,10 +75,21 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure Synapse/Databricks/Snowflake at architecture governance depth
-- **Proficient level required:** Data governance platforms (Purview, Collibra, Alation)
-- **Working Knowledge required:** ML platforms (Azure ML, SageMaker) at strategic oversight
-- **Awareness level expected:** AI ethics and responsible AI frameworks (NIST AI RMF, EU AI Act)
+**Expert level required:**
+
+- Azure Synapse/Databricks/Snowflake at architecture governance depth
+
+**Proficient level required:**
+
+- Data governance platforms (Purview, Collibra, Alation)
+
+**Working Knowledge required:**
+
+- ML platforms (Azure ML, SageMaker) at strategic oversight
+
+**Awareness level expected:**
+
+- AI ethics and responsible AI frameworks (NIST AI RMF, EU AI Act)
 
 ### Qualifications
 

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -74,10 +74,21 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** GitHub Actions/Azure DevOps at governance depth
-- **Proficient level required:** Internal Developer Platform tooling (Backstage, Port) for strategy
-- **Working Knowledge required:** DORA metrics tooling for chapter performance visibility
-- **Awareness level expected:** Integration platforms (Azure API Management, MuleSoft) at architecture depth
+**Expert level required:**
+
+- GitHub Actions/Azure DevOps at governance depth
+
+**Proficient level required:**
+
+- Internal Developer Platform tooling (Backstage, Port) for strategy
+
+**Working Knowledge required:**
+
+- DORA metrics tooling for chapter performance visibility
+
+**Awareness level expected:**
+
+- Integration platforms (Azure API Management, MuleSoft) at architecture depth
 
 ### Qualifications
 

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -76,10 +76,21 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft 365 at administrative and governance depth
-- **Proficient level required:** Microsoft Intune/Endpoint Manager at strategy depth
-- **Working Knowledge required:** Collaboration analytics (Viva Insights, Teams analytics) for workplace metrics
-- **Awareness level expected:** ITSM platforms (ServiceNow) for end-user service governance
+**Expert level required:**
+
+- Microsoft 365 at administrative and governance depth
+
+**Proficient level required:**
+
+- Microsoft Intune/Endpoint Manager at strategy depth
+
+**Working Knowledge required:**
+
+- Collaboration analytics (Viva Insights, Teams analytics) for workplace metrics
+
+**Awareness level expected:**
+
+- ITSM platforms (ServiceNow) for end-user service governance
 
 ### Qualifications
 

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -79,10 +79,21 @@ The Product Area Lead (PAL) is a senior IT management role responsible for the e
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** P&L management and business case tooling (Excel, Tableau, PowerBI)
-- **Proficient level required:** Programme/portfolio governance platforms (ServiceNow PPM, Jira Align)
-- **Working Knowledge required:** Azure/AWS/GCP at awareness level for investment decisions
-- **Awareness level expected:** ITIL 4 / SAFe framework literacy
+**Expert level required:**
+
+- P&L management and business case tooling (Excel, Tableau, PowerBI)
+
+**Proficient level required:**
+
+- Programme/portfolio governance platforms (ServiceNow PPM, Jira Align)
+
+**Working Knowledge required:**
+
+- Azure/AWS/GCP at awareness level for investment decisions
+
+**Awareness level expected:**
+
+- ITIL 4 / SAFe framework literacy
 
 ## Interactions with Other Roles
 

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -75,10 +75,21 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Sentinel/Defender at CSPM governance depth
-- **Proficient level required:** Microsoft Entra ID / Azure AD at IAM governance depth
-- **Working Knowledge required:** Zero trust architecture frameworks and tooling
-- **Awareness level expected:** GRC platforms (ServiceNow GRC, Archer) for risk oversight
+**Expert level required:**
+
+- Microsoft Sentinel/Defender at CSPM governance depth
+
+**Proficient level required:**
+
+- Microsoft Entra ID / Azure AD at IAM governance depth
+
+**Working Knowledge required:**
+
+- Zero trust architecture frameworks and tooling
+
+**Awareness level expected:**
+
+- GRC platforms (ServiceNow GRC, Archer) for risk oversight
 
 ### Qualifications
 

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -75,10 +75,21 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow at platform governance and architecture depth
-- **Proficient level required:** ITIL 4 / SIAM framework expertise
-- **Working Knowledge required:** Enterprise architecture tools (LeanIX, Ardoq) at governance depth
-- **Awareness level expected:** Power BI/Tableau for service performance reporting
+**Expert level required:**
+
+- ServiceNow at platform governance and architecture depth
+
+**Proficient level required:**
+
+- ITIL 4 / SIAM framework expertise
+
+**Working Knowledge required:**
+
+- Enterprise architecture tools (LeanIX, Ardoq) at governance depth
+
+**Awareness level expected:**
+
+- Power BI/Tableau for service performance reporting
 
 ### Qualifications
 

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -76,10 +76,21 @@ The Technical Area Lead (TAL) is the senior technical authority for a defined IT
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Architecture governance tools (LeanIX, Ardoq, Sparx EA)
-- **Proficient level required:** Azure/AWS/GCP at strategic oversight depth
-- **Working Knowledge required:** GitHub/Azure DevOps for engineering visibility and metrics
-- **Awareness level expected:** DORA metrics tooling and delivery performance dashboards
+**Expert level required:**
+
+- Architecture governance tools (LeanIX, Ardoq, Sparx EA)
+
+**Proficient level required:**
+
+- Azure/AWS/GCP at strategic oversight depth
+
+**Working Knowledge required:**
+
+- GitHub/Azure DevOps for engineering visibility and metrics
+
+**Awareness level expected:**
+
+- DORA metrics tooling and delivery performance dashboards
 
 ## Interactions with Other Roles
 

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -68,10 +68,24 @@ The Technical Community Leader is a senior individual contributor responsible fo
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** GitHub/GitLab community and repository features, Confluence/SharePoint knowledge base authoring
-- **Proficient level required:** Learning management platforms (Degreed, Cornerstone, internal LMS), Miro/Mural collaborative facilitation
-- **Working Knowledge required:** Metrics and analytics tooling (survey platforms, community engagement dashboards)
-- **Awareness level expected:** AI-powered learning and content tools, community platform analytics
+**Expert level required:**
+
+- GitHub/GitLab community and repository features
+- Confluence/SharePoint knowledge base authoring
+
+**Proficient level required:**
+
+- Learning management platforms (Degreed, Cornerstone, internal LMS)
+- Miro/Mural collaborative facilitation
+
+**Working Knowledge required:**
+
+- Metrics and analytics tooling (survey platforms, community engagement dashboards)
+
+**Awareness level expected:**
+
+- AI-powered learning and content tools
+- community platform analytics
 
 ### Qualifications
 

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -79,10 +79,28 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** LitmusChaos and Chaos Mesh for Kubernetes fault injection experiments, Kubernetes failure modes and cluster-level chaos (pod termination, node failure, resource pressure), Prometheus and Grafana for steady-state measurement and experiment impact validation, Hypothesis-driven chaos experiment design and blast radius controls
-- **Proficient level required:** Gremlin commercial chaos platform, AWS Fault Injection Simulator (FIS) and Azure Chaos Studio, Toxiproxy and tc-netem for network fault injection (latency, packet loss, bandwidth throttling), k6 and Locust for steady-state traffic generation during experiments
-- **Working Knowledge required:** Istio and Envoy service mesh fault injection, GitHub Actions and Azure DevOps for CI chaos pipeline integration, Python, Go, and Bash for experiment automation and tooling
-- **Awareness level expected:** OpenTelemetry for chaos observability integration, Emerging GameDay automation frameworks and chaos orchestration tooling
+**Expert level required:**
+
+- LitmusChaos and Chaos Mesh for Kubernetes fault injection experiments
+- Kubernetes failure modes and cluster-level chaos (pod termination, node failure, resource pressure)
+- Prometheus and Grafana for steady-state measurement and experiment impact validation
+- Hypothesis-driven chaos experiment design and blast radius controls
+
+**Proficient level required:**
+
+- Gremlin commercial chaos platform
+- AWS Fault Injection Simulator (FIS) and Azure Chaos Studio
+- Toxiproxy and tc-netem for network fault injection (latency, packet loss, bandwidth throttling)
+- k6 and Locust for steady-state traffic generation during experiments
+
+**Working Knowledge required:**
+
+- Istio and Envoy service mesh fault injection, GitHub Actions and Azure DevOps for CI chaos pipeline integration, Python, Go, and Bash for experiment automation and tooling
+
+**Awareness level expected:**
+
+- OpenTelemetry for chaos observability integration
+- Emerging GameDay automation frameworks and chaos orchestration tooling
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -55,10 +55,30 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Azure AI Foundry / Amazon Bedrock / Vertex AI LLM gateway platforms, Vector databases (Pinecone, pgvector, Azure AI Search, Qdrant), RAG and agentic frameworks (LangChain, LlamaIndex, Semantic Kernel, AutoGen), AI governance and responsible AI frameworks (Microsoft RAI, NIST AI RMF, EU AI Act)
-- **Proficient level required:** Model serving infrastructure (vLLM, NVIDIA Triton, KServe, Ollama), MLflow and Weights & Biases for experiment tracking and model registry, AI observability platforms (LangSmith, Arize AI, WhyLabs), Kubernetes GPU Operator and GPU cluster orchestration
-- **Working Knowledge required:** Fine-tuning and PEFT frameworks (LoRA, QLoRA, RLHF tooling), Edge AI inference platforms (NVIDIA Jetson, Intel OpenVINO, ONNX Runtime), TOGAF or equivalent enterprise architecture frameworks
-- **Awareness level expected:** Emerging foundation model architectures and multimodal capabilities, EU AI Act and evolving global AI regulatory landscape
+**Expert level required:**
+
+- Azure AI Foundry / Amazon Bedrock / Vertex AI LLM gateway platforms
+- Vector databases (Pinecone, pgvector, Azure AI Search, Qdrant)
+- RAG and agentic frameworks (LangChain, LlamaIndex, Semantic Kernel, AutoGen)
+- AI governance and responsible AI frameworks (Microsoft RAI, NIST AI RMF, EU AI Act)
+
+**Proficient level required:**
+
+- Model serving infrastructure (vLLM, NVIDIA Triton, KServe, Ollama)
+- MLflow and Weights & Biases for experiment tracking and model registry
+- AI observability platforms (LangSmith, Arize AI, WhyLabs)
+- Kubernetes GPU Operator and GPU cluster orchestration
+
+**Working Knowledge required:**
+
+- Fine-tuning and PEFT frameworks (LoRA, QLoRA, RLHF tooling)
+- Edge AI inference platforms (NVIDIA Jetson, Intel OpenVINO, ONNX Runtime)
+- TOGAF or equivalent enterprise architecture frameworks
+
+**Awareness level expected:**
+
+- Emerging foundation model architectures and multimodal capabilities
+- EU AI Act and evolving global AI regulatory landscape
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -69,10 +69,30 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** LLM serving platforms (vLLM, Ollama, Azure AI Foundry, Amazon Bedrock), Vector database operations (Pinecone, pgvector, Weaviate, Qdrant), RAG pipeline frameworks (LangChain, LlamaIndex, Semantic Kernel), Kubernetes with GPU Operator for AI workload orchestration
-- **Proficient level required:** Agentic AI frameworks (AutoGen, CrewAI, LangGraph, Azure AI Agents), AI evaluation tools (RAGAS, TruLens, Azure AI Evaluation SDK, LangSmith), MLflow and Weights & Biases for experiment tracking, Infrastructure as Code (Terraform, Bicep, Pulumi)
-- **Working Knowledge required:** CI/CD for AI pipelines (GitHub Actions, Azure DevOps, GitLab CI), Prompt Flow and PromptLayer for prompt versioning and management, Python ML/AI ecosystem (transformers, pydantic-ai)
-- **Awareness level expected:** Emerging model quantisation and inference optimisation techniques, Responsible AI governance tooling and regulatory framework developments
+**Expert level required:**
+
+- LLM serving platforms (vLLM, Ollama, Azure AI Foundry, Amazon Bedrock)
+- Vector database operations (Pinecone, pgvector, Weaviate, Qdrant)
+- RAG pipeline frameworks (LangChain, LlamaIndex, Semantic Kernel)
+- Kubernetes with GPU Operator for AI workload orchestration
+
+**Proficient level required:**
+
+- Agentic AI frameworks (AutoGen, CrewAI, LangGraph, Azure AI Agents)
+- AI evaluation tools (RAGAS, TruLens, Azure AI Evaluation SDK, LangSmith)
+- MLflow and Weights & Biases for experiment tracking
+- Infrastructure as Code (Terraform, Bicep, Pulumi)
+
+**Working Knowledge required:**
+
+- CI/CD for AI pipelines (GitHub Actions, Azure DevOps, GitLab CI)
+- Prompt Flow and PromptLayer for prompt versioning and management
+- Python ML/AI ecosystem (transformers, pydantic-ai)
+
+**Awareness level expected:**
+
+- Emerging model quantisation and inference optimisation techniques
+- Responsible AI governance tooling and regulatory framework developments
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/infrastructure_automation_architect.md
+++ b/Roles/modern_infrastructure/infrastructure_automation_architect.md
@@ -78,10 +78,28 @@ The Infrastructure Automation Architect designs and governs the organisation's e
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Terraform/Pulumi/Bicep, Ansible, GitOps tooling (ArgoCD/Flux), PowerShell DSC
-- **Proficient level required:** GitHub Actions/Azure DevOps Pipelines, HashiCorp Vault/SOPS secrets management, Packer
-- **Working Knowledge required:** Crossplane, Inspec/OPA compliance testing
-- **Awareness level expected:** Winglang, Dagger
+**Expert level required:**
+
+- Terraform/Pulumi/Bicep
+- Ansible
+- GitOps tooling (ArgoCD/Flux)
+- PowerShell DSC
+
+**Proficient level required:**
+
+- GitHub Actions/Azure DevOps Pipelines
+- HashiCorp Vault/SOPS secrets management
+- Packer
+
+**Working Knowledge required:**
+
+- Crossplane
+- Inspec/OPA compliance testing
+
+**Awareness level expected:**
+
+- Winglang
+- Dagger
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -69,10 +69,25 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** MLflow for experiment tracking, model registry, and pipeline orchestration, Kubeflow and Apache Airflow for ML workflow orchestration and scheduling, Kubernetes with GPU node pools for model training and serving, LLM serving platforms (vLLM, Azure AI Foundry, Amazon Bedrock, Vertex AI)
-- **Proficient level required:** Vector databases (Pinecone, Weaviate, pgvector, Qdrant) and RAG frameworks (LangChain, LlamaIndex), Feature stores (Feast, Tecton) for ML feature engineering, Distributed training frameworks (DeepSpeed, FSDP) for large model training, RAGAS and TruLens for LLM evaluation and quality measurement
-- **Working Knowledge required:** ONNX, TensorFlow Lite, and TinyML frameworks for edge model optimisation, Azure IoT Edge and AWS Greengrass for edge ML deployment pipelines, Responsible AI governance tooling and model risk management frameworks
-- **Awareness level expected:** Emerging agentic AI frameworks (AutoGen, LangGraph) for MLOps pipeline automation, Next-generation foundation model fine-tuning and PEFT approaches (LoRA, QLoRA)
+**Expert level required:**
+
+- MLflow for experiment tracking, model registry, and pipeline orchestration, Kubeflow and Apache Airflow for ML workflow orchestration and scheduling, Kubernetes with GPU node pools for model training and serving, LLM serving platforms (vLLM, Azure AI Foundry, Amazon Bedrock, Vertex AI)
+
+**Proficient level required:**
+
+- Vector databases (Pinecone, Weaviate, pgvector, Qdrant) and RAG frameworks (LangChain, LlamaIndex)
+- Feature stores (Feast, Tecton) for ML feature engineering
+- Distributed training frameworks (DeepSpeed, FSDP) for large model training
+- RAGAS and TruLens for LLM evaluation and quality measurement
+
+**Working Knowledge required:**
+
+- ONNX, TensorFlow Lite, and TinyML frameworks for edge model optimisation, Azure IoT Edge and AWS Greengrass for edge ML deployment pipelines, Responsible AI governance tooling and model risk management frameworks
+
+**Awareness level expected:**
+
+- Emerging agentic AI frameworks (AutoGen, LangGraph) for MLOps pipeline automation
+- Next-generation foundation model fine-tuning and PEFT approaches (LoRA, QLoRA)
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -79,10 +79,22 @@ The Observability Architect designs and governs the organisation's full-stack ob
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** OpenTelemetry SDK, Collector pipelines, and semantic conventions for enterprise instrumentation standards, Prometheus and Thanos / Grafana Mimir for large-scale metrics storage and querying, SLO/SLI framework design with error budget policies and burn-rate alerting, Grafana stack (Loki, Tempo, dashboards) and Datadog/Dynatrace for enterprise-grade observability
-- **Proficient level required:** Elastic Stack (Elasticsearch, Logstash, Kibana, Elastic APM) for log and APM architecture, Azure Monitor, Log Analytics Workspace, and Application Insights for cloud-native observability, Fluent Bit, Fluentd, and Vector for log pipeline agent design, Jaeger and Grafana Tempo for distributed tracing architecture
-- **Working Knowledge required:** Kubernetes-native observability (kube-state-metrics, node exporter, service mesh telemetry), Alertmanager, PagerDuty, and OpsGenie for alerting governance and on-call routing, OpenTelemetry Collector edge deployment for resource-constrained environments
-- **Awareness level expected:** AI/ML-assisted anomaly detection in observability platforms, Emerging eBPF-based continuous profiling tools (Parca, Pyroscope)
+**Expert level required:**
+
+- OpenTelemetry SDK, Collector pipelines, and semantic conventions for enterprise instrumentation standards, Prometheus and Thanos / Grafana Mimir for large-scale metrics storage and querying, SLO/SLI framework design with error budget policies and burn-rate alerting, Grafana stack (Loki, Tempo, dashboards) and Datadog/Dynatrace for enterprise-grade observability
+
+**Proficient level required:**
+
+- Elastic Stack (Elasticsearch, Logstash, Kibana, Elastic APM) for log and APM architecture, Azure Monitor, Log Analytics Workspace, and Application Insights for cloud-native observability, Fluent Bit, Fluentd, and Vector for log pipeline agent design, Jaeger and Grafana Tempo for distributed tracing architecture
+
+**Working Knowledge required:**
+
+- Kubernetes-native observability (kube-state-metrics, node exporter, service mesh telemetry), Alertmanager, PagerDuty, and OpsGenie for alerting governance and on-call routing, OpenTelemetry Collector edge deployment for resource-constrained environments
+
+**Awareness level expected:**
+
+- AI/ML-assisted anomaly detection in observability platforms
+- Emerging eBPF-based continuous profiling tools (Parca, Pyroscope)
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -72,10 +72,25 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Prometheus and Grafana for metrics collection, dashboard creation, and alerting rule configuration, Log aggregation systems (Elasticsearch/ELK Stack, Loki, Splunk) for centralised log management, PromQL and LogQL query languages for telemetry data analysis, Alert threshold configuration and noise reduction for actionable monitoring
-- **Proficient level required:** OpenTelemetry instrumentation basics and Collector configuration, Fluent Bit and Fluentd for log pipeline setup and log collection agents, Datadog or Dynatrace for APM and infrastructure monitoring, Distributed tracing concepts with Jaeger or Grafana Tempo
-- **Working Knowledge required:** Kubernetes monitoring stack (kube-state-metrics, node exporter, metrics-server), Alertmanager, PagerDuty, and OpsGenie for alert routing and on-call notification, Scripting and automation for monitoring configuration and dashboard-as-code
-- **Awareness level expected:** AI/ML-assisted anomaly detection capabilities in modern observability platforms, eBPF-based observability tooling and low-overhead profiling approaches
+**Expert level required:**
+
+- Prometheus and Grafana for metrics collection, dashboard creation, and alerting rule configuration, Log aggregation systems (Elasticsearch/ELK Stack, Loki, Splunk) for centralised log management, PromQL and LogQL query languages for telemetry data analysis, Alert threshold configuration and noise reduction for actionable monitoring
+
+**Proficient level required:**
+
+- OpenTelemetry instrumentation basics and Collector configuration
+- Fluent Bit and Fluentd for log pipeline setup and log collection agents
+- Datadog or Dynatrace for APM and infrastructure monitoring
+- Distributed tracing concepts with Jaeger or Grafana Tempo
+
+**Working Knowledge required:**
+
+- Kubernetes monitoring stack (kube-state-metrics, node exporter, metrics-server), Alertmanager, PagerDuty, and OpsGenie for alert routing and on-call notification, Scripting and automation for monitoring configuration and dashboard-as-code
+
+**Awareness level expected:**
+
+- AI/ML-assisted anomaly detection capabilities in modern observability platforms
+- eBPF-based observability tooling and low-overhead profiling approaches
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -72,10 +72,28 @@ The Observability Product Owner manages the observability platform portfolio, de
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise observability platforms (Datadog, Dynatrace, New Relic) at product feature and roadmap level, Jira and Confluence for backlog management and sprint planning, SLO/SLI frameworks and error budget governance for reliability management, PagerDuty and OpsGenie for incident management integration and on-call governance
-- **Proficient level required:** Prometheus and Grafana open-source observability stack at product capability level, Elastic Stack and Splunk for log management product features and adoption planning, Synthetic monitoring and Real User Monitoring (RUM) product capabilities, Dashboard and visualisation platform features for self-service adoption
-- **Working Knowledge required:** OpenTelemetry instrumentation concepts and team adoption patterns, Distributed tracing systems (Jaeger, Zipkin) and APM tool features, Time-series database concepts, cardinality management, and telemetry cost governance
-- **Awareness level expected:** AI-assisted root cause analysis and AIOps capabilities in observability platforms, eBPF-based observability and continuous profiling as emerging product features
+**Expert level required:**
+
+- Enterprise observability platforms (Datadog, Dynatrace, New Relic) at product feature and roadmap level
+- Jira and Confluence for backlog management and sprint planning
+- SLO/SLI frameworks and error budget governance for reliability management
+- PagerDuty and OpsGenie for incident management integration and on-call governance
+
+**Proficient level required:**
+
+- Prometheus and Grafana open-source observability stack at product capability level
+- Elastic Stack and Splunk for log management product features and adoption planning
+- Synthetic monitoring and Real User Monitoring (RUM) product capabilities
+- Dashboard and visualisation platform features for self-service adoption
+
+**Working Knowledge required:**
+
+- OpenTelemetry instrumentation concepts and team adoption patterns, Distributed tracing systems (Jaeger, Zipkin) and APM tool features, Time-series database concepts, cardinality management, and telemetry cost governance
+
+**Awareness level expected:**
+
+- AI-assisted root cause analysis and AIOps capabilities in observability platforms
+- eBPF-based observability and continuous profiling as emerging product features
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -74,10 +74,24 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Prometheus, Grafana, and Thanos for advanced metrics collection, long-term storage, and SLO dashboarding, OpenTelemetry SDK and Collector for multi-signal distributed tracing and instrumentation, SLO/SLI implementation and error budget management for business-critical services, Datadog, Dynatrace, or New Relic for full-stack APM and enterprise observability
-- **Proficient level required:** Elastic Stack (Elasticsearch, Loki, Splunk) for advanced log aggregation and correlation analysis, Jaeger and Zipkin for distributed trace analysis in microservice architectures, Alertmanager, PagerDuty, and OpsGenie for advanced on-call routing and alert deduplication, Service mesh observability with Istio and Linkerd telemetry integration
-- **Working Knowledge required:** AI/ML-based anomaly detection and intelligent alerting systems, Observability-as-code frameworks and IaC tooling for telemetry configuration, Real-time analytics platforms for high-cardinality telemetry data processing
-- **Awareness level expected:** eBPF-based continuous profiling tools (Parca, Pyroscope), OpenTelemetry emerging signals (profiling, events)
+**Expert level required:**
+
+- Prometheus, Grafana, and Thanos for advanced metrics collection, long-term storage, and SLO dashboarding, OpenTelemetry SDK and Collector for multi-signal distributed tracing and instrumentation, SLO/SLI implementation and error budget management for business-critical services, Datadog, Dynatrace, or New Relic for full-stack APM and enterprise observability
+
+**Proficient level required:**
+
+- Elastic Stack (Elasticsearch, Loki, Splunk) for advanced log aggregation and correlation analysis, Jaeger and Zipkin for distributed trace analysis in microservice architectures, Alertmanager, PagerDuty, and OpsGenie for advanced on-call routing and alert deduplication, Service mesh observability with Istio and Linkerd telemetry integration
+
+**Working Knowledge required:**
+
+- AI/ML-based anomaly detection and intelligent alerting systems
+- Observability-as-code frameworks and IaC tooling for telemetry configuration
+- Real-time analytics platforms for high-cardinality telemetry data processing
+
+**Awareness level expected:**
+
+- eBPF-based continuous profiling tools (Parca, Pyroscope)
+- OpenTelemetry emerging signals (profiling, events)
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -68,10 +68,28 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Backstage/Port IDP, Kubernetes, GitOps (ArgoCD/Flux), Software supply chain tooling (SLSA/Sigstore/SBOM)
-- **Proficient level required:** Terraform/Pulumi/Bicep, GitHub Actions/Azure DevOps Pipelines, Crossplane
-- **Working Knowledge required:** Service mesh (Istio/Linkerd), OPA/Kyverno policy-as-code
-- **Awareness level expected:** WebAssembly (WASM) for platform runtimes, Dapr distributed application runtime
+**Expert level required:**
+
+- Backstage/Port IDP
+- Kubernetes
+- GitOps (ArgoCD/Flux)
+- Software supply chain tooling (SLSA/Sigstore/SBOM)
+
+**Proficient level required:**
+
+- Terraform/Pulumi/Bicep
+- GitHub Actions/Azure DevOps Pipelines
+- Crossplane
+
+**Working Knowledge required:**
+
+- Service mesh (Istio/Linkerd)
+- OPA/Kyverno policy-as-code
+
+**Awareness level expected:**
+
+- WebAssembly (WASM) for platform runtimes
+- Dapr distributed application runtime
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -64,10 +64,27 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Kubernetes and container orchestration for platform component deployment and operations, CI/CD pipeline tools (GitHub Actions, GitLab CI, Jenkins) for developer self-service automation, Infrastructure as Code (Terraform, Pulumi) for platform component provisioning, Backstage or similar developer portal configuration, plugin management, and service catalog templates
-- **Proficient level required:** GitOps tools (ArgoCD, Flux) for platform deployment management, Service catalog and golden path template authoring, Prometheus and Grafana for platform component monitoring and health dashboards, Container registries and artifact repositories (Harbor, JFrog Artifactory)
-- **Working Knowledge required:** API gateways and service mesh basics (Istio, Linkerd) for platform-level traffic management, Helm and Kustomize for Kubernetes workload packaging and customisation, Policy engines (OPA, Kyverno) for platform governance and admission control
-- **Awareness level expected:** Platform engineering maturity frameworks (CNCF Platforms whitepaper, Team Topologies), Emerging internal developer portal features and ecosystem integrations
+**Expert level required:**
+
+- Kubernetes and container orchestration for platform component deployment and operations, CI/CD pipeline tools (GitHub Actions, GitLab CI, Jenkins) for developer self-service automation, Infrastructure as Code (Terraform, Pulumi) for platform component provisioning, Backstage or similar developer portal configuration, plugin management, and service catalog templates
+
+**Proficient level required:**
+
+- GitOps tools (ArgoCD, Flux) for platform deployment management
+- Service catalog and golden path template authoring
+- Prometheus and Grafana for platform component monitoring and health dashboards
+- Container registries and artifact repositories (Harbor, JFrog Artifactory)
+
+**Working Knowledge required:**
+
+- API gateways and service mesh basics (Istio, Linkerd) for platform-level traffic management
+- Helm and Kustomize for Kubernetes workload packaging and customisation
+- Policy engines (OPA, Kyverno) for platform governance and admission control
+
+**Awareness level expected:**
+
+- Platform engineering maturity frameworks (CNCF Platforms whitepaper, Team Topologies)
+- Emerging internal developer portal features and ecosystem integrations
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -64,10 +64,27 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Backstage or similar IDP portal at product management and strategic roadmap level, Jira and Confluence for backlog management, sprint planning, and engineering team ceremonies, , NIST CSF metrics and developer productivity measurement frameworks (deployment frequency, lead time, change failure rate), Developer satisfaction measurement (NPS surveys, SPACE framework analytics)
-- **Proficient level required:** CI/CD pipeline systems (GitHub Actions, GitLab CI, Azure DevOps) at capability and self-service feature level, Kubernetes and Docker container platforms for informed product decision-making, Self-service frameworks and service catalog design principles, Developer productivity analytics tools (LinearB, Jellyfish, custom DORA dashboards)
-- **Working Knowledge required:** Infrastructure as Code platforms (Terraform, Helm) for feature scoping and acceptance criteria, GitOps tools (ArgoCD, Flux) and progressive delivery concepts, Software supply chain security and DevSecOps platform requirements
-- **Awareness level expected:** Emerging internal developer platform trends and CNCF ecosystem developments, AI-assisted developer tooling adoption patterns and GitHub Copilot productivity metrics
+**Expert level required:**
+
+- Backstage or similar IDP portal at product management and strategic roadmap level, Jira and Confluence for backlog management, sprint planning, and engineering team ceremonies, , NIST CSF metrics and developer productivity measurement frameworks (deployment frequency, lead time, change failure rate), Developer satisfaction measurement (NPS surveys, SPACE framework analytics)
+
+**Proficient level required:**
+
+- CI/CD pipeline systems (GitHub Actions, GitLab CI, Azure DevOps) at capability and self-service feature level
+- Kubernetes and Docker container platforms for informed product decision-making
+- Self-service frameworks and service catalog design principles
+- Developer productivity analytics tools (LinearB, Jellyfish, custom DORA dashboards)
+
+**Working Knowledge required:**
+
+- Infrastructure as Code platforms (Terraform, Helm) for feature scoping and acceptance criteria
+- GitOps tools (ArgoCD, Flux) and progressive delivery concepts
+- Software supply chain security and DevSecOps platform requirements
+
+**Awareness level expected:**
+
+- Emerging internal developer platform trends and CNCF ecosystem developments
+- AI-assisted developer tooling adoption patterns and GitHub Copilot productivity metrics
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -64,10 +64,25 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Backstage IDP framework including plugin development, software catalog, and scaffolding templates, Kubernetes and container orchestration for complex internal platform workloads, Terraform and Pulumi for advanced IaC automation and platform self-service provisioning, GitHub Actions and GitLab CI for CI/CD template design and golden path governance
-- **Proficient level required:** Service mesh technologies (Istio, Linkerd) for platform-level traffic management and observability, Policy engines (OPA, Kyverno) for platform governance and Kubernetes admission control, ArgoCD and Flux for GitOps platform delivery and progressive rollouts, Helm, Kustomize, and Crossplane for Kubernetes workload management
-- **Working Knowledge required:** API gateway platforms and developer-facing service exposure patterns, Software supply chain security (Sigstore, Cosign, SLSA) for platform security controls, Developer productivity analytics and , NIST CSF metrics instrumentation
-- **Awareness level expected:** Emerging platform engineering standards (CNCF Platform Engineering whitepaper, Team Topologies), Next-generation GitOps and progressive delivery tooling (Argo Rollouts, Flagger)
+**Expert level required:**
+
+- Backstage IDP framework including plugin development, software catalog, and scaffolding templates, Kubernetes and container orchestration for complex internal platform workloads, Terraform and Pulumi for advanced IaC automation and platform self-service provisioning, GitHub Actions and GitLab CI for CI/CD template design and golden path governance
+
+**Proficient level required:**
+
+- Service mesh technologies (Istio, Linkerd) for platform-level traffic management and observability, Policy engines (OPA, Kyverno) for platform governance and Kubernetes admission control, ArgoCD and Flux for GitOps platform delivery and progressive rollouts, Helm, Kustomize, and Crossplane for Kubernetes workload management
+
+**Working Knowledge required:**
+
+- API gateway platforms and developer-facing service exposure patterns
+- Software supply chain security (Sigstore, Cosign, SLSA) for platform security controls
+- Developer productivity analytics and
+- NIST CSF metrics instrumentation
+
+**Awareness level expected:**
+
+- Emerging platform engineering standards (CNCF Platform Engineering whitepaper, Team Topologies)
+- Next-generation GitOps and progressive delivery tooling (Argo Rollouts, Flagger)
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -64,10 +64,27 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Prometheus and Grafana for SLI/SLO instrumentation, error budget dashboards, and reliability monitoring, Kubernetes for container platform reliability operations and resource management, SLO/SLI framework design and error budget policy implementation, Incident management platforms (PagerDuty, OpsGenie) and runbook automation
-- **Proficient level required:** Chaos engineering tools (LitmusChaos, Gremlin, Chaos Mesh) for resilience validation, Infrastructure as Code (Terraform, Pulumi) for reliability infrastructure automation, Load testing tools (k6, Locust, Apache JMeter) for performance and capacity validation, Log aggregation systems (Loki, Elasticsearch, Splunk) for incident diagnosis
-- **Working Knowledge required:** Service mesh technologies (Istio, Linkerd) for traffic management and circuit-breaking, Datadog or New Relic for APM and synthetic monitoring, CI/CD pipeline reliability gates and progressive delivery patterns
-- **Awareness level expected:** eBPF-based observability and low-overhead profiling tools, Emerging auto-remediation and AIOps platforms for toil reduction
+**Expert level required:**
+
+- Prometheus and Grafana for SLI/SLO instrumentation, error budget dashboards, and reliability monitoring, Kubernetes for container platform reliability operations and resource management, SLO/SLI framework design and error budget policy implementation, Incident management platforms (PagerDuty, OpsGenie) and runbook automation
+
+**Proficient level required:**
+
+- Chaos engineering tools (LitmusChaos, Gremlin, Chaos Mesh) for resilience validation
+- Infrastructure as Code (Terraform, Pulumi) for reliability infrastructure automation
+- Load testing tools (k6, Locust, Apache JMeter) for performance and capacity validation
+- Log aggregation systems (Loki, Elasticsearch, Splunk) for incident diagnosis
+
+**Working Knowledge required:**
+
+- Service mesh technologies (Istio, Linkerd) for traffic management and circuit-breaking
+- Datadog or New Relic for APM and synthetic monitoring
+- CI/CD pipeline reliability gates and progressive delivery patterns
+
+**Awareness level expected:**
+
+- eBPF-based observability and low-overhead profiling tools
+- Emerging auto-remediation and AIOps platforms for toil reduction
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -81,10 +81,24 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Prometheus, Grafana, and Alertmanager for SLO instrumentation, error budget burn-rate alerting, and reliability dashboards, Kubernetes (Helm, Kustomize) for cluster reliability operations and resource management, OpenTelemetry for distributed tracing and multi-signal observability, SLO/SLI/SLA framework design and error budget policy implementation for business-critical services
-- **Proficient level required:** LitmusChaos, Chaos Mesh, and AWS FIS for chaos engineering experiment design and execution, PagerDuty and OpsGenie for on-call programme management and incident routing, k6 and Locust for load testing, capacity validation, and traffic modelling, Python and Go for SRE tooling development and runbook automation
-- **Working Knowledge required:** Terraform and Pulumi for reliability infrastructure as code, Argo Rollouts and Flagger for progressive delivery and canary deployments, Datadog and Dynatrace for supplementary APM and infrastructure observability
-- **Awareness level expected:** AIOps and ML-assisted incident detection and anomaly correlation platforms, eBPF-based observability tooling (Pixie, Tetragon)
+**Expert level required:**
+
+- Prometheus, Grafana, and Alertmanager for SLO instrumentation, error budget burn-rate alerting, and reliability dashboards, Kubernetes (Helm, Kustomize) for cluster reliability operations and resource management, OpenTelemetry for distributed tracing and multi-signal observability, SLO/SLI/SLA framework design and error budget policy implementation for business-critical services
+
+**Proficient level required:**
+
+- LitmusChaos, Chaos Mesh, and AWS FIS for chaos engineering experiment design and execution, PagerDuty and OpsGenie for on-call programme management and incident routing, k6 and Locust for load testing, capacity validation, and traffic modelling, Python and Go for SRE tooling development and runbook automation
+
+**Working Knowledge required:**
+
+- Terraform and Pulumi for reliability infrastructure as code
+- Argo Rollouts and Flagger for progressive delivery and canary deployments
+- Datadog and Dynatrace for supplementary APM and infrastructure observability
+
+**Awareness level expected:**
+
+- AIOps and ML-assisted incident detection and anomaly correlation platforms
+- eBPF-based observability tooling (Pixie, Tetragon)
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -73,10 +73,29 @@ The Modern Workplace Engineer administers and supports the organisation's Micros
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Exchange Online mailbox and mail flow management, Microsoft Teams administration and policy configuration, SharePoint Online and OneDrive permissions management
-- **Proficient level required:** Microsoft Purview compliance portal (sensitivity labels, retention policies, eDiscovery), PowerShell for M365 administration tasks, Microsoft Entra ID user and licence management
-- **Working Knowledge required:** Microsoft Defender for Office 365 operations, Microsoft 365 Admin Centre reporting and service health, Microsoft Viva Engage and Viva Connections basics
-- **Awareness level expected:** Microsoft 365 Copilot capabilities, Microsoft Teams Rooms and meeting room systems, Power Automate for M365 workflow automation
+**Expert level required:**
+
+- Exchange Online mailbox and mail flow management
+- Microsoft Teams administration and policy configuration
+- SharePoint Online and OneDrive permissions management
+
+**Proficient level required:**
+
+- Microsoft Purview compliance portal (sensitivity labels, retention policies, eDiscovery)
+- PowerShell for M365 administration tasks
+- Microsoft Entra ID user and licence management
+
+**Working Knowledge required:**
+
+- Microsoft Defender for Office 365 operations
+- Microsoft 365 Admin Centre reporting and service health
+- Microsoft Viva Engage and Viva Connections basics
+
+**Awareness level expected:**
+
+- Microsoft 365 Copilot capabilities
+- Microsoft Teams Rooms and meeting room systems
+- Power Automate for M365 workflow automation
 
 ## Interactions with Other Roles
 

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -73,10 +73,30 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft 365 platform concepts and roadmap (Exchange, Teams, SharePoint, Purview, Copilot), Jira/Azure DevOps product backlog management, Microsoft 365 Adoption Score and usage analytics
-- **Proficient level required:** Microsoft 365 Copilot adoption and readiness frameworks, M365 licensing tiers (E3, E5, Copilot add-ons), Microsoft Purview compliance governance concepts, Microsoft FastTrack and TAM engagement
-- **Working Knowledge required:** Power BI for M365 reporting, Microsoft Viva suite (Insights, Engage, Topics), change management frameworks for digital adoption (Prosci/ADKAR)
-- **Awareness level expected:** AI-powered workplace features (Copilot, Loop, Places), Power Platform capabilities for workplace automation, Microsoft Teams Rooms and hybrid meeting technology
+**Expert level required:**
+
+- Microsoft 365 platform concepts and roadmap (Exchange, Teams, SharePoint, Purview, Copilot)
+- Jira/Azure DevOps product backlog management
+- Microsoft 365 Adoption Score and usage analytics
+
+**Proficient level required:**
+
+- Microsoft 365 Copilot adoption and readiness frameworks
+- M365 licensing tiers (E3, E5, Copilot add-ons)
+- Microsoft Purview compliance governance concepts
+- Microsoft FastTrack and TAM engagement
+
+**Working Knowledge required:**
+
+- Power BI for M365 reporting
+- Microsoft Viva suite (Insights, Engage, Topics)
+- change management frameworks for digital adoption (Prosci/ADKAR)
+
+**Awareness level expected:**
+
+- AI-powered workplace features (Copilot, Loop, Places)
+- Power Platform capabilities for workplace automation
+- Microsoft Teams Rooms and hybrid meeting technology
 
 ## Interactions with Other Roles
 

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -66,10 +66,28 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Cisco IOS-XE/NX-OS, BGP/OSPF/MPLS routing protocols, SD-WAN platforms (Cisco Meraki/Viptela, VMware VeloCloud)
-- **Proficient level required:** Azure Networking (vWAN/ExpressRoute), Palo Alto/Fortinet next-generation firewalls, Wireshark/packet analysis
-- **Working Knowledge required:** AWS/GCP networking constructs, DNSSEC, 802.1X network access control
-- **Awareness level expected:** 5G/private wireless networking, Azure Edge Zones/AWS Wavelength
+**Expert level required:**
+
+- Cisco IOS-XE/NX-OS
+- BGP/OSPF/MPLS routing protocols
+- SD-WAN platforms (Cisco Meraki/Viptela, VMware VeloCloud)
+
+**Proficient level required:**
+
+- Azure Networking (vWAN/ExpressRoute)
+- Palo Alto/Fortinet next-generation firewalls
+- Wireshark/packet analysis
+
+**Working Knowledge required:**
+
+- AWS/GCP networking constructs
+- DNSSEC
+- 802.1X network access control
+
+**Awareness level expected:**
+
+- 5G/private wireless networking
+- Azure Edge Zones/AWS Wavelength
 
 ## Interactions with Other Roles
 

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -64,10 +64,31 @@ The Network Automation Engineer specializes in developing and implementing autom
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Python scripting for network automation, Ansible/Nornir/NAPALM automation frameworks, CI/CD pipelines (Jenkins, GitLab CI, GitHub Actions), REST/NETCONF/gRPC API integration
-- **Proficient level required:** Terraform for network infrastructure as code, Git/GitHub version control and workflows, network testing frameworks (pyATS, Pytest), Prometheus/Grafana for network monitoring
-- **Working Knowledge required:** Network protocols and device configuration (routing, switching, VLANs), network source-of-truth platforms (NetBox), event-driven automation frameworks
-- **Awareness level expected:** AI/ML-based network analytics, eBPF-based network observability, Kubernetes networking automation
+**Expert level required:**
+
+- Python scripting for network automation
+- Ansible/Nornir/NAPALM automation frameworks
+- CI/CD pipelines (Jenkins, GitLab CI, GitHub Actions)
+- REST/NETCONF/gRPC API integration
+
+**Proficient level required:**
+
+- Terraform for network infrastructure as code
+- Git/GitHub version control and workflows
+- network testing frameworks (pyATS, Pytest)
+- Prometheus/Grafana for network monitoring
+
+**Working Knowledge required:**
+
+- Network protocols and device configuration (routing, switching, VLANs)
+- network source-of-truth platforms (NetBox)
+- event-driven automation frameworks
+
+**Awareness level expected:**
+
+- AI/ML-based network analytics
+- eBPF-based network observability
+- Kubernetes networking automation
 
 ## Interactions with Other Roles
 

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -64,10 +64,31 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise routing and switching platforms (Cisco/Juniper/Arista), VLAN and IP subnetting, firewall rule management, wireless access points and controllers
-- **Proficient level required:** Dynamic routing protocols (OSPF, BGP), VPN technologies, WAN connectivity solutions, network monitoring tools (PRTG, SolarWinds, Nagios)
-- **Working Knowledge required:** Basic SD-WAN technologies, network load balancers, basic network automation scripting (Python/Ansible)
-- **Awareness level expected:** SD-WAN and SASE architecture concepts, Zero Trust network access, cloud networking fundamentals
+**Expert level required:**
+
+- Enterprise routing and switching platforms (Cisco/Juniper/Arista)
+- VLAN and IP subnetting
+- firewall rule management
+- wireless access points and controllers
+
+**Proficient level required:**
+
+- Dynamic routing protocols (OSPF, BGP)
+- VPN technologies
+- WAN connectivity solutions
+- network monitoring tools (PRTG, SolarWinds, Nagios)
+
+**Working Knowledge required:**
+
+- Basic SD-WAN technologies
+- network load balancers
+- basic network automation scripting (Python/Ansible)
+
+**Awareness level expected:**
+
+- SD-WAN and SASE architecture concepts
+- Zero Trust network access
+- cloud networking fundamentals
 
 ## Interactions with Other Roles
 

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -64,10 +64,30 @@ The Network Product Owner manages the development and lifecycle of the organizat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise network service lifecycle management and roadmap planning, Jira/Azure DevOps backlog and sprint management, network performance and capacity planning concepts
-- **Proficient level required:** SD-WAN and SASE technology concepts, network security platforms and Zero Trust frameworks, Wi-Fi and wireless network technologies, network analytics and monitoring dashboards
-- **Working Knowledge required:** Network automation frameworks (Ansible, Python scripting), cloud connectivity and hybrid network concepts, MPLS and carrier services
-- **Awareness level expected:** IoT network management approaches, AI-driven network analytics (AIOps), private 5G and edge networking
+**Expert level required:**
+
+- Enterprise network service lifecycle management and roadmap planning
+- Jira/Azure DevOps backlog and sprint management
+- network performance and capacity planning concepts
+
+**Proficient level required:**
+
+- SD-WAN and SASE technology concepts
+- network security platforms and Zero Trust frameworks
+- Wi-Fi and wireless network technologies
+- network analytics and monitoring dashboards
+
+**Working Knowledge required:**
+
+- Network automation frameworks (Ansible, Python scripting)
+- cloud connectivity and hybrid network concepts
+- MPLS and carrier services
+
+**Awareness level expected:**
+
+- IoT network management approaches
+- AI-driven network analytics (AIOps)
+- private 5G and edge networking
 
 ## Interactions with Other Roles
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -64,10 +64,31 @@ The Network Senior Engineer leads the implementation and optimization of complex
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise routing and switching platforms (OSPF, BGP, MPLS), SD-WAN advanced configuration and troubleshooting, next-generation firewalls and security appliances, network automation frameworks (Ansible, Python)
-- **Proficient level required:** Software-Defined Networking (SDN) solutions, load balancers and application delivery controllers, Wi-Fi 6/6E and wireless network management, IPv6 implementation and migration
-- **Working Knowledge required:** Cloud network integration (AWS/Azure/GCP), network overlay technologies (VXLAN, EVPN), network access control (NAC) systems
-- **Awareness level expected:** Zero Trust Network Architecture, AI-driven network operations (AIOps), eBPF-based network monitoring
+**Expert level required:**
+
+- Enterprise routing and switching platforms (OSPF, BGP, MPLS)
+- SD-WAN advanced configuration and troubleshooting
+- next-generation firewalls and security appliances
+- network automation frameworks (Ansible, Python)
+
+**Proficient level required:**
+
+- Software-Defined Networking (SDN) solutions
+- load balancers and application delivery controllers
+- Wi-Fi 6/6E and wireless network management
+- IPv6 implementation and migration
+
+**Working Knowledge required:**
+
+- Cloud network integration (AWS/Azure/GCP)
+- network overlay technologies (VXLAN, EVPN)
+- network access control (NAC) systems
+
+**Awareness level expected:**
+
+- Zero Trust Network Architecture
+- AI-driven network operations (AIOps)
+- eBPF-based network monitoring
 
 ## Interactions with Other Roles
 

--- a/Roles/security/devsecops_architect.md
+++ b/Roles/security/devsecops_architect.md
@@ -80,10 +80,29 @@ The DevSecOps Architect is responsible for designing and governing the strategy,
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** GitHub Actions/Azure DevOps/GitLab CI, Checkmarx/Veracode (SAST), Trivy/Prisma Cloud (container security), Checkov/tfsec (IaC security)
-- **Proficient level required:** Snyk/OWASP Dependency-Check (SCA), HashiCorp Vault/Azure Key Vault, OPA/Gatekeeper (policy as code), OWASP ZAP/Burp Suite (DAST)
-- **Working Knowledge required:** DefectDojo/JFrog Xray (vulnerability management), CycloneDX/Syft (SBOM)
-- **Awareness level expected:** Falco/Sysdig (runtime security), Kyverno
+**Expert level required:**
+
+- GitHub Actions/Azure DevOps/GitLab CI
+- Checkmarx/Veracode (SAST)
+- Trivy/Prisma Cloud (container security)
+- Checkov/tfsec (IaC security)
+
+**Proficient level required:**
+
+- Snyk/OWASP Dependency-Check (SCA)
+- HashiCorp Vault/Azure Key Vault
+- OPA/Gatekeeper (policy as code)
+- OWASP ZAP/Burp Suite (DAST)
+
+**Working Knowledge required:**
+
+- DefectDojo/JFrog Xray (vulnerability management)
+- CycloneDX/Syft (SBOM)
+
+**Awareness level expected:**
+
+- Falco/Sysdig (runtime security)
+- Kyverno
 
 ## Interactions with Other Roles
 

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -77,10 +77,28 @@ The DevSecOps Engineer implements and maintains the security tooling, automation
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** GitHub Actions/Azure DevOps, Checkmarx/SonarQube (SAST), Snyk/OWASP Dependency-Check (SCA)
-- **Proficient level required:** Trivy/Docker Scout (container scanning), Checkov/tfsec (IaC security), HashiCorp Vault/Azure Key Vault
-- **Working Knowledge required:** Python/PowerShell scripting, CycloneDX/Syft (SBOM), OPA/Kyverno
-- **Awareness level expected:** OWASP ZAP (DAST), Falco (runtime security)
+**Expert level required:**
+
+- GitHub Actions/Azure DevOps
+- Checkmarx/SonarQube (SAST)
+- Snyk/OWASP Dependency-Check (SCA)
+
+**Proficient level required:**
+
+- Trivy/Docker Scout (container scanning)
+- Checkov/tfsec (IaC security)
+- HashiCorp Vault/Azure Key Vault
+
+**Working Knowledge required:**
+
+- Python/PowerShell scripting
+- CycloneDX/Syft (SBOM)
+- OPA/Kyverno
+
+**Awareness level expected:**
+
+- OWASP ZAP (DAST)
+- Falco (runtime security)
 
 ## Interactions with Other Roles
 

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -65,10 +65,28 @@ The Security Engineer implements and maintains security controls and technologie
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Sentinel (SIEM), Microsoft Defender for Endpoint (EDR), Qualys/Tenable (vulnerability management)
-- **Proficient level required:** Microsoft Defender for Cloud, Azure WAF, Microsoft Purview (DLP)
-- **Working Knowledge required:** Microsoft Entra ID (IAM), Azure Security Center, threat intelligence platforms
-- **Awareness level expected:** SOAR automation, Zero Trust architecture frameworks
+**Expert level required:**
+
+- Microsoft Sentinel (SIEM)
+- Microsoft Defender for Endpoint (EDR)
+- Qualys/Tenable (vulnerability management)
+
+**Proficient level required:**
+
+- Microsoft Defender for Cloud
+- Azure WAF
+- Microsoft Purview (DLP)
+
+**Working Knowledge required:**
+
+- Microsoft Entra ID (IAM)
+- Azure Security Center
+- threat intelligence platforms
+
+**Awareness level expected:**
+
+- SOAR automation
+- Zero Trust architecture frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -72,10 +72,27 @@ The Security Product Owner manages the development and lifecycle of the organiza
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Sentinel (SIEM), ServiceNow (security service management), Jira/Azure DevOps
-- **Proficient level required:** Microsoft Defender for Cloud (CSPM), Power BI (security metrics dashboards), Microsoft Purview (DLP)
-- **Working Knowledge required:** Microsoft Entra ID/CyberArk (PAM), SOAR automation tools
-- **Awareness level expected:** Zero Trust frameworks, DevSecOps pipeline integration tools
+**Expert level required:**
+
+- Microsoft Sentinel (SIEM)
+- ServiceNow (security service management)
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- Microsoft Defender for Cloud (CSPM)
+- Power BI (security metrics dashboards)
+- Microsoft Purview (DLP)
+
+**Working Knowledge required:**
+
+- Microsoft Entra ID/CyberArk (PAM)
+- SOAR automation tools
+
+**Awareness level expected:**
+
+- Zero Trust frameworks
+- DevSecOps pipeline integration tools
 
 ## Interactions with Other Roles
 

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -64,10 +64,29 @@ The Security Senior Engineer leads the implementation and optimization of comple
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Sentinel (SIEM/SOAR), Microsoft Defender XDR, KQL (threat hunting), Zero Trust implementation
-- **Proficient level required:** Microsoft Defender for Cloud (CSPM), CyberArk/BeyondTrust (PAM), container/Kubernetes security (Aqua/Trivy)
-- **Working Knowledge required:** Azure Key Vault (encryption/key management), DevSecOps pipeline tools, NDR solutions
-- **Awareness level expected:** Security data lake architectures, AI-driven threat detection
+**Expert level required:**
+
+- Microsoft Sentinel (SIEM/SOAR)
+- Microsoft Defender XDR
+- KQL (threat hunting)
+- Zero Trust implementation
+
+**Proficient level required:**
+
+- Microsoft Defender for Cloud (CSPM)
+- CyberArk/BeyondTrust (PAM)
+- container/Kubernetes security (Aqua/Trivy)
+
+**Working Knowledge required:**
+
+- Azure Key Vault (encryption/key management)
+- DevSecOps pipeline tools
+- NDR solutions
+
+**Awareness level expected:**
+
+- Security data lake architectures
+- AI-driven threat detection
 
 ## Interactions with Other Roles
 

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -76,10 +76,27 @@ The Cloud Security Posture Manager implements and operates Cloud Security Postur
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Defender for Cloud (CSPM), Wiz/Prisma Cloud (multi-cloud CSPM), Azure Policy/Blueprints
-- **Proficient level required:** AWS Security Hub/AWS Config, GCP Security Command Center, Checkov/tfsec (IaC security)
-- **Working Knowledge required:** Orca Security, GCP Organisation Policies
-- **Awareness level expected:** KQL (Defender for Cloud queries), CSPM automation/SOAR integration
+**Expert level required:**
+
+- Microsoft Defender for Cloud (CSPM)
+- Wiz/Prisma Cloud (multi-cloud CSPM)
+- Azure Policy/Blueprints
+
+**Proficient level required:**
+
+- AWS Security Hub/AWS Config
+- GCP Security Command Center
+- Checkov/tfsec (IaC security)
+
+**Working Knowledge required:**
+
+- Orca Security
+- GCP Organisation Policies
+
+**Awareness level expected:**
+
+- KQL (Defender for Cloud queries)
+- CSPM automation/SOAR integration
 
 ## Interactions with Other Roles
 

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -78,10 +78,29 @@ The Security Automation Engineer builds and maintains the automated security too
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Snyk (SCA/SAST/container/IaC), GitHub Advanced Security (GHAS)/Microsoft Defender for DevOps, Python/Go (security automation), OPA/Conftest
-- **Proficient level required:** Semgrep, Trivy/Grype, Palo Alto XSOAR/Splunk SOAR, Kyverno/Falco
-- **Working Knowledge required:** OWASP ZAP (DAST), Wiz/Prisma Cloud
-- **Awareness level expected:** eBPF-based security tools, AI-driven security automation
+**Expert level required:**
+
+- Snyk (SCA/SAST/container/IaC)
+- GitHub Advanced Security (GHAS)/Microsoft Defender for DevOps
+- Python/Go (security automation)
+- OPA/Conftest
+
+**Proficient level required:**
+
+- Semgrep
+- Trivy/Grype
+- Palo Alto XSOAR/Splunk SOAR
+- Kyverno/Falco
+
+**Working Knowledge required:**
+
+- OWASP ZAP (DAST)
+- Wiz/Prisma Cloud
+
+**Awareness level expected:**
+
+- eBPF-based security tools
+- AI-driven security automation
 
 ### Qualifications
 

--- a/Roles/security_cross_platform/security_cross_platform_architect.md
+++ b/Roles/security_cross_platform/security_cross_platform_architect.md
@@ -72,10 +72,28 @@ The Security Cross-Platform Architect designs and develops comprehensive securit
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Zero Trust architecture frameworks, SABSA/TOGAF Security, Microsoft Defender XDR
-- **Proficient level required:** Microsoft Sentinel, Prisma Cloud/Wiz (multi-cloud CSPM), Microsoft Entra ID (identity fabric)
-- **Working Knowledge required:** IaC security tools (Checkov/tfsec), API security gateways, HashiCorp Vault
-- **Awareness level expected:** SOAR automation platforms, eBPF-based runtime security
+**Expert level required:**
+
+- Zero Trust architecture frameworks
+- SABSA/TOGAF Security
+- Microsoft Defender XDR
+
+**Proficient level required:**
+
+- Microsoft Sentinel
+- Prisma Cloud/Wiz (multi-cloud CSPM)
+- Microsoft Entra ID (identity fabric)
+
+**Working Knowledge required:**
+
+- IaC security tools (Checkov/tfsec)
+- API security gateways
+- HashiCorp Vault
+
+**Awareness level expected:**
+
+- SOAR automation platforms
+- eBPF-based runtime security
 
 ## Interactions with Other Roles
 

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -72,10 +72,28 @@ The Security Cross-Platform Engineer implements and maintains security controls 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Defender for Endpoint, Microsoft Sentinel, CIS Benchmarks/security hardening
-- **Proficient level required:** Qualys/Tenable (vulnerability scanning), Ansible/PowerShell (configuration management), Aqua/Trivy (container security)
-- **Working Knowledge required:** Microsoft Entra ID (IAM), Azure Security Center, patch management tools
-- **Awareness level expected:** SOAR automation, Zero Trust network access
+**Expert level required:**
+
+- Microsoft Defender for Endpoint
+- Microsoft Sentinel
+- CIS Benchmarks/security hardening
+
+**Proficient level required:**
+
+- Qualys/Tenable (vulnerability scanning)
+- Ansible/PowerShell (configuration management)
+- Aqua/Trivy (container security)
+
+**Working Knowledge required:**
+
+- Microsoft Entra ID (IAM)
+- Azure Security Center
+- patch management tools
+
+**Awareness level expected:**
+
+- SOAR automation
+- Zero Trust network access
 
 ## Interactions with Other Roles
 

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -72,10 +72,27 @@ The Security Cross-Platform Product Owner manages the portfolio of security serv
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Sentinel (SIEM), Microsoft Defender for Cloud (CSPM), Jira/Azure DevOps
-- **Proficient level required:** Power BI (security metrics), ServiceNow (security governance), Microsoft Defender XDR
-- **Working Knowledge required:** DevSecOps pipeline integration tools, identity federation platforms
-- **Awareness level expected:** SOAR automation, multi-cloud governance frameworks
+**Expert level required:**
+
+- Microsoft Sentinel (SIEM)
+- Microsoft Defender for Cloud (CSPM)
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- Power BI (security metrics)
+- ServiceNow (security governance)
+- Microsoft Defender XDR
+
+**Working Knowledge required:**
+
+- DevSecOps pipeline integration tools
+- identity federation platforms
+
+**Awareness level expected:**
+
+- SOAR automation
+- multi-cloud governance frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
@@ -72,10 +72,28 @@ The Security Cross-Platform Senior Engineer leads the technical implementation o
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Sentinel, Ansible/Terraform (configuration/IaC management), Aqua/Prisma Cloud (container security), HashiCorp Vault/Azure Key Vault
-- **Proficient level required:** OPA/Kyverno/Falco (Kubernetes security), Microsoft Entra ID/Okta (identity federation), Trivy/Qualys (scanning)
-- **Working Knowledge required:** Azure Security Center/AWS Security Hub, InSpec (compliance automation)
-- **Awareness level expected:** NeuVector, eBPF-based security tools
+**Expert level required:**
+
+- Microsoft Sentinel
+- Ansible/Terraform (configuration/IaC management)
+- Aqua/Prisma Cloud (container security)
+- HashiCorp Vault/Azure Key Vault
+
+**Proficient level required:**
+
+- OPA/Kyverno/Falco (Kubernetes security)
+- Microsoft Entra ID/Okta (identity federation)
+- Trivy/Qualys (scanning)
+
+**Working Knowledge required:**
+
+- Azure Security Center/AWS Security Hub
+- InSpec (compliance automation)
+
+**Awareness level expected:**
+
+- NeuVector
+- eBPF-based security tools
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -72,10 +72,27 @@ The Access Management Architect designs and oversees the organization's access m
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** SailPoint/Saviynt (IGA), CyberArk/BeyondTrust (PAM), Microsoft Entra ID (Zero Trust access)
-- **Proficient level required:** OAuth 2.0/OIDC/SAML, Cloud Access Security Broker (CASB), RBAC/ABAC frameworks
-- **Working Knowledge required:** API/service access management, access analytics platforms
-- **Awareness level expected:** AI-driven access governance, SSPM (SaaS security posture management)
+**Expert level required:**
+
+- SailPoint/Saviynt (IGA)
+- CyberArk/BeyondTrust (PAM)
+- Microsoft Entra ID (Zero Trust access)
+
+**Proficient level required:**
+
+- OAuth 2.0/OIDC/SAML
+- Cloud Access Security Broker (CASB)
+- RBAC/ABAC frameworks
+
+**Working Knowledge required:**
+
+- API/service access management
+- access analytics platforms
+
+**Awareness level expected:**
+
+- AI-driven access governance
+- SSPM (SaaS security posture management)
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -72,10 +72,27 @@ The Access Management Engineer implements and maintains access management system
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Entra ID (SSO/MFA), CyberArk/BeyondTrust (PAM), RBAC systems
-- **Proficient level required:** Access request/approval workflows, access certification tools, Azure MFA
-- **Working Knowledge required:** Access reporting/analytics, OAuth 2.0/SAML
-- **Awareness level expected:** SailPoint/Saviynt (IGA), Zero Trust access control
+**Expert level required:**
+
+- Microsoft Entra ID (SSO/MFA)
+- CyberArk/BeyondTrust (PAM)
+- RBAC systems
+
+**Proficient level required:**
+
+- Access request/approval workflows
+- access certification tools
+- Azure MFA
+
+**Working Knowledge required:**
+
+- Access reporting/analytics
+- OAuth 2.0/SAML
+
+**Awareness level expected:**
+
+- SailPoint/Saviynt (IGA)
+- Zero Trust access control
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -99,10 +99,27 @@ The Access Management Product Owner manages the development and lifecycle of the
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Entra ID, ServiceNow (access request workflows), Jira/Azure DevOps
-- **Proficient level required:** CyberArk/BeyondTrust (PAM), Power BI (access reporting), access certification platforms
-- **Working Knowledge required:** SailPoint/Saviynt (IGA), Azure MFA/SSO
-- **Awareness level expected:** AI-driven access governance, Zero Trust access frameworks
+**Expert level required:**
+
+- Microsoft Entra ID
+- ServiceNow (access request workflows)
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- CyberArk/BeyondTrust (PAM)
+- Power BI (access reporting)
+- access certification platforms
+
+**Working Knowledge required:**
+
+- SailPoint/Saviynt (IGA)
+- Azure MFA/SSO
+
+**Awareness level expected:**
+
+- AI-driven access governance
+- Zero Trust access frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -72,10 +72,27 @@ The Access Management Senior Engineer leads the implementation and optimization 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Entra ID (advanced configurations), CyberArk/BeyondTrust (PAM), access governance/certification tools
-- **Proficient level required:** OAuth 2.0/OIDC/SAML, automated access provisioning, risk-based access control (ABAC)
-- **Working Knowledge required:** Access management APIs/integrations, PowerShell/Python automation
-- **Awareness level expected:** SailPoint/Saviynt (IGA), AI-driven access analytics
+**Expert level required:**
+
+- Microsoft Entra ID (advanced configurations)
+- CyberArk/BeyondTrust (PAM)
+- access governance/certification tools
+
+**Proficient level required:**
+
+- OAuth 2.0/OIDC/SAML
+- automated access provisioning
+- risk-based access control (ABAC)
+
+**Working Knowledge required:**
+
+- Access management APIs/integrations
+- PowerShell/Python automation
+
+**Awareness level expected:**
+
+- SailPoint/Saviynt (IGA)
+- AI-driven access analytics
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -78,10 +78,27 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** SailPoint IdentityNow/IdentityIQ, Microsoft Entra ID Governance, Saviynt Enterprise Identity Cloud
-- **Proficient level required:** Microsoft Entra ID (Azure AD), ServiceNow (access request/SoD), PowerShell/Python
-- **Working Knowledge required:** Workday/SAP SuccessFactors (HR integration), CyberArk Identity (PAM-IGA)
-- **Awareness level expected:** Omada Identity, AI-driven identity governance tools
+**Expert level required:**
+
+- SailPoint IdentityNow/IdentityIQ
+- Microsoft Entra ID Governance
+- Saviynt Enterprise Identity Cloud
+
+**Proficient level required:**
+
+- Microsoft Entra ID (Azure AD)
+- ServiceNow (access request/SoD)
+- PowerShell/Python
+
+**Working Knowledge required:**
+
+- Workday/SAP SuccessFactors (HR integration)
+- CyberArk Identity (PAM-IGA)
+
+**Awareness level expected:**
+
+- Omada Identity
+- AI-driven identity governance tools
 
 ### Qualifications
 

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -72,10 +72,27 @@ The Identity Management Architect designs and oversees the organization's identi
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Entra ID, Windows Active Directory, Microsoft Entra Connect (hybrid identity)
-- **Proficient level required:** AD FS/SAML/OAuth 2.0/OIDC (federation), SailPoint/Saviynt (IGA), PKI/AD CS
-- **Working Knowledge required:** LDAP/Kerberos, identity provisioning tools (SCIM)
-- **Awareness level expected:** Decentralized identity (Verifiable Credentials), AI-driven identity analytics
+**Expert level required:**
+
+- Microsoft Entra ID
+- Windows Active Directory
+- Microsoft Entra Connect (hybrid identity)
+
+**Proficient level required:**
+
+- AD FS/SAML/OAuth 2.0/OIDC (federation)
+- SailPoint/Saviynt (IGA)
+- PKI/AD CS
+
+**Working Knowledge required:**
+
+- LDAP/Kerberos
+- identity provisioning tools (SCIM)
+
+**Awareness level expected:**
+
+- Decentralized identity (Verifiable Credentials)
+- AI-driven identity analytics
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -72,10 +72,27 @@ The Identity Management Engineer implements and maintains identity management sy
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Active Directory, Microsoft Entra ID, Azure MFA
-- **Proficient level required:** AD FS/SAML (federation services), Microsoft Entra Connect (sync), LDAP
-- **Working Knowledge required:** Identity provisioning tools (SCIM), password management systems
-- **Awareness level expected:** OAuth 2.0/OIDC, SailPoint/Saviynt (IGA)
+**Expert level required:**
+
+- Windows Active Directory
+- Microsoft Entra ID
+- Azure MFA
+
+**Proficient level required:**
+
+- AD FS/SAML (federation services)
+- Microsoft Entra Connect (sync)
+- LDAP
+
+**Working Knowledge required:**
+
+- Identity provisioning tools (SCIM)
+- password management systems
+
+**Awareness level expected:**
+
+- OAuth 2.0/OIDC
+- SailPoint/Saviynt (IGA)
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -102,10 +102,27 @@ The Identity Management Product Owner manages the development and lifecycle of t
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Entra ID, ServiceNow (identity request workflows), Jira/Azure DevOps
-- **Proficient level required:** SailPoint/Saviynt (IGA), Azure MFA, Power BI (identity reporting/analytics)
-- **Working Knowledge required:** Microsoft Entra Connect (sync), federation services (AD FS/SAML)
-- **Awareness level expected:** Decentralized identity frameworks, AI-driven identity governance
+**Expert level required:**
+
+- Microsoft Entra ID
+- ServiceNow (identity request workflows)
+- Jira/Azure DevOps
+
+**Proficient level required:**
+
+- SailPoint/Saviynt (IGA)
+- Azure MFA
+- Power BI (identity reporting/analytics)
+
+**Working Knowledge required:**
+
+- Microsoft Entra Connect (sync)
+- federation services (AD FS/SAML)
+
+**Awareness level expected:**
+
+- Decentralized identity frameworks
+- AI-driven identity governance
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -72,10 +72,27 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Entra ID (advanced configurations), Windows Active Directory, Microsoft Entra Connect (hybrid identity)
-- **Proficient level required:** AD FS/SAML/OAuth 2.0/OIDC (federation), SailPoint/Saviynt (IGA), advanced authentication (MFA/PIM)
-- **Working Knowledge required:** SCIM/custom identity connectors, PowerShell automation
-- **Awareness level expected:** Verifiable Credentials/Decentralized Identity, AI-driven identity analytics
+**Expert level required:**
+
+- Microsoft Entra ID (advanced configurations)
+- Windows Active Directory
+- Microsoft Entra Connect (hybrid identity)
+
+**Proficient level required:**
+
+- AD FS/SAML/OAuth 2.0/OIDC (federation)
+- SailPoint/Saviynt (IGA)
+- advanced authentication (MFA/PIM)
+
+**Working Knowledge required:**
+
+- SCIM/custom identity connectors
+- PowerShell automation
+
+**Awareness level expected:**
+
+- Verifiable Credentials/Decentralized Identity
+- AI-driven identity analytics
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/privileged_access_management_architect.md
+++ b/Roles/security_identity/privileged_access_management_architect.md
@@ -79,10 +79,27 @@ The Privileged Access Management (PAM) Architect designs, governs, and evolves t
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** CyberArk PAM Suite (EPV/PSM/PVWA/CPM/AIM), Microsoft Entra ID PIM, BeyondTrust Password Safe
-- **Proficient level required:** HashiCorp Vault/CyberArk Conjur (DevOps secrets), Microsoft Sentinel (SIEM), Azure Key Vault
-- **Working Knowledge required:** Delinea/Thycotic Secret Server, Endpoint Privilege Management (EPM/BeyondTrust EPM)
-- **Awareness level expected:** BeyondTrust Privileged Remote Access, AWS Secrets Manager
+**Expert level required:**
+
+- CyberArk PAM Suite (EPV/PSM/PVWA/CPM/AIM)
+- Microsoft Entra ID PIM
+- BeyondTrust Password Safe
+
+**Proficient level required:**
+
+- HashiCorp Vault/CyberArk Conjur (DevOps secrets)
+- Microsoft Sentinel (SIEM)
+- Azure Key Vault
+
+**Working Knowledge required:**
+
+- Delinea/Thycotic Secret Server
+- Endpoint Privilege Management (EPM/BeyondTrust EPM)
+
+**Awareness level expected:**
+
+- BeyondTrust Privileged Remote Access
+- AWS Secrets Manager
 
 ## Interactions with Other Roles
 

--- a/Roles/security_identity/privileged_access_management_engineer.md
+++ b/Roles/security_identity/privileged_access_management_engineer.md
@@ -77,10 +77,27 @@ The Privileged Access Management (PAM) Engineer implements, operates, and mainta
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** CyberArk EPV/PVWA/PSM/CPM, Microsoft Entra ID PIM, Active Directory (service account management)
-- **Proficient level required:** Microsoft Sentinel (SIEM/audit), PowerShell/Python automation, BeyondTrust/Delinea (PAM)
-- **Working Knowledge required:** Network device management (Cisco/Juniper PAM), Database PAM (SQL Server/Oracle)
-- **Awareness level expected:** HashiCorp Vault (DevOps secrets), CyberArk Conjur
+**Expert level required:**
+
+- CyberArk EPV/PVWA/PSM/CPM
+- Microsoft Entra ID PIM
+- Active Directory (service account management)
+
+**Proficient level required:**
+
+- Microsoft Sentinel (SIEM/audit)
+- PowerShell/Python automation
+- BeyondTrust/Delinea (PAM)
+
+**Working Knowledge required:**
+
+- Network device management (Cisco/Juniper PAM)
+- Database PAM (SQL Server/Oracle)
+
+**Awareness level expected:**
+
+- HashiCorp Vault (DevOps secrets)
+- CyberArk Conjur
 
 ## Interactions with Other Roles
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -72,10 +72,27 @@ The Server Hardware Engineer implements and maintains the physical server infras
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise server hardware platforms (Dell PowerEdge, HPE ProLiant, Cisco UCS), server management interfaces (iDRAC, iLO, CIMC), hardware RAID configurations
-- **Proficient level required:** Server firmware and driver management, hardware diagnostics utilities, rack, power, and cooling solutions
-- **Working Knowledge required:** Server deployment tools, hardware inventory systems, remote management technologies (IPMI, Redfish)
-- **Awareness level expected:** Composable infrastructure, hardware automation via Redfish API, server security technologies (TPM, secure boot)
+**Expert level required:**
+
+- Enterprise server hardware platforms (Dell PowerEdge, HPE ProLiant, Cisco UCS)
+- server management interfaces (iDRAC, iLO, CIMC)
+- hardware RAID configurations
+
+**Proficient level required:**
+
+- Server firmware and driver management, hardware diagnostics utilities, rack, power, and cooling solutions
+
+**Working Knowledge required:**
+
+- Server deployment tools
+- hardware inventory systems
+- remote management technologies (IPMI, Redfish)
+
+**Awareness level expected:**
+
+- Composable infrastructure
+- hardware automation via Redfish API
+- server security technologies (TPM, secure boot)
 
 ## Interactions with Other Roles
 

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -89,10 +89,28 @@ The Server Hardware Product Owner manages the lifecycle of physical server infra
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Server hardware lifecycle management platforms, Jira / Azure DevOps (backlog and roadmap management)
-- **Proficient level required:** Capacity planning and resource allocation tools, TCO optimization frameworks, hardware vendor management (Dell, HPE, Cisco)
-- **Working Knowledge required:** Server provisioning automation tools, DCIM platforms, power management and optimization technologies
-- **Awareness level expected:** Composable and disaggregated infrastructure trends, as-a-service hardware models (HPE GreenLake, Dell APEX), sustainable computing and green data center standards
+**Expert level required:**
+
+- Server hardware lifecycle management platforms
+- Jira / Azure DevOps (backlog and roadmap management)
+
+**Proficient level required:**
+
+- Capacity planning and resource allocation tools
+- TCO optimization frameworks
+- hardware vendor management (Dell, HPE, Cisco)
+
+**Working Knowledge required:**
+
+- Server provisioning automation tools
+- DCIM platforms
+- power management and optimization technologies
+
+**Awareness level expected:**
+
+- Composable and disaggregated infrastructure trends
+- as-a-service hardware models (HPE GreenLake, Dell APEX)
+- sustainable computing and green data center standards
 
 ## Interactions with Other Roles
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -85,10 +85,31 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPE ProLiant servers (DL/ML series), HPE iLO management interface, HPE OneView, server firmware and RAID configurations
-- **Proficient level required:** HPE Smart Update Manager, HPE BladeSystem and Synergy enclosures, HPE InfoSight for servers, hardware diagnostics tools
-- **Working Knowledge required:** Server power management, hardware compatibility matrices, HPE GreenLake infrastructure
-- **Awareness level expected:** HPE Compute Ops Manager, HPE SimpliVity, composable infrastructure automation
+**Expert level required:**
+
+- HPE ProLiant servers (DL/ML series)
+- HPE iLO management interface
+- HPE OneView
+- server firmware and RAID configurations
+
+**Proficient level required:**
+
+- HPE Smart Update Manager
+- HPE BladeSystem and Synergy enclosures
+- HPE InfoSight for servers
+- hardware diagnostics tools
+
+**Working Knowledge required:**
+
+- Server power management
+- hardware compatibility matrices
+- HPE GreenLake infrastructure
+
+**Awareness level expected:**
+
+- HPE Compute Ops Manager
+- HPE SimpliVity
+- composable infrastructure automation
 
 ## Recommended Certifications & Learning Paths
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -197,10 +197,32 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPE ProLiant servers (DL/ML series), HPE GreenLake infrastructure services, Jira / Azure DevOps (backlog and roadmap management)
-- **Proficient level required:** HPE OneView management platform, HPE InfoSight analytics, HPE Synergy composable infrastructure, hardware asset management systems
-- **Working Knowledge required:** HPE BladeSystem and enclosures, HPE iLO management, server lifecycle management tools, capacity planning tools
-- **Awareness level expected:** HPE Compute Ops Manager, HPE Alletra storage, cloud hardware alternatives, sustainable computing standards
+**Expert level required:**
+
+- HPE ProLiant servers (DL/ML series)
+- HPE GreenLake infrastructure services
+- Jira / Azure DevOps (backlog and roadmap management)
+
+**Proficient level required:**
+
+- HPE OneView management platform
+- HPE InfoSight analytics
+- HPE Synergy composable infrastructure
+- hardware asset management systems
+
+**Working Knowledge required:**
+
+- HPE BladeSystem and enclosures
+- HPE iLO management
+- server lifecycle management tools
+- capacity planning tools
+
+**Awareness level expected:**
+
+- HPE Compute Ops Manager
+- HPE Alletra storage
+- cloud hardware alternatives
+- sustainable computing standards
 
 **Complementary Certifications:**
 

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -68,10 +68,33 @@ The Linux Server Architect designs and defines the strategic direction for the o
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** RHEL/SLES/Ubuntu enterprise distributions, Ansible and Terraform (IaC), Kubernetes/OpenShift container orchestration, Linux HA (Pacemaker, Corosync), Linux security hardening and CIS compliance
-- **Proficient level required:** Docker/Podman container technologies, KVM/VMware virtualization, LVM/ZFS advanced storage, Linux networking and firewall configuration, LDAP/SSO identity integration
-- **Working Knowledge required:** Cloud-native Linux deployments (AWS/Azure/GCP), Linux monitoring and observability solutions, OpenShift platform services
-- **Awareness level expected:** eBPF-based observability tooling, immutable OS patterns (CoreOS, Flatcar), edge computing Linux workloads
+**Expert level required:**
+
+- RHEL/SLES/Ubuntu enterprise distributions
+- Ansible and Terraform (IaC)
+- Kubernetes/OpenShift container orchestration
+- Linux HA (Pacemaker, Corosync)
+- Linux security hardening and CIS compliance
+
+**Proficient level required:**
+
+- Docker/Podman container technologies
+- KVM/VMware virtualization
+- LVM/ZFS advanced storage
+- Linux networking and firewall configuration
+- LDAP/SSO identity integration
+
+**Working Knowledge required:**
+
+- Cloud-native Linux deployments (AWS/Azure/GCP)
+- Linux monitoring and observability solutions
+- OpenShift platform services
+
+**Awareness level expected:**
+
+- eBPF-based observability tooling
+- immutable OS patterns (CoreOS, Flatcar)
+- edge computing Linux workloads
 
 ## Key Technologies
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -72,10 +72,30 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** RHEL/Ubuntu/SUSE enterprise Linux administration, Bash scripting, Linux package management (RPM/APT/Zypper)
-- **Proficient level required:** LVM and file system management, Linux networking configuration, Linux security hardening tools, SSH and remote management
-- **Working Knowledge required:** Ansible basics for configuration management, virtualization and container fundamentals, Linux monitoring tools
-- **Awareness level expected:** Infrastructure as Code concepts (Ansible/Terraform), cloud Linux services (AWS/Azure), DevSecOps practices
+**Expert level required:**
+
+- RHEL/Ubuntu/SUSE enterprise Linux administration
+- Bash scripting
+- Linux package management (RPM/APT/Zypper)
+
+**Proficient level required:**
+
+- LVM and file system management
+- Linux networking configuration
+- Linux security hardening tools
+- SSH and remote management
+
+**Working Knowledge required:**
+
+- Ansible basics for configuration management
+- virtualization and container fundamentals
+- Linux monitoring tools
+
+**Awareness level expected:**
+
+- Infrastructure as Code concepts (Ansible/Terraform)
+- cloud Linux services (AWS/Azure)
+- DevSecOps practices
 
 ## Interactions with Other Roles
 

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -72,10 +72,30 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Enterprise Linux distribution concepts and lifecycle (RHEL, Ubuntu, SUSE), Jira/Azure DevOps backlog management, Linux platform metrics and compliance dashboards
-- **Proficient level required:** Ansible automation concepts and coverage reporting, Linux security hardening frameworks (CIS benchmarks), container and Kubernetes platform awareness, Linux monitoring and observability platforms
-- **Working Knowledge required:** Infrastructure as Code tools (Terraform, Ansible), cloud Linux services (AWS/Azure/GCP), open source license and risk frameworks
-- **Awareness level expected:** eBPF observability tooling, immutable infrastructure patterns, Linux AI/ML workload considerations
+**Expert level required:**
+
+- Enterprise Linux distribution concepts and lifecycle (RHEL, Ubuntu, SUSE)
+- Jira/Azure DevOps backlog management
+- Linux platform metrics and compliance dashboards
+
+**Proficient level required:**
+
+- Ansible automation concepts and coverage reporting
+- Linux security hardening frameworks (CIS benchmarks)
+- container and Kubernetes platform awareness
+- Linux monitoring and observability platforms
+
+**Working Knowledge required:**
+
+- Infrastructure as Code tools (Terraform, Ansible)
+- cloud Linux services (AWS/Azure/GCP)
+- open source license and risk frameworks
+
+**Awareness level expected:**
+
+- eBPF observability tooling
+- immutable infrastructure patterns
+- Linux AI/ML workload considerations
 
 ## Interactions with Other Roles
 

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -72,10 +72,31 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Ansible/Puppet automation frameworks, Linux HA solutions (Pacemaker, Corosync), advanced Linux kernel tuning and performance analysis tools, Linux security hardening and CIS compliance tooling
-- **Proficient level required:** Terraform Infrastructure as Code, LVM/ZFS advanced storage configurations, Docker/Podman container technologies, Bash and Python scripting
-- **Working Knowledge required:** Kubernetes container host configuration, cloud Linux integration (AWS/Azure/GCP), enterprise monitoring and observability platforms
-- **Awareness level expected:** eBPF-based observability, GitOps workflows for Linux infrastructure, immutable OS patterns (CoreOS, Flatcar)
+**Expert level required:**
+
+- Ansible/Puppet automation frameworks
+- Linux HA solutions (Pacemaker, Corosync)
+- advanced Linux kernel tuning and performance analysis tools
+- Linux security hardening and CIS compliance tooling
+
+**Proficient level required:**
+
+- Terraform Infrastructure as Code
+- LVM/ZFS advanced storage configurations
+- Docker/Podman container technologies
+- Bash and Python scripting
+
+**Working Knowledge required:**
+
+- Kubernetes container host configuration
+- cloud Linux integration (AWS/Azure/GCP)
+- enterprise monitoring and observability platforms
+
+**Awareness level expected:**
+
+- eBPF-based observability
+- GitOps workflows for Linux infrastructure
+- immutable OS patterns (CoreOS, Flatcar)
 
 ## Interactions with Other Roles
 

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -68,10 +68,32 @@ The Windows Server Architect designs and defines the strategic direction for the
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Server (2019/2022/2025) advanced architecture, Active Directory Domain Services design, Windows Server Failover Clustering, PowerShell and DSC automation frameworks
-- **Proficient level required:** Azure Stack/hybrid services integration, Hyper-V virtualization, Storage Spaces Direct and Storage Replica, Microsoft Endpoint Configuration Manager, Windows security hardening standards
-- **Working Knowledge required:** Azure Arc for hybrid management, Windows Admin Center, Windows Server containers and Docker integration
-- **Awareness level expected:** Azure Stack HCI evolution, Kubernetes on Windows, Microsoft Entra hybrid identity patterns
+**Expert level required:**
+
+- Windows Server (2019/2022/2025) advanced architecture
+- Active Directory Domain Services design
+- Windows Server Failover Clustering
+- PowerShell and DSC automation frameworks
+
+**Proficient level required:**
+
+- Azure Stack/hybrid services integration
+- Hyper-V virtualization
+- Storage Spaces Direct and Storage Replica
+- Microsoft Endpoint Configuration Manager
+- Windows security hardening standards
+
+**Working Knowledge required:**
+
+- Azure Arc for hybrid management
+- Windows Admin Center
+- Windows Server containers and Docker integration
+
+**Awareness level expected:**
+
+- Azure Stack HCI evolution
+- Kubernetes on Windows
+- Microsoft Entra hybrid identity patterns
 
 ## Key Technologies
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -72,10 +72,31 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Server (2016/2019/2022) administration, Active Directory user/group/OU management, Group Policy configuration and troubleshooting, WSUS patch management
-- **Proficient level required:** PowerShell scripting for Windows administration, DNS and DHCP management, Windows File Services and DFS, IIS and Remote Desktop Services
-- **Working Knowledge required:** Windows Firewall and security features, Windows Backup and recovery tools, Hyper-V virtualization basics
-- **Awareness level expected:** Azure Arc management basics, PowerShell DSC concepts, Windows Server containers
+**Expert level required:**
+
+- Windows Server (2016/2019/2022) administration
+- Active Directory user/group/OU management
+- Group Policy configuration and troubleshooting
+- WSUS patch management
+
+**Proficient level required:**
+
+- PowerShell scripting for Windows administration
+- DNS and DHCP management
+- Windows File Services and DFS
+- IIS and Remote Desktop Services
+
+**Working Knowledge required:**
+
+- Windows Firewall and security features
+- Windows Backup and recovery tools
+- Hyper-V virtualization basics
+
+**Awareness level expected:**
+
+- Azure Arc management basics
+- PowerShell DSC concepts
+- Windows Server containers
 
 ## Interactions with Other Roles
 

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -72,10 +72,30 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Windows Server lifecycle management and Microsoft version roadmap, Microsoft licensing portals and cost management, Jira/Azure DevOps backlog and sprint management
-- **Proficient level required:** Windows Server platform concepts (AD, GPO, WSUS, Failover Clustering), Azure hybrid services awareness, PowerShell scripting concepts, ITSM platforms (ServiceNow)
-- **Working Knowledge required:** Microsoft Endpoint Configuration Manager concepts, Azure Arc and hybrid management, Windows Server security frameworks (CIS, NIST)
-- **Awareness level expected:** Azure Stack HCI adoption trends, Windows Server containerization, Infrastructure as Code approaches
+**Expert level required:**
+
+- Windows Server lifecycle management and Microsoft version roadmap
+- Microsoft licensing portals and cost management
+- Jira/Azure DevOps backlog and sprint management
+
+**Proficient level required:**
+
+- Windows Server platform concepts (AD, GPO, WSUS, Failover Clustering)
+- Azure hybrid services awareness
+- PowerShell scripting concepts
+- ITSM platforms (ServiceNow)
+
+**Working Knowledge required:**
+
+- Microsoft Endpoint Configuration Manager concepts
+- Azure Arc and hybrid management
+- Windows Server security frameworks (CIS, NIST)
+
+**Awareness level expected:**
+
+- Azure Stack HCI adoption trends
+- Windows Server containerization
+- Infrastructure as Code approaches
 
 ## Interactions with Other Roles
 

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -72,10 +72,32 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** PowerShell automation and Desired State Configuration (DSC), Windows Server Failover Clustering and high availability, advanced Active Directory design and implementation, Windows Server security hardening and compliance tooling
-- **Proficient level required:** Azure Arc hybrid management, System Center suite (SCCM/SCOM), Windows Admin Center, PKI and certificate services, IIS advanced configuration
-- **Working Knowledge required:** Windows Server containers and Docker integration, Azure hybrid services (Azure Stack HCI), Storage Spaces Direct
-- **Awareness level expected:** Azure Stack HCI evolution, Kubernetes on Windows, GitHub Actions for Windows infrastructure automation
+**Expert level required:**
+
+- PowerShell automation and Desired State Configuration (DSC)
+- Windows Server Failover Clustering and high availability
+- advanced Active Directory design and implementation
+- Windows Server security hardening and compliance tooling
+
+**Proficient level required:**
+
+- Azure Arc hybrid management
+- System Center suite (SCCM/SCOM)
+- Windows Admin Center
+- PKI and certificate services
+- IIS advanced configuration
+
+**Working Knowledge required:**
+
+- Windows Server containers and Docker integration
+- Azure hybrid services (Azure Stack HCI)
+- Storage Spaces Direct
+
+**Awareness level expected:**
+
+- Azure Stack HCI evolution
+- Kubernetes on Windows
+- GitHub Actions for Windows infrastructure automation
 
 ## Interactions with Other Roles
 

--- a/Roles/service_desk/service_desk_analyst.md
+++ b/Roles/service_desk/service_desk_analyst.md
@@ -70,10 +70,24 @@ The Service Desk Analyst is the Tier-1 point of contact for every employee techn
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ITSM ticketing platform (ServiceNow or equivalent) day-to-day operation
-- **Proficient level required:** Windows 10/11 and Microsoft 365 end-user troubleshooting, remote-support tooling (Quick Assist, TeamViewer, or equivalent)
-- **Working Knowledge required:** macOS end-user troubleshooting, Active Directory / Entra ID account concepts
-- **Awareness level expected:** mobile device (iOS/Android) basic troubleshooting, VPN/network connectivity fundamentals
+**Expert level required:**
+
+- ITSM ticketing platform (ServiceNow or equivalent) day-to-day operation
+
+**Proficient level required:**
+
+- Windows 10/11 and Microsoft 365 end-user troubleshooting
+- remote-support tooling (Quick Assist, TeamViewer, or equivalent)
+
+**Working Knowledge required:**
+
+- macOS end-user troubleshooting
+- Active Directory / Entra ID account concepts
+
+**Awareness level expected:**
+
+- mobile device (iOS/Android) basic troubleshooting
+- VPN/network connectivity fundamentals
 
 ## Interactions with Other Roles
 

--- a/Roles/service_desk/service_desk_lead.md
+++ b/Roles/service_desk/service_desk_lead.md
@@ -73,10 +73,23 @@ The Service Desk Lead owns the service desk as an operational function: staffing
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ITSM ticketing platform administration and SLA/reporting configuration (ServiceNow or equivalent)
-- **Proficient level required:** Workforce/shift scheduling tooling, Windows/macOS and Microsoft 365 end-user support concepts
-- **Working Knowledge required:** Endpoint management (Intune) and identity (Entra ID) concepts sufficient to set escalation criteria
-- **Awareness level expected:** ITIL 4 major incident and problem management practices, standard-change governance models
+**Expert level required:**
+
+- ITSM ticketing platform administration and SLA/reporting configuration (ServiceNow or equivalent)
+
+**Proficient level required:**
+
+- Workforce/shift scheduling tooling
+- Windows/macOS and Microsoft 365 end-user support concepts
+
+**Working Knowledge required:**
+
+- Endpoint management (Intune) and identity (Entra ID) concepts sufficient to set escalation criteria
+
+**Awareness level expected:**
+
+- ITIL 4 major incident and problem management practices
+- standard-change governance models
 
 ## Interactions with Other Roles
 

--- a/Roles/service_desk/service_desk_product_owner.md
+++ b/Roles/service_desk/service_desk_product_owner.md
@@ -69,10 +69,24 @@ The Service Desk Product Owner owns the backlog for the tooling and self-service
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Desk tooling backlog and sprint/kanban management (Jira, Confluence)
-- **Proficient level required:** ServiceNow (or equivalent) self-service portal and knowledge base configuration, chatbot/virtual-agent platform capabilities
-- **Working Knowledge required:** ITIL 4 request fulfilment and knowledge management practices, Power BI or ServiceNow Performance Analytics for deflection reporting
-- **Awareness level expected:** AI-assisted ticket triage and resolution tooling, telephony/contact-centre platform integration patterns
+**Expert level required:**
+
+- Desk tooling backlog and sprint/kanban management (Jira, Confluence)
+
+**Proficient level required:**
+
+- ServiceNow (or equivalent) self-service portal and knowledge base configuration
+- chatbot/virtual-agent platform capabilities
+
+**Working Knowledge required:**
+
+- ITIL 4 request fulfilment and knowledge management practices
+- Power BI or ServiceNow Performance Analytics for deflection reporting
+
+**Awareness level expected:**
+
+- AI-assisted ticket triage and resolution tooling
+- telephony/contact-centre platform integration patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/service_desk/service_desk_senior_analyst.md
+++ b/Roles/service_desk/service_desk_senior_analyst.md
@@ -70,10 +70,25 @@ The Service Desk Senior Analyst is the Tier-2 technical backbone of the service 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ITSM ticketing platform administration, Windows 10/11 and Microsoft 365 troubleshooting depth
-- **Proficient level required:** Microsoft Entra ID / Active Directory administration, macOS troubleshooting
-- **Working Knowledge required:** Microsoft Intune / endpoint compliance concepts, network connectivity and VPN diagnostics
-- **Awareness level expected:** PowerShell for basic diagnostic scripting, mobile device management (iOS/Android) troubleshooting
+**Expert level required:**
+
+- ITSM ticketing platform administration
+- Windows 10/11 and Microsoft 365 troubleshooting depth
+
+**Proficient level required:**
+
+- Microsoft Entra ID / Active Directory administration
+- macOS troubleshooting
+
+**Working Knowledge required:**
+
+- Microsoft Intune / endpoint compliance concepts
+- network connectivity and VPN diagnostics
+
+**Awareness level expected:**
+
+- PowerShell for basic diagnostic scripting
+- mobile device management (iOS/Android) troubleshooting
 
 ## Interactions with Other Roles
 

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -64,10 +64,27 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (ITSM architecture), ITIL v4 processes, CMDB architectural patterns
-- **Proficient level required:** SIAM (Service Integration and Management), process automation architectures, IT4IT reference architecture
-- **Working Knowledge required:** Power Automate (workflow automation), Azure Monitor/SCOM (monitoring integration)
-- **Awareness level expected:** AI/ML for ITSM, Digital workplace architecture frameworks
+**Expert level required:**
+
+- ServiceNow (ITSM architecture)
+- ITIL v4 processes
+- CMDB architectural patterns
+
+**Proficient level required:**
+
+- SIAM (Service Integration and Management)
+- process automation architectures
+- IT4IT reference architecture
+
+**Working Knowledge required:**
+
+- Power Automate (workflow automation)
+- Azure Monitor/SCOM (monitoring integration)
+
+**Awareness level expected:**
+
+- AI/ML for ITSM
+- Digital workplace architecture frameworks
 
 ## Interactions with Other Roles
 

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -64,10 +64,28 @@ The Service Management Engineer implements and maintains IT service management p
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (ITSM platform), CMDB/asset tracking, service catalog design
-- **Proficient level required:** Workflow automation tools, knowledge management systems, Power BI (reporting/dashboards)
-- **Working Knowledge required:** BMC Helix/Jira Service Management, ITIL v4 processes, basic scripting (PowerShell)
-- **Awareness level expected:** Azure Monitor/SCOM (monitoring integration), AI-driven ITSM automation
+**Expert level required:**
+
+- ServiceNow (ITSM platform)
+- CMDB/asset tracking
+- service catalog design
+
+**Proficient level required:**
+
+- Workflow automation tools
+- knowledge management systems
+- Power BI (reporting/dashboards)
+
+**Working Knowledge required:**
+
+- BMC Helix/Jira Service Management
+- ITIL v4 processes
+- basic scripting (PowerShell)
+
+**Awareness level expected:**
+
+- Azure Monitor/SCOM (monitoring integration)
+- AI-driven ITSM automation
 
 ## Interactions with Other Roles
 

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -64,10 +64,27 @@ The Service Management Product Owner manages the development and lifecycle of th
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (ITSM platform), Jira/Azure DevOps (backlog), ITIL v4 processes
-- **Proficient level required:** Power BI/ServiceNow dashboards (service analytics), service catalog management, CMDB/asset management
-- **Working Knowledge required:** Power Automate (workflow automation), change/release management tools
-- **Awareness level expected:** AI-driven ITSM automation, service value stream mapping tools
+**Expert level required:**
+
+- ServiceNow (ITSM platform)
+- Jira/Azure DevOps (backlog)
+- ITIL v4 processes
+
+**Proficient level required:**
+
+- Power BI/ServiceNow dashboards (service analytics)
+- service catalog management
+- CMDB/asset management
+
+**Working Knowledge required:**
+
+- Power Automate (workflow automation)
+- change/release management tools
+
+**Awareness level expected:**
+
+- AI-driven ITSM automation
+- service value stream mapping tools
 
 ## Interactions with Other Roles
 

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -64,10 +64,27 @@ The Service Management Senior Engineer leads the implementation and optimization
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** ServiceNow (advanced ITSM administration), CMDB design/configuration, workflow engines/scripting
-- **Proficient level required:** ITSM platform integration technologies, advanced reporting/analytics (Power BI), ITIL v4
-- **Working Knowledge required:** Performance monitoring for ITSM (Azure Monitor), ITSM testing/validation frameworks
-- **Awareness level expected:** AI-driven ITSM automation, Mobile ITSM platforms
+**Expert level required:**
+
+- ServiceNow (advanced ITSM administration)
+- CMDB design/configuration
+- workflow engines/scripting
+
+**Proficient level required:**
+
+- ITSM platform integration technologies
+- advanced reporting/analytics (Power BI)
+- ITIL v4
+
+**Working Knowledge required:**
+
+- Performance monitoring for ITSM (Azure Monitor)
+- ITSM testing/validation frameworks
+
+**Awareness level expected:**
+
+- AI-driven ITSM automation
+- Mobile ITSM platforms
 
 ## Interactions with Other Roles
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -80,10 +80,27 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Slurm or PBS Pro job scheduler administration, queue configuration, and resource policy management, Linux HPC system administration and cluster node imaging with xCAT or Bright Cluster Manager, Parallel file systems (Lustre, GPFS/Spectrum Scale, BeeGFS) operations, maintenance, and capacity management, HPC cluster management and automation using Ansible for configuration management
-- **Proficient level required:** MPI implementations (OpenMPI, MPICH) and scientific library installation and environment module configuration, InfiniBand and OmniPath high-performance interconnect management and diagnostics, Container technologies for HPC (Singularity/Apptainer, Docker) for reproducible research environments, GPU computing frameworks (CUDA, OpenACC) for scientific application support and user enablement
-- **Working Knowledge required:** Cluster monitoring tools (Prometheus, Grafana, Ganglia) for HPC environment health visibility, Cloud HPC solutions (AWS ParallelCluster, Azure CycleCloud) for hybrid burst workload integration, Bash and Python scripting for job submission automation and workflow tooling
-- **Awareness level expected:** ROCm AMD GPU computing platform for accelerated scientific workloads, Emerging cloud-native HPC patterns and Kubernetes batch scheduling (Volcano, Kueue)
+**Expert level required:**
+
+- Slurm or PBS Pro job scheduler administration, queue configuration, and resource policy management, Linux HPC system administration and cluster node imaging with xCAT or Bright Cluster Manager, Parallel file systems (Lustre, GPFS/Spectrum Scale, BeeGFS) operations, maintenance, and capacity management, HPC cluster management and automation using Ansible for configuration management
+
+**Proficient level required:**
+
+- MPI implementations (OpenMPI, MPICH) and scientific library installation and environment module configuration
+- InfiniBand and OmniPath high-performance interconnect management and diagnostics
+- Container technologies for HPC (Singularity/Apptainer, Docker) for reproducible research environments
+- GPU computing frameworks (CUDA, OpenACC) for scientific application support and user enablement
+
+**Working Knowledge required:**
+
+- Cluster monitoring tools (Prometheus, Grafana, Ganglia) for HPC environment health visibility
+- Cloud HPC solutions (AWS ParallelCluster, Azure CycleCloud) for hybrid burst workload integration
+- Bash and Python scripting for job submission automation and workflow tooling
+
+**Awareness level expected:**
+
+- ROCm AMD GPU computing platform for accelerated scientific workloads
+- Emerging cloud-native HPC patterns and Kubernetes batch scheduling (Volcano, Kueue)
 
 ## Interactions with Other Roles
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -78,10 +78,26 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** HPC cluster platform capabilities (Slurm, PBS Pro, job schedulers) at product planning and SLA governance level, Jira and Confluence for backlog management, research stakeholder engagement, and sprint planning, Cluster utilisation dashboards (Grafana, Prometheus) and reporting tools for data-driven capacity planning, ServiceNow and ITSM platforms for HPC service request and incident governance
-- **Proficient level required:** Cloud HPC platforms (AWS ParallelCluster, Azure CycleCloud) product capabilities and hybrid burst use case planning, GPU and accelerator allocation governance and cost-per-compute-hour reporting frameworks, Power BI and analytics tools for cluster utilisation metrics and researcher satisfaction measurement
-- **Working Knowledge required:** Parallel file systems (Lustre, GPFS) and HPC storage service capabilities for service catalog design, MPI-based workload requirements and parallel application resource needs for capacity planning, HPC container technologies (Singularity, Apptainer) for reproducible research enablement
-- **Awareness level expected:** Emerging quantum computing platforms and future HPC technology directions, NVIDIA H100/Blackwell and AMD Instinct accelerator roadmaps for capacity planning
+**Expert level required:**
+
+- HPC cluster platform capabilities (Slurm, PBS Pro, job schedulers) at product planning and SLA governance level, Jira and Confluence for backlog management, research stakeholder engagement, and sprint planning, Cluster utilisation dashboards (Grafana, Prometheus) and reporting tools for data-driven capacity planning, ServiceNow and ITSM platforms for HPC service request and incident governance
+
+**Proficient level required:**
+
+- Cloud HPC platforms (AWS ParallelCluster, Azure CycleCloud) product capabilities and hybrid burst use case planning
+- GPU and accelerator allocation governance and cost-per-compute-hour reporting frameworks
+- Power BI and analytics tools for cluster utilisation metrics and researcher satisfaction measurement
+
+**Working Knowledge required:**
+
+- Parallel file systems (Lustre, GPFS) and HPC storage service capabilities for service catalog design
+- MPI-based workload requirements and parallel application resource needs for capacity planning
+- HPC container technologies (Singularity, Apptainer) for reproducible research enablement
+
+**Awareness level expected:**
+
+- Emerging quantum computing platforms and future HPC technology directions
+- NVIDIA H100/Blackwell and AMD Instinct accelerator roadmaps for capacity planning
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -77,10 +77,27 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Hyper-V architecture, cluster design, and high availability configuration, System Center Virtual Machine Manager (SCVMM) for enterprise VM fleet and library management, Azure Stack HCI and Storage Spaces Direct (S2D) hyperconverged architecture, Windows Server Failover Clustering for Hyper-V environments
-- **Proficient level required:** Hyper-V Replica and Azure Site Recovery for disaster recovery architecture, Software-Defined Networking in Windows Server and Hyper-V SDN stack, Windows Admin Center for centralised management and monitoring, PowerShell DSC and advanced automation for Hyper-V orchestration
-- **Working Knowledge required:** Azure Arc integration and hybrid cloud connectivity for Hyper-V workloads, Shielded VMs and Virtualization-Based Security (VBS) for platform security design, Azure migration tooling for Hyper-V workload cloud integration
-- **Awareness level expected:** Azure Stack HCI next-generation capabilities and evolving licensing, Emerging containerisation and Kubernetes integration on Windows Server
+**Expert level required:**
+
+- Microsoft Hyper-V architecture, cluster design, and high availability configuration, System Center Virtual Machine Manager (SCVMM) for enterprise VM fleet and library management, Azure Stack HCI and Storage Spaces Direct (S2D) hyperconverged architecture, Windows Server Failover Clustering for Hyper-V environments
+
+**Proficient level required:**
+
+- Hyper-V Replica and Azure Site Recovery for disaster recovery architecture
+- Software-Defined Networking in Windows Server and Hyper-V SDN stack
+- Windows Admin Center for centralised management and monitoring
+- PowerShell DSC and advanced automation for Hyper-V orchestration
+
+**Working Knowledge required:**
+
+- Azure Arc integration and hybrid cloud connectivity for Hyper-V workloads
+- Shielded VMs and Virtualization-Based Security (VBS) for platform security design
+- Azure migration tooling for Hyper-V workload cloud integration
+
+**Awareness level expected:**
+
+- Azure Stack HCI next-generation capabilities and evolving licensing
+- Emerging containerisation and Kubernetes integration on Windows Server
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -79,10 +79,24 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Hyper-V host configuration, virtual machine provisioning, and lifecycle management, System Center Virtual Machine Manager (SCVMM) for VM operations and cluster management, Windows Server administration and update management with WSUS, PowerShell scripting for Hyper-V management and routine automation
-- **Proficient level required:** Windows Server Failover Clustering and Hyper-V high availability configuration, Hyper-V Replica setup, configuration, and recovery procedure testing, Storage Spaces Direct (S2D) and Cluster Shared Volumes (CSV) management, Windows Admin Center for remote server and VM management
-- **Working Knowledge required:** Software-Defined Networking and Hyper-V virtual switch configuration, Azure hybrid services integration for on-premises Hyper-V environments, Virtual Machine Queue (VMQ) and network performance settings
-- **Awareness level expected:** Azure Stack HCI cloud-managed Hyper-V features and capabilities, Windows Server 2025 virtualisation improvements and new Hyper-V features
+**Expert level required:**
+
+- Microsoft Hyper-V host configuration, virtual machine provisioning, and lifecycle management, System Center Virtual Machine Manager (SCVMM) for VM operations and cluster management, Windows Server administration and update management with WSUS, PowerShell scripting for Hyper-V management and routine automation
+
+**Proficient level required:**
+
+- Windows Server Failover Clustering and Hyper-V high availability configuration, Hyper-V Replica setup, configuration, and recovery procedure testing, Storage Spaces Direct (S2D) and Cluster Shared Volumes (CSV) management, Windows Admin Center for remote server and VM management
+
+**Working Knowledge required:**
+
+- Software-Defined Networking and Hyper-V virtual switch configuration
+- Azure hybrid services integration for on-premises Hyper-V environments
+- Virtual Machine Queue (VMQ) and network performance settings
+
+**Awareness level expected:**
+
+- Azure Stack HCI cloud-managed Hyper-V features and capabilities
+- Windows Server 2025 virtualisation improvements and new Hyper-V features
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -79,10 +79,27 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Hyper-V platform capabilities and Windows Server licensing models for product governance, Jira and Confluence for agile backlog management, sprint planning, and roadmap communication, Azure Stack HCI platform roadmap and infrastructure investment strategy, Windows Server Datacenter and Standard licensing governance and cost optimisation
-- **Proficient level required:** System Center Virtual Machine Manager (SCVMM) product capabilities and service catalog design, Windows Admin Center for platform health monitoring and service reporting, Azure hybrid integration features and virtual machine migration tooling, Capacity planning and infrastructure utilisation reporting
-- **Working Knowledge required:** Hyper-V Replica and Azure Site Recovery for DR planning and SLA governance, Software-Defined Networking product capabilities in Windows Server, PowerShell automation and self-service provisioning pattern design
-- **Awareness level expected:** Azure Arc and Azure Stack HCI platform convergence roadmap, VMware and Nutanix competitive positioning for infrastructure strategy context
+**Expert level required:**
+
+- Microsoft Hyper-V platform capabilities and Windows Server licensing models for product governance, Jira and Confluence for agile backlog management, sprint planning, and roadmap communication, Azure Stack HCI platform roadmap and infrastructure investment strategy, Windows Server Datacenter and Standard licensing governance and cost optimisation
+
+**Proficient level required:**
+
+- System Center Virtual Machine Manager (SCVMM) product capabilities and service catalog design
+- Windows Admin Center for platform health monitoring and service reporting
+- Azure hybrid integration features and virtual machine migration tooling
+- Capacity planning and infrastructure utilisation reporting
+
+**Working Knowledge required:**
+
+- Hyper-V Replica and Azure Site Recovery for DR planning and SLA governance
+- Software-Defined Networking product capabilities in Windows Server
+- PowerShell automation and self-service provisioning pattern design
+
+**Awareness level expected:**
+
+- Azure Arc and Azure Stack HCI platform convergence roadmap
+- VMware and Nutanix competitive positioning for infrastructure strategy context
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -82,10 +82,24 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Microsoft Hyper-V at advanced cluster configuration and performance optimisation level, Windows Server Failover Clustering and high availability implementation, System Center Virtual Machine Manager (SCVMM) advanced orchestration, templates, and library management, PowerShell Direct and advanced scripting for Hyper-V automation workflows
-- **Proficient level required:** Storage Spaces Direct (S2D) and Azure Stack HCI implementation and performance tuning, Hyper-V Replica and disaster recovery configuration, failover testing, and runbook design, Shielded VMs and Virtualization-Based Security (VBS) deployment, Software-Defined Networking in Windows Server advanced configuration
-- **Working Knowledge required:** Windows Admin Center extensions and performance monitoring integration, Azure Arc and Azure Stack HCI hybrid connectivity for management, Microsoft Endpoint Configuration Manager integration for VM guest OS management
-- **Awareness level expected:** Azure Stack HCI next-generation capabilities and ARC-enabled services, Windows Server container integration and Kubernetes on Hyper-V emerging patterns
+**Expert level required:**
+
+- Microsoft Hyper-V at advanced cluster configuration and performance optimisation level, Windows Server Failover Clustering and high availability implementation, System Center Virtual Machine Manager (SCVMM) advanced orchestration, templates, and library management, PowerShell Direct and advanced scripting for Hyper-V automation workflows
+
+**Proficient level required:**
+
+- Storage Spaces Direct (S2D) and Azure Stack HCI implementation and performance tuning, Hyper-V Replica and disaster recovery configuration, failover testing, and runbook design, Shielded VMs and Virtualization-Based Security (VBS) deployment, Software-Defined Networking in Windows Server advanced configuration
+
+**Working Knowledge required:**
+
+- Windows Admin Center extensions and performance monitoring integration
+- Azure Arc and Azure Stack HCI hybrid connectivity for management
+- Microsoft Endpoint Configuration Manager integration for VM guest OS management
+
+**Awareness level expected:**
+
+- Azure Stack HCI next-generation capabilities and ARC-enabled services
+- Windows Server container integration and Kubernetes on Hyper-V emerging patterns
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -72,10 +72,27 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Nutanix AOS and AHV hypervisor architecture, cluster design, and sizing methodology, Nutanix Prism Central for enterprise multi-cluster governance and policy automation, Nutanix Flow microsegmentation and network security architecture, Nutanix HCI disaster recovery design (Nutanix Leap, Metro Availability, Async DR)
-- **Proficient level required:** Nutanix Calm for application lifecycle automation and blueprint design, Nutanix Files and Objects software-defined storage architecture and design, Nutanix Era for database-as-a-service workload placement, Nutanix Karbon for Kubernetes platform design and integration
-- **Working Knowledge required:** Nutanix Clusters and Xi for hybrid and multi-cloud workload placement strategy, Nutanix Beam for multi-cloud cost governance and chargeback, Nutanix Foundation for automated large-scale cluster deployment
-- **Awareness level expected:** Nutanix Frame for desktop-as-a-service product capabilities, Cloud-native HCI competitive landscape (VMware vSAN, Azure Stack HCI, HPE SimpliVity)
+**Expert level required:**
+
+- Nutanix AOS and AHV hypervisor architecture, cluster design, and sizing methodology, Nutanix Prism Central for enterprise multi-cluster governance and policy automation, Nutanix Flow microsegmentation and network security architecture, Nutanix HCI disaster recovery design (Nutanix Leap, Metro Availability, Async DR)
+
+**Proficient level required:**
+
+- Nutanix Calm for application lifecycle automation and blueprint design
+- Nutanix Files and Objects software-defined storage architecture and design
+- Nutanix Era for database-as-a-service workload placement
+- Nutanix Karbon for Kubernetes platform design and integration
+
+**Working Knowledge required:**
+
+- Nutanix Clusters and Xi for hybrid and multi-cloud workload placement strategy
+- Nutanix Beam for multi-cloud cost governance and chargeback
+- Nutanix Foundation for automated large-scale cluster deployment
+
+**Awareness level expected:**
+
+- Nutanix Frame for desktop-as-a-service product capabilities
+- Cloud-native HCI competitive landscape (VMware vSAN, Azure Stack HCI, HPE SimpliVity)
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -72,10 +72,27 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Nutanix AOS and AHV hypervisor for day-to-day cluster operations and maintenance, Nutanix Prism Element and Prism Central for VM provisioning, monitoring, and cluster management, Nutanix Foundation for node imaging and cluster deployment procedures, VM provisioning, template management, and storage container configuration
-- **Proficient level required:** Nutanix Flow for VM-level microsegmentation policy configuration, Nutanix Files and Objects for software-defined storage management, Nutanix Move for workload migration execution and cutover, Nutanix REST APIs and automation scripts for routine operational tasks
-- **Working Knowledge required:** Nutanix backup and disaster recovery tools configuration and recovery testing, Nutanix Guest Tools installation and management in virtual machines, Nutanix software upgrade execution and patch compliance processes
-- **Awareness level expected:** Nutanix Calm blueprints and self-service provisioning automation capabilities, Nutanix Karbon Kubernetes platform administration concepts
+**Expert level required:**
+
+- Nutanix AOS and AHV hypervisor for day-to-day cluster operations and maintenance, Nutanix Prism Element and Prism Central for VM provisioning, monitoring, and cluster management, Nutanix Foundation for node imaging and cluster deployment procedures, VM provisioning, template management, and storage container configuration
+
+**Proficient level required:**
+
+- Nutanix Flow for VM-level microsegmentation policy configuration
+- Nutanix Files and Objects for software-defined storage management
+- Nutanix Move for workload migration execution and cutover
+- Nutanix REST APIs and automation scripts for routine operational tasks
+
+**Working Knowledge required:**
+
+- Nutanix backup and disaster recovery tools configuration and recovery testing
+- Nutanix Guest Tools installation and management in virtual machines
+- Nutanix software upgrade execution and patch compliance processes
+
+**Awareness level expected:**
+
+- Nutanix Calm blueprints and self-service provisioning automation capabilities
+- Nutanix Karbon Kubernetes platform administration concepts
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -64,10 +64,27 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Nutanix HCI platform capabilities, licensing models, and strategic roadmap management, Jira and Confluence for agile backlog management, sprint planning, and stakeholder communication, Nutanix Prism Central product features and service catalog governance, Nutanix node licensing and NX/third-party hardware cost management
-- **Proficient level required:** Nutanix Beam for multi-cloud cost governance and utilisation chargeback reporting, Nutanix AOS upgrade and lifecycle management at programme planning level, Capacity planning and resource utilisation dashboards in Prism Central, Stakeholder-facing reporting and HCI service KPI tracking tools
-- **Working Knowledge required:** Nutanix Calm and automation capabilities for self-service provisioning design, Nutanix Flow microsegmentation and security policy management at governance level, Nutanix Clusters on public clouds for hybrid workload placement decisions
-- **Awareness level expected:** Nutanix Frame desktop-as-a-service capabilities and competitive positioning, Competitive HCI landscape (VMware vSAN, Azure Stack HCI, HPE SimpliVity) for market context
+**Expert level required:**
+
+- Nutanix HCI platform capabilities, licensing models, and strategic roadmap management, Jira and Confluence for agile backlog management, sprint planning, and stakeholder communication, Nutanix Prism Central product features and service catalog governance, Nutanix node licensing and NX/third-party hardware cost management
+
+**Proficient level required:**
+
+- Nutanix Beam for multi-cloud cost governance and utilisation chargeback reporting
+- Nutanix AOS upgrade and lifecycle management at programme planning level
+- Capacity planning and resource utilisation dashboards in Prism Central
+- Stakeholder-facing reporting and HCI service KPI tracking tools
+
+**Working Knowledge required:**
+
+- Nutanix Calm and automation capabilities for self-service provisioning design
+- Nutanix Flow microsegmentation and security policy management at governance level
+- Nutanix Clusters on public clouds for hybrid workload placement decisions
+
+**Awareness level expected:**
+
+- Nutanix Frame desktop-as-a-service capabilities and competitive positioning
+- Competitive HCI landscape (VMware vSAN, Azure Stack HCI, HPE SimpliVity) for market context
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -64,10 +64,27 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** Nutanix AOS and AHV hypervisor at advanced configuration, performance tuning, and cluster optimisation level, Nutanix Prism Central multi-cluster management, automation, and advanced policy design, Nutanix Flow network security advanced microsegmentation and policy design, Nutanix Calm blueprint development and application lifecycle automation
-- **Proficient level required:** Nutanix Files and Objects advanced storage configuration and troubleshooting, Nutanix Era database-as-a-service implementation and lifecycle management, Nutanix Karbon Kubernetes platform deployment and operations, Nutanix Foundation for large-scale automated cluster deployments and expansions
-- **Working Knowledge required:** Nutanix Beam for cloud cost governance and resource optimisation reporting, Nutanix Mine for backup integration and data protection policy management, Nutanix Clusters on public clouds (AWS, Azure, GCP) for hybrid workload operations
-- **Awareness level expected:** Nutanix Frame desktop-as-a-service capabilities and use cases, Nutanix GPT-in-a-Box and AI/ML workload acceleration features
+**Expert level required:**
+
+- Nutanix AOS and AHV hypervisor at advanced configuration, performance tuning, and cluster optimisation level, Nutanix Prism Central multi-cluster management, automation, and advanced policy design, Nutanix Flow network security advanced microsegmentation and policy design, Nutanix Calm blueprint development and application lifecycle automation
+
+**Proficient level required:**
+
+- Nutanix Files and Objects advanced storage configuration and troubleshooting
+- Nutanix Era database-as-a-service implementation and lifecycle management
+- Nutanix Karbon Kubernetes platform deployment and operations
+- Nutanix Foundation for large-scale automated cluster deployments and expansions
+
+**Working Knowledge required:**
+
+- Nutanix Beam for cloud cost governance and resource optimisation reporting
+- Nutanix Mine for backup integration and data protection policy management
+- Nutanix Clusters on public clouds (AWS, Azure, GCP) for hybrid workload operations
+
+**Awareness level expected:**
+
+- Nutanix Frame desktop-as-a-service capabilities and use cases
+- Nutanix GPT-in-a-Box and AI/ML workload acceleration features
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -72,10 +72,24 @@ The VMware Architect designs and oversees the organization's virtualization infr
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** VMware vSphere (ESXi, vCenter Server) architecture and SDDC design patterns, VMware NSX-T software-defined networking and microsegmentation architecture, VMware vSAN storage design, performance optimisation, and policy management, VMware Cloud Foundation (VCF) platform architecture and lifecycle management
-- **Proficient level required:** VMware vRealize Suite and Aria Suite for automation, operations, and lifecycle management, VMware Site Recovery Manager (SRM) and vSphere Replication for DR architecture, VMware Horizon VDI platform architecture and design, VMware HCX for workload mobility and cloud migration
-- **Working Knowledge required:** VMware Tanzu for Kubernetes and container workload integration, PowerCLI and vRealize Orchestrator for automation strategy and scripting, VMware Carbon Black for virtualisation security controls
-- **Awareness level expected:** Broadcom VMware licensing model changes and platform consolidation roadmap, Azure VMware Solution and VMware Cloud on AWS for hybrid cloud strategy
+**Expert level required:**
+
+- VMware vSphere (ESXi, vCenter Server) architecture and SDDC design patterns, VMware NSX-T software-defined networking and microsegmentation architecture, VMware vSAN storage design, performance optimisation, and policy management, VMware Cloud Foundation (VCF) platform architecture and lifecycle management
+
+**Proficient level required:**
+
+- VMware vRealize Suite and Aria Suite for automation, operations, and lifecycle management, VMware Site Recovery Manager (SRM) and vSphere Replication for DR architecture, VMware Horizon VDI platform architecture and design, VMware HCX for workload mobility and cloud migration
+
+**Working Knowledge required:**
+
+- VMware Tanzu for Kubernetes and container workload integration
+- PowerCLI and vRealize Orchestrator for automation strategy and scripting
+- VMware Carbon Black for virtualisation security controls
+
+**Awareness level expected:**
+
+- Broadcom VMware licensing model changes and platform consolidation roadmap
+- Azure VMware Solution and VMware Cloud on AWS for hybrid cloud strategy
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -72,10 +72,24 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** VMware vSphere (ESXi, vCenter Server) for VM provisioning and daily operational management, Virtual machine lifecycle management including templates, snapshots, and customisation specifications, VMware Lifecycle Manager (vSphere Update Manager) for host patching and compliance baseline management, vSphere networking with Distributed vSwitches and port group configuration
-- **Proficient level required:** vSphere storage management (VMFS, NFS datastores, Storage DRS), vSphere resource pools, clusters, DRS, and HA configuration, VMware roles-based access control and permission management, vSphere performance dashboards and monitoring within vCenter Server
-- **Working Knowledge required:** VMware NSX-T basics for network virtualisation awareness, vSAN fundamentals for hyperconverged storage operations, PowerCLI for task automation and bulk VM configuration operations
-- **Awareness level expected:** VMware Tanzu and container workload capabilities, Broadcom VMware product consolidation and licensing changes for operational planning
+**Expert level required:**
+
+- VMware vSphere (ESXi, vCenter Server) for VM provisioning and daily operational management, Virtual machine lifecycle management including templates, snapshots, and customisation specifications, VMware Lifecycle Manager (vSphere Update Manager) for host patching and compliance baseline management, vSphere networking with Distributed vSwitches and port group configuration
+
+**Proficient level required:**
+
+- vSphere storage management (VMFS, NFS datastores, Storage DRS), vSphere resource pools, clusters, DRS, and HA configuration, VMware roles-based access control and permission management, vSphere performance dashboards and monitoring within vCenter Server
+
+**Working Knowledge required:**
+
+- VMware NSX-T basics for network virtualisation awareness
+- vSAN fundamentals for hyperconverged storage operations
+- PowerCLI for task automation and bulk VM configuration operations
+
+**Awareness level expected:**
+
+- VMware Tanzu and container workload capabilities
+- Broadcom VMware product consolidation and licensing changes for operational planning
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -72,10 +72,23 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** VMware vSphere platform capabilities and strategic product roadmap management, Jira and Confluence for agile backlog management, sprint ceremonies, and roadmap reporting, VMware and Broadcom licensing models, TCO analysis, and cost optimisation governance, vRealize Operations and Aria Suite dashboards for platform performance and capacity reporting
-- **Proficient level required:** VMware NSX-T, vSAN, and Cloud Foundation (VCF) product capabilities at service planning and SLA definition level, VMware Site Recovery Manager for DR governance and business continuity planning, vCenter Server and ESXi upgrade lifecycle planning and risk assessment, Stakeholder-facing capacity and utilisation reporting
-- **Working Knowledge required:** VMware Horizon VDI and desktop virtualisation product features for service catalog design, VMware Tanzu Kubernetes integration capabilities for container strategy decisions, PowerCLI and vRealize Orchestrator automation capabilities for self-service provisioning design
-- **Awareness level expected:** Broadcom VMware strategic direction, pricing changes, and alternative platform migration options, Azure VMware Solution and VMware Cloud on AWS for hybrid cloud positioning
+**Expert level required:**
+
+- VMware vSphere platform capabilities and strategic product roadmap management, Jira and Confluence for agile backlog management, sprint ceremonies, and roadmap reporting, VMware and Broadcom licensing models, TCO analysis, and cost optimisation governance, vRealize Operations and Aria Suite dashboards for platform performance and capacity reporting
+
+**Proficient level required:**
+
+- VMware NSX-T, vSAN, and Cloud Foundation (VCF) product capabilities at service planning and SLA definition level, VMware Site Recovery Manager for DR governance and business continuity planning, vCenter Server and ESXi upgrade lifecycle planning and risk assessment, Stakeholder-facing capacity and utilisation reporting
+
+**Working Knowledge required:**
+
+- VMware Horizon VDI and desktop virtualisation product features for service catalog design
+- VMware Tanzu Kubernetes integration capabilities for container strategy decisions
+- PowerCLI and vRealize Orchestrator automation capabilities for self-service provisioning design
+
+**Awareness level expected:**
+
+- Broadcom VMware strategic direction, pricing changes, and alternative platform migration options, Azure VMware Solution and VMware Cloud on AWS for hybrid cloud positioning
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -72,10 +72,27 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 
 **Technology Proficiency Levels:**
 
-- **Expert level required:** VMware vSphere (ESXi 7.0/8.0, vCenter Server) at advanced configuration, cluster design, and performance optimisation level, VMware vSAN storage design, deduplication, compression, and performance tuning, VMware NSX-T software-defined networking and microsegmentation implementation, PowerCLI scripting and automation for vSphere operational management and bulk tasks
-- **Proficient level required:** VMware Site Recovery Manager (SRM) and vSphere Replication for DR implementation and failover testing, VMware vRealize Operations (Aria Operations) and Log Insight for performance management, VMware Cloud Foundation (VCF) lifecycle management and SDDC upgrade procedures, VMware Aria Suite for infrastructure automation and orchestration
-- **Working Knowledge required:** VMware Tanzu for Kubernetes workload management and integration, VMware HCX for workload mobility and cloud migration workflows, vRealize Orchestrator for complex multi-step workflow automation
-- **Awareness level expected:** Broadcom VMware product consolidation and licensing changes impact on platform strategy, Emerging cloud-native alternatives and Azure VMware Solution integration patterns
+**Expert level required:**
+
+- VMware vSphere (ESXi 7.0/8.0, vCenter Server) at advanced configuration, cluster design, and performance optimisation level, VMware vSAN storage design, deduplication, compression, and performance tuning, VMware NSX-T software-defined networking and microsegmentation implementation, PowerCLI scripting and automation for vSphere operational management and bulk tasks
+
+**Proficient level required:**
+
+- VMware Site Recovery Manager (SRM) and vSphere Replication for DR implementation and failover testing
+- VMware vRealize Operations (Aria Operations) and Log Insight for performance management
+- VMware Cloud Foundation (VCF) lifecycle management and SDDC upgrade procedures
+- VMware Aria Suite for infrastructure automation and orchestration
+
+**Working Knowledge required:**
+
+- VMware Tanzu for Kubernetes workload management and integration
+- VMware HCX for workload mobility and cloud migration workflows
+- vRealize Orchestrator for complex multi-step workflow automation
+
+**Awareness level expected:**
+
+- Broadcom VMware product consolidation and licensing changes impact on platform strategy
+- Emerging cloud-native alternatives and Azure VMware Solution integration patterns
 
 ## Interactions with Other Roles
 


### PR DESCRIPTION
## Summary

Second #122 pass. 191 files folded each proficiency tier into a single inline bullet instead of the template's sub-heading followed by a list.

**Validator warnings: 391 → 200.** Everything remaining is the KPI class.

Refs #122

## Splitting these lines is not uniformly safe

Most are flat tool lists and split cleanly. **73 are grouped capability phrases using Oxford commas**, and a naive split destroys them:

```
Amazon EC2, Auto Scaling groups, and Elastic Load Balancing for compute management,
Amazon VPC, subnets, security groups, and route table configuration,
AWS IAM (users, roles, policies, and service account management),
Amazon S3 and core storage services (EBS, EFS, Glacier)
```

That is **four** capabilities. Splitting on top-level commas yields nine fragments including `and route table configuration` and `and log management` — valid Markdown, ruined meaning.

The transform detects the signal (a segment beginning with `and`/`or`) and keeps those lines verbatim as one bullet. Splitting is paren-aware throughout, so `Azure Networking (Hub-spoke, vWAN, ExpressRoute, Azure Firewall)` stays intact.

| | Lines |
|---|---|
| Split into per-item bullets | **653** |
| Kept verbatim (unsafe) | **73** → tracked in #138 |
| No top-level comma | 38 |

## The safety proof

Every one of the 191 files was checked to have an **identical word multiset before and after** — normalising list markers, bold markers and whitespace, then comparing sorted words:

```
files changed: 191
files where the word multiset differs (content lost or invented): 0
```

Structure changed; content did not. The +4095/-764 line count is bullets replacing long single lines, not new text.

## Test plan

- [x] Dry-run and audited before applying: inspected all 272 lines containing parenthesised commas, the 66 items over 110 chars, and every item starting with a connective — that audit is what surfaced the 73 unsafe lines
- [x] Word-multiset equality across all 191 files (above)
- [x] `npm test` — 143/143
- [x] `npm run validate` — 0 errors, 0 duplicate titles; proficiency warnings 191 → **0**
- [x] Spot-checked both paths: a clean line split into 4 bullets, an unsafe line retained whole