### PR TITLE
docs: cascade edge computing coverage from architects to their ladders

### DIFF
--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -44,6 +44,7 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 - Support teams in remediating identified resilience weaknesses.
 - Contribute to production readiness review checklists by defining resilience acceptance criteria.
 - Develop chaos engineering runbooks and experiment templates for engineering team self-service.
+- Design failure experiments for edge topologies: network partition between edge sites and the control plane, prolonged disconnection with local queueing, and degraded-mode behaviour when a site cannot reach central services
 
 ## Key Decisions & Accountabilities
 
@@ -124,6 +125,8 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 - k6 / Locust (load generation for steady state)
 - Python / Go / bash (experiment automation)
 - GitHub Actions / Azure DevOps (CI chaos integration)
+- Network partition and latency injection for cloud-to-edge links
+- Edge disconnection experiments — validating local buffering, queueing and autonomous recovery
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -43,6 +43,7 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 - Optimize LLM inference costs through batching, caching, quantization, and model selection
 - Maintain IaC for AI platform components and automate deployments through CI/CD
 - Document AI platform capabilities, patterns, and runbooks
+- Deploy and operate inference at the edge: model packaging for constrained hardware, rollout and rollback across distributed sites, and monitoring of edge inference latency and accuracy drift
 
 ## Key Decisions & Accountabilities
 
@@ -120,6 +121,8 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 - CI/CD for AI pipelines (GitHub Actions, Azure DevOps, GitLab CI)
 - AI observability and monitoring platforms
 - Python ML/AI ecosystem (LangChain, transformers, pydantic-ai)
+- Edge inference runtimes (NVIDIA Jetson, Intel OpenVINO) for on-device model serving
+- Model distribution and versioning across edge fleets (Azure IoT Edge, AWS Greengrass)
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -40,6 +40,7 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 - Assist application teams with instrumentation and monitoring integration
 - Troubleshoot issues with observability platforms and data collection
 - Document observability implementations and procedures
+- Implement telemetry collection from edge sites: local buffering for intermittent links, sampling and aggregation to fit constrained bandwidth, and alerting that distinguishes a disconnected site from a failed one
 
 ## Key Decisions & Accountabilities
 
@@ -112,6 +113,8 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 - Alert routing and incident integration (Alertmanager, PagerDuty/Opsgenie, ITSM webhooks)
 - Dashboards-as-code and monitoring configuration management (Grafana provisioning, Terraform)
 - Scripting for automation and integration (Python, PowerShell, Bash)
+- OpenTelemetry Collector in edge/gateway deployment modes (local buffering, tail sampling)
+- Edge site monitoring under intermittent connectivity — store-and-forward and backfill patterns
 
 ## Key Performance Indicators
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -40,6 +40,7 @@ The Observability Product Owner manages the observability platform portfolio, de
 - Establish service level objectives for the observability platform itself
 - Coordinate platform adoption and enablement initiatives
 - Track and report on observability platform value and metrics
+- Prioritise observability coverage for edge estates in the backlog, and set the cost expectation for telemetry from bandwidth-constrained sites where full-fidelity collection is not affordable
 
 ## Key Decisions & Accountabilities
 
@@ -129,6 +130,7 @@ The Observability Product Owner manages the observability platform portfolio, de
 - Synthetic monitoring solutions
 - Real User Monitoring (RUM) technologies
 - Dashboard visualization platforms
+- Edge observability cost model — egress and retention trade-offs for distributed sites
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -41,6 +41,7 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 - Develop custom integrations and extensions for observability platforms
 - Mentor Observability Engineers on advanced techniques
 - Evaluate and prototype new observability tools and approaches
+- Own the edge telemetry pipeline design: collection topology across distributed sites, retention and aggregation tiers that keep egress affordable, and the signal model that separates site connectivity loss from workload failure
 
 ## Key Decisions & Accountabilities
 
@@ -126,6 +127,8 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 - Observability as code tools and frameworks
 - AI/ML-based anomaly detection systems
 - Real-time analytics platforms
+- OpenTelemetry Collector edge/gateway topologies and tail-sampling strategy
+- Bandwidth- and cost-aware telemetry tiering for geographically distributed estates
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -40,6 +40,7 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 - Maintain documentation for platform services
 - Implement observability for platform components
 - Support application teams in platform adoption
