### PR TITLE
docs: add the 11 missing domains to the relationship graph

### DIFF
--- a/docs/CROSS_DOMAIN_INTERACTIONS.md
+++ b/docs/CROSS_DOMAIN_INTERACTIONS.md
@@ -30,6 +30,17 @@ The table below records which domain holds primary decision-making authority ove
 | Automation framework and reusable tooling standards (cross-domain) | DevOps (Automation Framework Engineer) | Infrastructure Automation Architect, Network Automation Architect, Security Automation Engineer |
 | Site reliability engineering practice and SLO/error-budget methodology | Modern Infrastructure (Site Reliability Engineer / Senior SRE) | DevOps, Database Management, Data Protection |
 | Service desk support model, staffing, and Tier-1/2/3 escalation boundaries | Service Desk (Service Desk Lead) | Client Platform, Endpoint Management, Modern Workplace, Service Management |
+| Hypervisor platform selection and virtual infrastructure standards | Virtualization | Server Hardware, Network, Data Management, Security |
+| Physical server platform, capacity, and refresh strategy | Server Hardware | Virtualization, Specialized Computing, Data Management, Network |
+| HPE-specific server tooling and firmware baselines (OneView, iLO) | HPE Server Hardware | Server Hardware, Network, Specialized Computing |
+| Linux OS build standards, hardening baselines, and patching cadence | Linux Server OS | Security, Kubernetes, Database Management, Specialized Computing |
+| Windows Server OS build standards, hardening baselines, and patching cadence | Windows Server OS | Security, Directory Services, Cloud Platforms, Server Hardware |
+| HPC and specialised compute (GPU, research computing) platform design | Specialized Computing | Server Hardware, Linux Server OS, Network, Data Management |
+| Cloud security posture management and cross-platform guardrails | Security Cross-Platform | Security, DevOps, Cloud Platforms, Kubernetes |
+| CMDB structure, configuration item model, and service catalogue design | ITSM & Configuration | Service Management, DevOps, Security, Enterprise Architecture |
+| Infrastructure onboarding pathway and platform intake standards | Infrastructure Onboarding | DevOps, Enterprise Architecture, ITSM & Configuration, Security Cross-Platform |
+| Chapter structure, technical career framework, and engineering practice standards | Leadership | Enterprise Architecture, all chapters |
+| Enterprise technology strategy, IT investment, and risk appetite | C-Suite | Leadership, Enterprise Architecture, Security & Identity |
 
 ## Key cross-domain relationships
 
@@ -49,6 +60,21 @@ The pairs below represent the most frequent and consequential collaboration rela
 - **Service Management ↔ Data Protection** — major-incident coordination vs recovery execution: the Major Incident Manager runs the incident bridge and communications; the BC/DR Manager owns recovery plans, BIA coverage, and DR test governance; the affected service's engineers execute the technical recovery
 - **Data Management ↔ Security** — classification vs enforcement: the Data Governance Lead defines the classification scheme and data catalogue; Security implements the enforcing controls (DLP, access policy); the Data Privacy Officer sets the privacy requirements both must satisfy for personal data
 - **Service Management ↔ FinOps** — license and contract inputs to cloud cost governance: the Vendor / Supplier / IT Asset Manager provides the contract register, license entitlements, and renewal pipeline that FinOps consumes for commitment and cost optimisation decisions
+- **Virtualization ↔ Server Hardware** — node specifications for hypervisor clusters (Nutanix, vSphere, Hyper-V hosts), firmware/HCL compatibility, and capacity planning for the physical estate the virtual platform runs on
+- **Virtualization ↔ Network** — virtual switching and overlay networking (NSX, distributed switches), east-west traffic design, and connectivity requirements for cluster and vMotion/live-migration traffic
+- **Virtualization ↔ Data Management** — virtual storage design: datastore and container layout, storage policy-based management, and the interaction between hypervisor-level and array-level protection
+- **Server Hardware ↔ Specialized Computing** — HPC and GPU node selection, high-density rack power and cooling constraints, and interconnect (InfiniBand/RoCE) requirements the standard server platform does not cover
+- **Linux Server OS ↔ Kubernetes** — container host configuration: kernel and runtime tuning, host hardening for worker nodes, and the boundary between OS-level patching and cluster node lifecycle
+- **Windows Server OS ↔ Directory Services** — domain-joined server build standards, Group Policy scope for server workloads, and the split between OS hardening baselines and directory-enforced policy
+- **Security Cross-Platform ↔ DevOps** — shift-left posture management: surfacing CSPM and compliance-as-code checks inside CI/CD pipelines so misconfiguration is caught before deployment rather than detected in production
+- **Security Cross-Platform ↔ Security** — scope split: Security owns organisation-wide policy, threat modelling and the control framework; Security Cross-Platform owns the posture tooling and automated enforcement that implements it across cloud and platform estates
+- **ITSM & Configuration ↔ Service Management** — tooling versus process: ITSM & Configuration owns the platform build, CMDB model and integrations; Service Management owns the process design, SLAs and governance those capabilities serve
+- **Infrastructure Onboarding ↔ DevOps** — pipeline integration for platform intake: onboarding standards expressed as reusable pipeline stages and templates rather than manual gates
+- **Infrastructure Onboarding ↔ ITSM & Configuration** — service catalogue design for onboarding requests, and ensuring newly onboarded infrastructure registers correctly as configuration items
+- **HPE Server Hardware ↔ Server Hardware** — vendor-specific depth within the general platform: HPE OneView/iLO tooling, firmware baselines and support entitlements operating inside the hardware standards the broader domain sets
+- **Leadership ↔ Enterprise Architecture** — chapter leads and architects jointly own how architecture principles reach delivery teams: EA sets the standards, chapter leadership owns capability, staffing and adoption within each chapter
+- **C-Suite ↔ Leadership** — strategy to delivery: the C-Suite sets technology direction, investment envelope and risk appetite; SVP/TAL/PAL and chapter leads translate those into structure, headcount and roadmaps
+- **C-Suite ↔ Security & Identity** — the CISO's dual line: security strategy and risk reporting run to the CEO/Board where governance independence requires it, while day-to-day security delivery sits with the Security & Identity chapter
 
 ## Security domain scope clarification
 

