### PR TITLE
fix: revert reference-section de-emphasis, group onboarding templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -702,10 +702,14 @@
         }
         .md-section .owns-advises td:last-child { color: var(--text-secondary); }
 
-        /* Trailing reference material is looked up deliberately rather than
-           read through, so it sits back from the substantive sections. */
-        .md-section.section-reference > .md-section-hd { color: var(--text-secondary); font-weight: 600; }
-        .md-section.section-reference { font-size: 0.95em; }
+        /* #113 de-emphasised Key Technologies, Remote Work Considerations and
+           Recommended Certifications with a muted heading and a 0.95em size on
+           the whole section. Reverted in #143: shrinking the body copy of three
+           sections out of thirteen read as a rendering fault rather than as
+           hierarchy — the first thing it prompted was "why are these headers a
+           different font?". Sections already collapse by default (#112) and the
+           section nav (#111) handles navigation, so this was buying almost
+           nothing in exchange for looking broken. */
 
         /* ── Sticky section nav (#111) ──────────────────────── */
         .toc-nav {
@@ -1482,7 +1486,7 @@
         sectionStartsOpen, panelStateFor,
         tocIdFor, activeTocIndex,
         parseRoleMeta, splitReportingValue, reviewSlotFor,
-        EXEC_LEVELS, STAT_GROUPS, countRolesAtLevels, roleMatchesFilter,
+        EXEC_LEVELS, STAT_GROUPS, countRolesAtLevels, roleMatchesFilter, groupResources,
         findRoleByTitle: resolveRoleTitle,
     } = ViewerLogic;
 
@@ -1511,12 +1515,26 @@
     const openChapters = new Set(); // chapters explicitly expanded by user
 
     // ── Reference documents ──────────────────────────────
+    // Two kinds of thing, kept apart (#144). The reference docs describe what
+    // the catalogue contains and are read; the onboarding templates are
+    // working documents you copy and fill in for a specific person. Listing
+    // them identically made the templates easy to miss and gave no signal
+    // they were actionable.
+    //
+    // Order here is the order rendered, and the onboarding group is meant to
+    // grow — 30/60/90 plans, buddy checklists, per-chapter variants — so add
+    // a row rather than a second hard-coded list.
+    const RESOURCE_GROUPS = [
+        { key: 'reference',  label: '📚 Resources'  },
+        { key: 'onboarding', label: '🚀 Onboarding' },
+    ];
+
     const RESOURCES = [
-        { file: 'docs/CHAPTERS_OVERVIEW.md',                  icon: '🗂️', title: 'Chapters Overview' },
-        { file: 'docs/SKILLS_PROGRESSION.md',                 icon: '📈', title: 'Career Paths & Skills Progression' },
-        { file: 'docs/CROSS_DOMAIN_INTERACTIONS.md',          icon: '🔀', title: 'Domain Interactions' },
-        { file: 'docs/ONBOARDING_TEMPLATE.md',                icon: '🚀', title: 'Onboarding Template' },
-        { file: 'docs/onboarding_chapter_lead_template.md',   icon: '👑', title: 'Chapter Lead Onboarding Template' },
+        { group: 'reference',  file: 'docs/CHAPTERS_OVERVIEW.md',                icon: '🗂️', title: 'Chapters Overview' },
+        { group: 'reference',  file: 'docs/SKILLS_PROGRESSION.md',               icon: '📈', title: 'Career Paths & Skills Progression' },
+        { group: 'reference',  file: 'docs/CROSS_DOMAIN_INTERACTIONS.md',        icon: '🔀', title: 'Domain Interactions' },
+        { group: 'onboarding', file: 'docs/ONBOARDING_TEMPLATE.md',              icon: '📋', title: 'Onboarding Template' },
+        { group: 'onboarding', file: 'docs/onboarding_chapter_lead_template.md', icon: '👑', title: 'Chapter Lead Onboarding Template' },
     ];
 
     // ── Chapter → domain groupings ───────────────────────
@@ -2345,19 +2363,20 @@
             </div>` + html;
         }
 
-        // Resources section — always visible regardless of search filter
-        const resourcesHtml = `
+        // Resources — always visible regardless of search filter, and grouped
+        // so read-only references and fill-in templates are told apart (#144).
+        const resourcesHtml = groupResources(RESOURCES, RESOURCE_GROUPS).map(g => `
             <div class="resources-sep">
-                <div class="resources-hd">📚 Resources</div>
-                ${RESOURCES.map(r => `
+                <div class="resources-hd">${escapeHtml(g.label)}</div>
+                ${g.items.map(r => `
                 <div class="resource-item ${activeDoc === r.file ? 'active' : ''}"
                      role="button" tabindex="0"
                      data-doc="${escapeHtml(r.file)}"
                      data-doc-title="${escapeHtml(r.title)}">
                     <span class="resource-ico">${r.icon}</span>
-                    <span>${r.title}</span>
+                    <span>${escapeHtml(r.title)}</span>
                 </div>`).join('')}
-            </div>`;
+            </div>`).join('');
 
         nav.innerHTML = resourcesHtml + html;
     }
@@ -2662,13 +2681,6 @@
             const details = document.createElement('details');
             details.className = 'md-section';
             if (sectionStartsOpen(heading)) details.open = true;