+- Implement edge deployment paths in the internal developer platform: extend golden-path templates to edge and IoT targets, and support teams onboarding workloads to edge runtimes
 
 ## Key Decisions & Accountabilities
 
@@ -111,6 +112,8 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 - Artifact repositories
 - Container registries
 - Developer utility tools
+- Edge orchestration runtimes (KubeEdge, OpenYurt) as IDP deployment targets
+- Managed edge runtimes (AWS Greengrass, Azure IoT Edge) for platform-provided edge onboarding
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -40,6 +40,7 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 - Create and maintain a strategic roadmap for platform evolution
 - Establish metrics for measuring platform effectiveness
 - Track and report on platform adoption and value delivery
+- Prioritise edge platform capabilities in the backlog: which edge and IoT targets the platform supports, and the sequencing of edge golden paths against demand from consuming teams
 
 ## Key Decisions & Accountabilities
 
@@ -111,6 +112,7 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 - Developer productivity analytics
 - Workflow automation tools
 - Knowledge management systems
+- Edge platform capability landscape (KubeEdge, OpenYurt, AWS Greengrass, Azure IoT Edge) at a capability-and-cost level for roadmap decisions
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -40,6 +40,7 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 - Optimize platform performance and resource utilization
 - Create platform automation and CI/CD integration
 - Provide technical mentorship to Platform Engineers
+- Own the edge portion of the platform golden paths: deployment templates for edge and IoT targets, and the operational runbooks for platform services running outside the datacentre
 
 ## Key Decisions & Accountabilities
 
@@ -109,6 +110,8 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 - Policy engines (OPA, Kyverno)
 - Developer experience tooling
 - Platform automation frameworks
+- Edge orchestration platforms (KubeEdge, OpenYurt) for platform workloads at edge sites
+- Managed edge runtimes (AWS Greengrass, Azure IoT Edge) and their fleet-management models
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -40,6 +40,7 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 - Conduct postmortem analysis and implement reliability improvements
 - Develop runbooks and playbooks for operational procedures
 - Implement chaos engineering practices to improve system resilience
+- Extend SLOs and error budgets to services running at edge sites, where a site can be unreachable without being unhealthy and recovery may not be remotely actionable
 
 ## Key Decisions & Accountabilities
 
@@ -111,6 +112,8 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 - Incident management platforms
 - Runbook automation tools
 - Configuration management systems
+- Edge site reliability patterns — degraded-mode operation and autonomous local recovery
+- Multi-site SLO aggregation where per-site availability differs from service availability
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -44,6 +44,7 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 - Mentor SREs and provide technical coaching to engineering teams on reliability best practices.
 - Define and maintain on-call runbooks and playbooks for critical services.
 - Evaluate and adopt new reliability tooling and platform improvements.
+- Define the reliability model for geographically distributed edge estates: what an SLO means when sites are intermittently reachable, how error budgets are apportioned per site, and when an unreachable site is an incident
 
 ## Key Decisions & Accountabilities
 
@@ -122,6 +123,8 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 - Terraform / Pulumi
 - k6 / Locust (load testing)
 - Argo Rollouts / Flagger (progressive delivery)
+- Multi-site SLO and error-budget modelling for intermittently connected estates
+- Edge failure-domain design — blast radius containment when a site or region is isolated
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -45,6 +45,7 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 - Promote sustainable and energy-efficient HPC operations
 - Provide user training and develop clear documentation
 - Continuously seek opportunities for process and technology improvement
+- Operate distributed edge inference and pre-processing nodes: deployment to accelerator hardware at edge sites, and the data movement between edge collection and central HPC capacity
 
 ## Key Decisions & Accountabilities
 
@@ -127,6 +128,8 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 - GPU computing frameworks (CUDA, OpenACC)
 - Cloud HPC solutions (AWS ParallelCluster, Azure CycleCloud, Google Cloud HPC)
 - Batch processing and workflow scripting
+- Edge accelerator platforms (NVIDIA Jetson, Intel OpenVINO) for distributed inference
+- Edge-to-datacentre data staging for compute pipelines that begin at the edge
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -44,6 +44,7 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 - Advocate for sustainability and diversity in HPC strategy and operations
 - Lead change management and communication for HPC initiatives
 - Gather and act on continuous feedback from users and stakeholders