--- a/test/skills-progression.test.js
+++ b/test/skills-progression.test.js
@@ -59,3 +59,34 @@ test('every domain has a ladder heading', () => {
     .filter(d => d.isDirectory()).length;
   assert.equal(headings, domainCount, 'one ladder heading per domain');
 });
+
+// ── Cross-domain interactions coverage (#125) ─────────────
+// The viewer's Domain Relationship Graph is built from
+// docs/CROSS_DOMAIN_INTERACTIONS.md. A domain absent from that document is
+// absent from the graph with no indication, so a reader gets a picture that
+// silently omits part of the catalogue — 11 of 33 domains were missing when
+// this guard was written.
+test('every canonical domain appears in CROSS_DOMAIN_INTERACTIONS.md', () => {
+  const { DOMAIN_LABELS } = require('../roleMeta');
+  const doc = fs.readFileSync(path.join(ROOT, 'docs', 'CROSS_DOMAIN_INTERACTIONS.md'), 'utf8')
+    .replace(/^\uFEFF/, '');
+  const missing = Object.entries(DOMAIN_LABELS)
+    .filter(([key, label]) => fs.existsSync(path.join(ROOT, 'Roles', key)) && !doc.includes(label))
+    .map(([, label]) => label);
+  assert.deepEqual(missing, [], 'domains missing from the relationship graph');
+});
+
+test('CROSS_DOMAIN_INTERACTIONS.md references no domain label that no longer exists', () => {
+  // The mirror of the above: a renamed or removed domain leaves a phantom
+  // node in the graph.
+  const { DOMAIN_LABELS } = require('../roleMeta');
+  const labels = new Set(Object.values(DOMAIN_LABELS));
+  const doc = fs.readFileSync(path.join(ROOT, 'docs', 'CROSS_DOMAIN_INTERACTIONS.md'), 'utf8');
+  // Only check the ownership table's Primary Owner column, which must name a
+  // real domain; prose bullets legitimately mention teams and externals.
+  const owners = [...doc.matchAll(/^\|[^|]+\|([^|]+)\|/gm)]
+    .map(m => m[1].trim().replace(/\s*\(.*\)\s*$/, ''))
+    .filter(v => v && v !== 'Primary Owner' && !/^-+$/.test(v));
+  const phantom = [...new Set(owners)].filter(o => !labels.has(o));
+  assert.deepEqual(phantom, [], 'ownership rows naming a non-existent domain');
+});


### PR DESCRIPTION
## Summary

The Domain Relationship Graph is built from `CROSS_DOMAIN_INTERACTIONS.md`, which named only **22 of the catalogue's 33 domains**. The other 11 — including Virtualization (12 roles) and Security Cross-Platform (6) — were absent from the view with no indication, so a reader trying to understand who works with whom got a picture silently missing a third of the catalogue.

Closes #125

## Nothing invented

Entries are **derived from the domains' own role files**. Those 11 domains carry 377 existing interaction rows between them; I resolved each named role to its domain via `findRoleByTitle` and read the relationships the catalogue already describes.

Examples of what the data said:

| Domain | Signal |
|---|---|
| Virtualization | 6 roles name Server Hardware (node specs for hypervisor clusters), 4 name Network, 4 Data Management |
| Specialized Computing | 4 name Server Hardware (HPC hardware), 3 Linux Server OS |
| Security Cross-Platform | 4 name DevOps (shift-left CSPM in pipelines), 3 Security |
| ITSM & Configuration | 3 name DevOps (CI/CD integration), 1 Service Management |

For the thinner domains I read the raw interaction text rather than relying on resolved-link counts alone, since many rows name teams rather than catalogue roles.

Adds **11 ownership rows** and **16 relationship bullets**.

| | Before | After |
|---|---|---|
| Domains named | 22 / 33 | **33 / 33** |
| Graph nodes | 27 | **38** |
| Graph links | — | **81** |
| Accessible list fallback | 123 | **207** entries |

## Drift guards — and proof they work

Two tests in the `SKILLS_PROGRESSION` style: every canonical domain must appear, and the ownership table must not name a domain that no longer exists.

A guard that has never failed is unproven, so I verified both rather than assuming:

```
--- with a domain removed ---
✖ every canonical domain appears in CROSS_DOMAIN_INTERACTIONS.md
--- with a phantom owner ---
✖ CROSS_DOMAIN_INTERACTIONS.md references no domain label that no longer exists
--- restored ---
ℹ pass 5   ℹ fail 0
```

## Test plan

- [x] `npm test` — **154/154** (was 152) · `npm run validate` — 0 errors
- [x] All 33 canonical domains confirmed present in the document
- [x] Graph verified in-browser: all 11 new domains appear as nodes, chart renders, no console errors