### PR TITLE
feat: add a recently-viewed list to the welcome screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -669,6 +669,51 @@
         .cm-empty { color: var(--text-muted); }
         .cm-error { color: var(--accent-red, #d13438); }
 
+        /* ── Recently viewed (#117) ─────────────────────────── */
+        .recent-block {
+            width: 100%;
+            max-width: 900px;
+            margin: 0 auto 26px;
+            text-align: left;
+        }
+        .recent-block[hidden] { display: none; }
+
+        .recent-hd-row {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 10px;
+        }
+        .recent-hd {
+            font-size: 0.82em;
+            font-weight: 700;
+            letter-spacing: 0.4px;
+            text-transform: uppercase;
+            color: var(--text-muted);
+        }
+
+        .recent-list { display: flex; flex-wrap: wrap; gap: 8px; }
+
+        .recent-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 12px;
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-lg);
+            background: var(--bg-card);
+            cursor: pointer;
+            font-size: 0.85em;
+            transition: border-color var(--transition), background var(--transition);
+        }
+        .recent-item:hover { border-color: var(--accent-blue); background: var(--bg-card-hover); }
+        .recent-item:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }
+        .recent-item-name { color: var(--text-primary); }
+
+        /* A reading aid, not content. */
+        @media print { .recent-block { display: none !important; } }
+
         /* ── Reporting line in the header (#113) ────────────── */
         .role-reporting { margin-top: 8px; }
         .meta-reporting {
@@ -1356,6 +1401,16 @@
             <div class="welcome-icon">📋</div>
             <h2>Select a role to view</h2>
             <p>Choose a domain and role from the sidebar to read the full role definition.</p>
+
+            <!-- Recently viewed (#117) — hidden until there is history -->
+            <section class="recent-block" id="recentBlock" aria-labelledby="recentHd" hidden>
+                <div class="recent-hd-row">
+                    <h3 class="recent-hd" id="recentHd">🕘 Recently viewed</h3>
+                    <button class="link-btn" id="clearRecent" onclick="clearRecent()">Clear</button>
+                </div>
+                <div class="recent-list" id="recentList"></div>
+            </section>
+
             <div class="stats-cards" id="statsCards"></div>
 
             <!-- Distribution charts (rendered once role data is loaded) -->
@@ -1479,7 +1534,7 @@
 <script>
     // ── Shared pure view logic (viewer-logic.js, also under node:test) ──
     const {
-        STALE_MONTHS, REFERENCE_DOC_PATTERN, LEVEL_ORDER, LEVEL_SHORT,
+        STALE_MONTHS, REFERENCE_DOC_PATTERN, LEVEL_ORDER, LEVEL_SHORT, pushRecent,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
@@ -1499,6 +1554,57 @@
     // Levels the sidebar is currently narrowed to (#115). Empty = no
     // constraint. Combines with the text query rather than replacing it.
     let activeLevels = new Set();
+
+    // ── Recently viewed (#117) ───────────────────────────
+    // localStorage throws rather than returning null when storage is
+    // unavailable — Safari private mode, disabled site data, a full quota —
+    // so every access is guarded. Losing the history is a non-event; taking
+    // the whole viewer down with it would not be.
+    const RECENT_KEY = 'doc-itroles:recent';
+    const RECENT_MAX = 10;
+    let recentRoles = [];
+
+    function loadRecent() {
+        try {
+            recentRoles = pushRecent(JSON.parse(localStorage.getItem(RECENT_KEY)), null, RECENT_MAX);
+        } catch { recentRoles = []; }
+    }
+
+    function saveRecent() {
+        try { localStorage.setItem(RECENT_KEY, JSON.stringify(recentRoles)); } catch { /* history is expendable */ }
+    }
+
+    function recordRecent(file, title, level, domainLabel) {
+        recentRoles = pushRecent(recentRoles, { file, title, level, domainLabel }, RECENT_MAX);
+        saveRecent();
+        renderRecent();
+    }
+
+    function clearRecent() {
+        recentRoles = [];
+        saveRecent();
+        renderRecent();
+    }
+
+    function renderRecent() {
+        const block = document.getElementById('recentBlock');
+        const list  = document.getElementById('recentList');
+        if (!block || !list) return;
+        block.hidden = recentRoles.length === 0;
+        list.innerHTML = recentRoles.map(r => `
+            <div class="recent-item" role="button" tabindex="0"
+                 data-file="${escapeHtml(r.file)}" data-title="${escapeHtml(r.title)}"
+                 data-level="${escapeHtml(r.level)}" data-domain="${escapeHtml(r.domainLabel)}">
+                <span class="recent-item-name">${escapeHtml(r.title)}</span>
+                <span class="badge ${badgeClass(r.level)}">${escapeHtml(r.level)}</span>
+            </div>`).join('');
+    }
+
+    document.getElementById('recentList').addEventListener('click', e => {
+        const item = e.target.closest('.recent-item[data-file]');
+        if (!item) return;
+        openRole(item.dataset.file, item.dataset.title, item.dataset.level, item.dataset.domain);
+    });
 
     // ── State ───────────────────────────────────────────
     let allDomains  = {};
@@ -1646,6 +1752,8 @@
         try {
             const res  = await fetch('/api/roles');
             allDomains = await res.json();
+            loadRecent();
+            renderRecent();
             renderLevelFilters();
             renderSidebar(allDomains);
             renderWelcomeStats(allDomains);
@@ -2873,6 +2981,7 @@
     async function openRole(file, title, level, domainLabel) {
         closeSidebar();
         pushHistory();
+        recordRecent(file, title, level, domainLabel);
         activeFile  = file;
         activeDoc   = null;
         activeChapter = null;

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const {
     STALE_MONTHS,
+    pushRecent,
     groupResources,
     EXEC_LEVELS,
     STAT_GROUPS,
@@ -1049,4 +1050,62 @@ test('groupResources keeps an ungrouped item visible in the first group', () => 
         { key: 'onboarding', label: 'Onboarding' },
     ]);
     assert.deepEqual(groups[0].items.map(i => i.title), ['Orphan']);
+});
+
+// ── pushRecent (#117) ─────────────────────────────────────
+// Navigation history is a single linear Back stack, so returning to a role
+// seen a few minutes ago means re-finding it. A recently-viewed list needs
+// most-recent-first ordering, no duplicates, and a hard cap.
+test('pushRecent puts the newest entry first', () => {
+    const list = pushRecent([], { file: 'a.md', title: 'A' }, 5);
+    assert.deepEqual(list.map(r => r.file), ['a.md']);
+    const list2 = pushRecent(list, { file: 'b.md', title: 'B' }, 5);
+    assert.deepEqual(list2.map(r => r.file), ['b.md', 'a.md']);
+});
+
+test('pushRecent moves a revisited role to the front rather than duplicating it', () => {
+    let list = [];
+    for (const f of ['a.md', 'b.md', 'c.md']) list = pushRecent(list, { file: f, title: f }, 5);
+    list = pushRecent(list, { file: 'a.md', title: 'a.md' }, 5);
+    assert.deepEqual(list.map(r => r.file), ['a.md', 'c.md', 'b.md']);
+    assert.equal(new Set(list.map(r => r.file)).size, list.length, 'no duplicates');
+});
+
+test('pushRecent caps the list and drops the oldest', () => {
+    let list = [];
+    for (const f of ['a', 'b', 'c', 'd']) list = pushRecent(list, { file: f, title: f }, 3);
+    assert.deepEqual(list.map(r => r.file), ['d', 'c', 'b']);
+});
+
+test('pushRecent ignores an entry with no file', () => {
+    const list = pushRecent([{ file: 'a.md', title: 'A' }], { title: 'no file' }, 5);
+    assert.deepEqual(list.map(r => r.file), ['a.md']);
+});
+
+test('pushRecent tolerates a corrupt or non-array stored value', () => {
+    // localStorage content is user-writable and survives across versions, so
+    // it cannot be trusted to still be the shape we wrote.
+    assert.deepEqual(pushRecent(null,        { file: 'a', title: 'A' }, 5).map(r => r.file), ['a']);
+    assert.deepEqual(pushRecent('garbage',   { file: 'a', title: 'A' }, 5).map(r => r.file), ['a']);
+    assert.deepEqual(pushRecent([1, 2, null],{ file: 'a', title: 'A' }, 5).map(r => r.file), ['a']);
+});
+
+test('pushRecent keeps only the fields the list renders', () => {
+    // Storing the whole role object would persist stale titles and levels
+    // across catalogue edits.
+    const list = pushRecent([], { file: 'a.md', title: 'A', level: 'Engineer', domainLabel: 'X', extra: 'drop me' }, 5);
+    assert.deepEqual(Object.keys(list[0]).sort(), ['domainLabel', 'file', 'level', 'title']);
+});
+
+test('pushRecent sanitises the list even when there is no entry to add', () => {
+    // loadRecent() calls pushRecent(stored, null) purely to clean whatever
+    // localStorage held. The early return for a missing entry used to hand
+    // the raw list straight back, so a stored null survived and crashed the
+    // renderer on r.file.
+    assert.deepEqual(pushRecent([1, 2, null, { nope: true }], null, 5), []);
+    assert.deepEqual(
+        pushRecent([{ file: 'a.md', title: 'A', level: 'Engineer', domainLabel: 'D' }, null], null, 5),
+        [{ file: 'a.md', title: 'A', level: 'Engineer', domainLabel: 'D' }]
+    );
+    assert.deepEqual(pushRecent('garbage', null, 5), []);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -715,8 +715,35 @@
             .filter(g => g.items.length);
     }
 
+    // Prepend a role to the recently-viewed list (#117): newest first, no
+    // duplicates, hard cap. Navigation history is a single linear Back stack,
+    // so returning to a role seen a few minutes ago otherwise means finding it
+    // again — and the Compare feature actively encourages visiting several in
+    // sequence.
+    //
+    // Defensive about the incoming list: it comes from localStorage, which is
+    // user-writable and survives across versions, so it cannot be trusted to
+    // still be the shape we wrote. Only the four fields the list renders are
+    // kept, so a stale title or level cannot outlive a catalogue edit by more
+    // than one visit.
+    // Passing a null entry sanitises the list without adding to it, which is
+    // how stored history is cleaned on load. The sanitising must happen on
+    // that path too — returning the raw list let a stored null through and
+    // crashed the renderer on r.file.
+    function pushRecent(list, entry, max = 10) {
+        const keep = r => r && typeof r === 'object' && r.file
+            ? { file: r.file, title: r.title || '', level: r.level || '', domainLabel: r.domainLabel || '' }
+            : null;
+        const kept  = keep(entry);
+        const prior = (Array.isArray(list) ? list : [])
+            .map(keep)
+            .filter(r => r && (!kept || r.file !== kept.file));
+        return (kept ? [kept, ...prior] : prior).slice(0, max);
+    }
+
     return {
         STALE_MONTHS,
+        pushRecent,
         groupResources,
         EXEC_LEVELS,
         STAT_GROUPS,


### PR DESCRIPTION
## Summary

Navigation history was a single linear Back stack, so returning to a role seen a few minutes ago meant finding it again — and Compare actively encourages visiting several in sequence.

The last ten roles opened now appear on the welcome screen, newest first, persisted in `localStorage`. Revisiting a role moves it to the front rather than duplicating it. The block stays hidden until there is history, so a first visit is unchanged.

Closes #117

## Two deliberate calls

**No explicit bookmarking.** The issue listed it as optional. Recently-viewed populates itself; a pin control is a second mechanism to learn for the same job.

**Storage is treated as hostile.** `localStorage` *throws* rather than returning null when unavailable — Safari private mode, disabled site data, a full quota — so every access is guarded. Losing the history is a non-event; taking the viewer down with it would not be. Stored content is also user-writable and outlives the version that wrote it, so it is sanitised on load rather than trusted.

## A bug the browser found that the unit tests missed

`loadRecent()` calls `pushRecent(stored, null)` purely to clean whatever was in storage. The early return for a missing entry handed the **raw list straight back**, skipping the sanitising filter — so a stored `null` survived and crashed the renderer on `r.file`:

```
TypeError: Cannot read properties of null (reading 'file')
    at renderRecent
```

My unit test for junk entries passed only because it supplied a *valid* entry, which takes the other branch. The exact path the app uses was uncovered. Fixed, with a test that pins the null-entry path specifically.

Worth noting because it is the argument for driving the real thing: the suite was green and the feature was broken for anyone whose stored history had ever been touched.

## Test plan

- [x] TDD — 6 tests first, watched fail as `pushRecent is not defined`; a 7th added after the browser exposed the sanitising gap, watched fail, then fixed
- [x] `npm test` — **161/161** (was 154) · `npm run validate` — 0 errors, 0 duplicate titles
- [x] Hidden when empty; appears after the first role; newest-first ordering; revisit moves to front without duplicating
- [x] Capped at 10 with 13 roles visited; storage holds 10
- [x] Clicking an entry opens that role; Clear empties both list and storage
- [x] **Survives a real page reload**
- [x] Resilience: corrupt JSON → empty and hidden · valid JSON of the wrong shape → empty · mixed valid/junk → keeps only the valid entry · `localStorage` throwing → no exception, viewer unaffected
- [x] 375px: wraps to multiple rows, stays inside the viewport, no horizontal page scroll
- [x] Regression — prior waves intact: 11 collapsed sections, 13 TOC chips, 3 cross-references, 2 reporting chips, level filters still report `49 of 222 roles at Architect`
- [x] No console errors