+- Prioritise edge-HPC capability in the backlog: which workloads justify distributed edge capacity against central compute, and the cost and data-residency trade-offs each option carries
 
 ## Key Decisions & Accountabilities
 
@@ -133,6 +134,7 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 - Utilization, chargeback, and value reporting for HPC investments
 - Scientific application stacks and environment module systems
 - HPC user portals and self-service gateways (Open OnDemand)
+- Edge compute capability and cost landscape (AWS Wavelength, Azure Edge Zones) for capacity planning
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -44,6 +44,7 @@ The HPC Senior Engineer leads the technical implementation, automation, and opti
 - Foster a culture of innovation, diversity, equity, and inclusion within the HPC team
 - Proactively identify and mitigate risks to HPC operations and security
 - Lead continuous improvement initiatives for HPC processes and technologies
+- Own the operational design of edge-HPC pipelines: where pre-processing runs at the edge versus centrally, how results are staged back, and the scheduling implications of geographically distributed capacity
 
 ## Key Decisions & Accountabilities
 
@@ -130,6 +131,8 @@ The HPC Senior Engineer leads the technical implementation, automation, and opti
 - Performance profiling and monitoring tools (Intel VTune, Arm Forge, TAU, Grafana)
 - Cloud HPC solutions (AWS ParallelCluster, Azure CycleCloud, Google Cloud HPC)
 - Advanced scripting and automation (Python, Bash, Ansible)
+- Edge-HPC pipeline design (NVIDIA Jetson, Intel OpenVINO, AWS Wavelength, Azure Edge Zones)
+- Data-gravity and staging strategy for workloads that originate at edge sites
 
 ## Typical Day-to-Day Activities
 


### PR DESCRIPTION
## The issue's numbers were wrong, and the real gap is more specific

I filed #150 saying three roles were covered and nineteen needed review. Both figures were wrong, because I had counted with a case-insensitive search for `edge` — which matches **know*ledge***, and every role file contains "Working Knowledge required".

Recounting on a word boundary:

| | |
|---|---|
| Actually covered | **6** — the three named, plus `genai_platform_architect` (17 mentions), `mlops_engineer` (16) and `observability_architect` (14), presumably from the AI/GenAI review |
| Actually uncovered | **13** |

And the pattern in those 13 is the real finding: **every covered role is architect-level**. The March review added edge at the top of each ladder and never carried it down, so ten roles were expected to implement, operate or prioritise something their own role file never mentioned.

| Group | Roles |
|---|---|
| Ladder-mates of a covered architect | platform_engineering (engineer, senior, PO) · observability (engineer, senior, PO) · genai_platform (engineer) · hpc (engineer, senior, PO) — **10** |
| Judged on merit, no covered architect above them | site_reliability_engineer · site_reliability_senior_engineer · chaos_engineer — **3** |

All three in the second group earned inclusion: SLOs for intermittently reachable sites and cloud-to-edge partition experiments are real work, not associations.

Closes #150

## Written per role, not generated

Content is pitched to the role, since a Product Owner does not need runtime tooling depth and an Engineer does not need a cost model:

- **Engineers** — operational detail: local buffering for intermittent links, model rollout and rollback across edge fleets, deployment to accelerator hardware at edge sites
- **Senior Engineers** — the design and ownership slice: telemetry collection topology, what an SLO means when a site is unreachable but healthy, where edge-HPC pre-processing runs versus central compute
- **Product Owners** — roadmap and prioritisation framing: which edge targets the platform supports, and the cost and data-residency trade-offs each carries

Each role gets one Key Responsibilities bullet and one or two Key Technologies entries, matching how the existing six were done.

## Test plan

- [x] Dry-run first; the transform reported 13 of 13 before anything was written
- [x] Insertion finds sections **by name** — section order varies between files, so position could not be assumed, and the transform refuses rather than guessing if a section does not end in a bullet list
- [x] Recount after applying: **zero** roles in Modern Infrastructure or Specialized Computing left without edge coverage
- [x] `npm test` — 154/154 · `npm run validate` — 0 errors, 0 duplicate titles · `npm run check-counts` — README matches
- [x] Diff is 36 insertions across 13 files, no deletions — purely additive