-
-            // Reference sections are looked up on demand rather than read
-            // through, so they carry less visual weight than the sections
-            // that state what the role owns and does (#113).
-            if (/^(Key Technologies|Recommended Certifications|Remote Work Considerations)/i.test(heading)) {
-                details.classList.add('section-reference');
-            }
 
             const summary = document.createElement('summary');
             summary.className = 'md-section-hd';

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const {
     STALE_MONTHS,
+    groupResources,
     EXEC_LEVELS,
     STAT_GROUPS,
     countRolesAtLevels,
@@ -1010,4 +1011,42 @@ test('roleMatchesFilter matches on domain and chapter as well as title', () => {
     const ctx  = { domainLabel: 'Cloud Platforms', chapterLabel: 'Cloud, Platform & Infrastructure' };
     assert.equal(roleMatchesFilter(role, ctx, { q: 'cloud platforms', levels: [] }), true);
     assert.equal(roleMatchesFilter(role, ctx, { q: 'infrastructure',  levels: [] }), true);
+});
+
+// ── groupResources (#144) ─────────────────────────────────
+// The Resources list mixed two kinds of thing: read-only references
+// describing the catalogue, and onboarding templates you copy and fill in.
+// Grouping is data-driven so the onboarding group is somewhere new
+// templates get added, not a hard-coded second list.
+test('groupResources returns groups in the declared order, not alphabetically', () => {
+    const items = [
+        { group: 'reference',  title: 'A' },
+        { group: 'onboarding', title: 'B' },
+        { group: 'reference',  title: 'C' },
+    ];
+    const groups = groupResources(items, [
+        { key: 'reference',  label: '📚 Resources' },
+        { key: 'onboarding', label: '🚀 Onboarding' },
+    ]);
+    assert.deepEqual(groups.map(g => g.label), ['📚 Resources', '🚀 Onboarding']);
+    assert.deepEqual(groups[0].items.map(i => i.title), ['A', 'C']);
+    assert.deepEqual(groups[1].items.map(i => i.title), ['B']);
+});
+
+test('groupResources omits a group that has no items', () => {
+    const groups = groupResources([{ group: 'reference', title: 'A' }], [
+        { key: 'reference',  label: 'Ref' },
+        { key: 'onboarding', label: 'Onboarding' },
+    ]);
+    assert.deepEqual(groups.map(g => g.label), ['Ref']);
+});
+
+test('groupResources keeps an ungrouped item visible in the first group', () => {
+    // A resource added without a group must not silently vanish from the
+    // sidebar - that failure mode is invisible until someone goes looking.
+    const groups = groupResources([{ title: 'Orphan' }], [
+        { key: 'reference',  label: 'Ref' },
+        { key: 'onboarding', label: 'Onboarding' },
+    ]);
+    assert.deepEqual(groups[0].items.map(i => i.title), ['Orphan']);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -699,8 +699,25 @@
             || String(chapterLabel).toLowerCase().includes(needle);
     }
 
+    // Bucket sidebar resources by their declared group, preserving the order
+    // the groups are declared in (#144). Empty groups are dropped; an item
+    // with no group falls into the first one rather than disappearing, since
+    // a resource silently missing from the sidebar is not noticed until
+    // somebody goes looking for it.
+    function groupResources(items, groups) {
+        const first = groups[0] && groups[0].key;
+        return groups
+            .map(g => ({
+                key: g.key,
+                label: g.label,
+                items: (items || []).filter(i => (i.group || first) === g.key),
+            }))
+            .filter(g => g.items.length);
+    }
+
     return {
         STALE_MONTHS,
+        groupResources,
         EXEC_LEVELS,
         STAT_GROUPS,
         countRolesAtLevels,


### PR DESCRIPTION
## Summary

Two things the maintainer spotted on the rendered page.

Closes #143, #144

## #143 — reverting my own change

#113 de-emphasised **Key Technologies**, **Remote Work Considerations** and **Recommended Certifications** with a muted heading *and* `font-size: 0.95em` on the whole section — which shrank their body copy. Three sections out of thirteen rendering smaller than the rest reads as a rendering fault, and the first question it prompted was *"why are some of the headers in a different font style?"*

A de-emphasis signal subtle enough to be mistaken for a bug has failed at its job. It was also buying very little: #112 already collapses every section by default and #111 added the section nav, so hierarchy and navigation were both covered.

Full revert of the rules and the class assignment. **#113's other change stays** — the Owns / Advises On table keeps its rule and stronger first column, and the header reporting chips are untouched.

Verified across all 13 sections: **one** distinct heading colour, **one** weight, **one** section font size, and zero `.section-reference` elements remaining.

## #144 — Resources split in two

The list mixed two different kinds of thing:

| Group | Items |
|---|---|
| 📚 Resources | Chapters Overview · Career Paths & Skills Progression · Domain Interactions |
| 🚀 Onboarding | Onboarding Template · Chapter Lead Onboarding Template |

The first three *describe* the catalogue; the last two are working documents you copy and fill in for a specific person. Listing them identically made the templates easy to miss and gave no signal they were actionable.

Grouping is data-driven via `groupResources`, so the onboarding group is somewhere new templates get **added** — 30/60/90 plans, buddy checklists, per-chapter variants — rather than a second hard-coded list. An item declared without a group falls into the first one rather than silently vanishing, which is a failure mode nobody notices until they go looking.

The Onboarding Template icon moves 🚀 → 📋, since the rocket is now the group heading.

## Test plan

- [x] TDD — 3 tests for `groupResources` written first, watched fail as `not defined`
- [x] `npm test` — **152/152** (was 149) · `npm run validate` — 0 errors
- [x] #143: all 13 section headings render with identical colour/weight/size; the three formerly-odd ones verified specifically
- [x] #113 regression: Owns/Advises still tagged with its 2px rule and 600 weight; 2 reporting chips still present
- [x] #144: two groups render with the right members; Chapter Lead Onboarding Template still opens
- [x] No console errors