### PR TITLE
feat: add the Quality Engineering domain, record the Service Desk exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/JeanKadang/DOC-ITRoles/actions/workflows/ci.yml/badge.svg)](https://github.com/JeanKadang/DOC-ITRoles/actions/workflows/ci.yml)
 
-A portable role definition repository for infrastructure and platform engineering teams. Covers 33 domains grouped into 7 chapters, and 222 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
+A portable role definition repository for infrastructure and platform engineering teams. Covers 34 domains grouped into 7 chapters, and 226 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
 
 Repository: [github.com/JeanKadang/DOC-ITRoles](https://github.com/JeanKadang/DOC-ITRoles) (private). Issues and backlog are tracked on the [Issues tab](https://github.com/JeanKadang/DOC-ITRoles/issues).
 
@@ -70,7 +70,7 @@ $env:PORT = 8080; node server.js
 
 ## Chapters
 
-The 33 domains are grouped into 7 chapters, each led by a Chapter Lead:
+The 34 domains are grouped into 7 chapters, each led by a Chapter Lead:
 
 | # | Chapter | Focus |
 |---|---------|-------|
@@ -107,7 +107,7 @@ roles_master/
 ├── .github/
 │   ├── workflows/ci.yml                    # CI: npm test, npm run validate, check-counts, markdownlint
 │   └── dependabot.yml                      # Weekly GitHub Actions + npm update checks
-├── Roles/                                  # All role definitions (33 domains, 222 roles)
+├── Roles/                                  # All role definitions (34 domains, 226 roles)
 │   ├── leadership/                         # SVP, CISO, Chapter Leads, TAL, PAL
 │   ├── c_suite/                            # CEO, CTO, CIO, CFO
 │   ├── cloud_platforms/                    # Azure, AWS, GCP + Lead/Principal
@@ -119,7 +119,7 @@ roles_master/
 │   ├── security/                           # README.md explains scope
 │   ├── security_cross_platform/            # README.md explains scope
 │   ├── security_identity/                  # README.md explains scope
-│   └── ...                                 # 33 domains total
+│   └── ...                                 # 34 domains total
 ├── docs/                                   # Governance and reference documentation
 │   ├── role_template.md                    # Template for new roles
 │   ├── improvements_and_recommendations.md # Closed - review history (see Issues for open work)

--- a/Roles/quality_engineering/quality_engineer.md
+++ b/Roles/quality_engineering/quality_engineer.md
@@ -1,0 +1,177 @@
+# Quality Engineer
+
+| Field | Value |
+|---|---|
+| **Domain** | Quality Engineering |
+| **Chapter:** | DevOps & Delivery |
+| **Role Level** | Engineer |
+| **Reports To** | Quality Engineering Senior Engineer |
+| **Direct Reports** | None |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Quality Engineer builds and maintains automated tests for platform and application delivery, working from test strategies set by senior engineers and the Quality Engineering Architect. This is a software engineering role applied to testing: the work is writing and maintaining test code, keeping suites fast and trustworthy, and making failures easy to diagnose — not manually executing test scripts. The Quality Engineer is the first line of defence against a suite becoming slow, flaky, or ignored.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Team — implementation and maintenance of test suites for assigned services to defined standards
+- **Experience Anchor:** 1-3 years in test automation or software engineering — works under guidance, building toward independent ownership of a service's test strategy
+- **Out of Scope:** Test strategy and coverage standards across the estate (Architect-owned); CI/CD pipeline architecture (DevOps-owned, this role contributes test stages to it); release go/no-go decisions (Change / Release Manager-owned); production incident diagnosis beyond reproducing a defect
+- **Escalates To:** Quality Engineering Senior Engineer — flaky tests that resist diagnosis, and coverage gaps that need a strategy decision
+- **Escalated To By:** Delivery teams on how to test a specific change, and on interpreting a failing suite
+
+## Business Impact
+
+- **Business Objective:** Keep defects from reaching production by catching them in automated checks that run on every change, so delivery speed is not paid for in escaped defects
+- **Value Metrics:** Escaped defect rate, test suite pass rate and runtime, flaky test count, proportion of changes covered by automated tests
+- **Key Stakeholders:** Delivery teams whose changes the suites gate, DevOps Engineers who run the pipelines, Service Desk and Major Incident Manager as the people who meet escaped defects
+- **Processes Supported:** Automated regression testing, pull-request quality gates, release verification, defect reproduction, test data management
+
+## Key Responsibilities
+
+- Write and maintain automated tests at unit, integration, and end-to-end level for assigned services, following the test strategy set by senior engineers
+- Diagnose and fix flaky tests, treating an unreliable test as a defect in its own right rather than a nuisance to be retried
+- Keep suite runtime within agreed budgets so that quality gates do not become something teams route around
+- Build and maintain test data and environment fixtures, including anonymised data sets where production-like data is needed
+- Contribute test stages to CI/CD pipelines in partnership with DevOps Engineers
+- Reproduce reported defects, capture them as failing tests, and confirm the fix closes them
+- Maintain test tooling and framework upgrades for assigned services
+- Document what each suite covers and, as importantly, what it does not
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Test implementation and maintenance for assigned services | Test strategy and coverage standards across the estate (Architect-owned) |
+| Flaky-test diagnosis and remediation | CI/CD pipeline architecture and stage design (DevOps-owned) |
+| Test data and fixture management for assigned suites | Release go/no-go decisions (Change / Release Manager-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Programming ability in at least one language used by the delivery teams supported (C#, Java, Python, TypeScript)
+- Working knowledge of test frameworks: xUnit/NUnit, JUnit, pytest, Jest or equivalent
+- Familiarity with end-to-end and browser automation tooling: Playwright, Cypress, or Selenium
+- Understanding of API testing: contract tests, schema validation, Postman or equivalent
+- Basic CI/CD literacy — how a test stage is invoked, and how to read a pipeline failure
+- Version control and branching workflows (Git)
+
+**Soft Skills & Leadership:**
+
+- Methodical debugging: an intermittent failure is a puzzle to solve, not a test to disable
+- Clear defect reporting that gives a developer enough to reproduce without a conversation
+- Willingness to push back when a change is untestable as designed
+
+**Technology Proficiency Levels:**
+
+**Expert level required:**
+
+- Test framework implementation in the team's primary language (xUnit/NUnit, JUnit, pytest, or Jest)
+- Git and pull-request workflows
+
+**Proficient level required:**
+
+- Playwright or Cypress for end-to-end and browser automation
+- API and contract testing (Postman, REST-assured, or equivalent)
+- Azure DevOps Pipelines or GitHub Actions for running test stages
+
+**Working Knowledge required:**
+
+- Test data management and anonymisation approaches
+- Containerised test environments (Docker, Testcontainers)
+
+**Awareness level expected:**
+
+- Performance and load testing tooling (k6, JMeter)
+- AI-assisted test generation and maintenance tooling
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Quality Engineering Senior Engineer | Receives test strategy direction; escalates flaky tests and coverage gaps | Escalates To |
+| DevOps Engineer | Contributes test stages to pipelines and interprets pipeline failures together | Collaborates |
+| Delivery Teams | Provides automated coverage that gates their changes, and support on how to test a change | Provides To |
+| Automation Framework Engineer | Consumes shared automation frameworks and reusable tooling standards | Consumes From |
+| Change / Release Manager | Supplies test evidence that informs release decisions | Provides To |
+
+## Key Technologies
+
+- Test frameworks: xUnit, NUnit, JUnit, pytest, Jest
+- End-to-end and browser automation: Playwright, Cypress, Selenium
+- API and contract testing: Postman, REST-assured, Pact
+- CI/CD test execution: Azure DevOps Pipelines, GitHub Actions
+- Containerised test environments: Docker, Testcontainers
+- Test data management and anonymisation tooling
+- Coverage and quality reporting: SonarQube, Coverlet, JaCoCo
+- Defect tracking: Jira, Azure Boards
+
+## Typical Day-to-Day Activities
+
+- Writing and reviewing automated tests for changes moving through the pipeline
+- Investigating a failing or intermittent test and fixing the underlying cause
+- Reproducing a reported defect as a failing test before the fix is written
+- Pairing with delivery engineers on how to make a change testable
+- Refreshing test data and environment fixtures
+- Reviewing suite runtime and trimming or parallelising slow tests
+- Updating documentation on what a suite covers
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Automated test pass rate on the main branch | ≥98% | Weekly |
+| Flaky tests open at end of month | ≤3 | Monthly |
+| Suite runtime for assigned services | Within agreed budget | Weekly |
+| Reported defects reproduced as a failing test before fix | ≥90% | Monthly |
+| Escaped defects traced to a gap in assigned coverage | Decreasing trend | Quarterly |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; all test development, execution and diagnosis is performed through cloud tooling
+- **Collaboration Tools:** Microsoft Teams, Azure DevOps or GitHub, Jira, test reporting dashboards
+- **On-Site Requirements:** None typically; occasional on-site for device or hardware-dependent testing
+- **Time Zone Flexibility:** Standard business hours, with overlap for delivery-team ceremonies
+- **On-Call / Operational Demands:** Not on-call; may support release verification outside hours during major releases
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Software Engineer moving toward quality and test automation
+- Manual QA Analyst who has learned to code
+- DevOps Engineer with a strong testing interest
+- Graduate or apprentice engineer entering through a quality route
+
+**Potential Next Roles:**
+
+- Quality Engineering Senior Engineer
+- Software Engineer on a delivery team
+- DevOps Engineer
+- Automation Framework Engineer
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- ISTQB Certified Tester Foundation Level
+- Microsoft Certified: Azure Developer Associate (AZ-204) or equivalent for the team's platform
+
+**Complementary Certifications:**
+
+- ISTQB Test Automation Engineer
+- Certified Kubernetes Application Developer (CKAD) where services are containerised
+
+**Learning Resources & Communities:**
+
+- Playwright and Cypress official documentation and learning paths
+- Ministry of Testing community (ministryoftesting.com)
+- Test Automation University (testautomationu.applitools.com)

--- a/Roles/quality_engineering/quality_engineering_architect.md
+++ b/Roles/quality_engineering/quality_engineering_architect.md
@@ -1,0 +1,189 @@
+# Quality Engineering Architect
+
+| Field | Value |
+|---|---|
+| **Domain** | Quality Engineering |
+| **Chapter:** | DevOps & Delivery |
+| **Role Level** | Architect |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (technical direction role, not a people manager) |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Quality Engineering Architect owns how quality is engineered across the delivery estate: the testing standards every team works to, the tooling they share, and the quality gates that apply regardless of which team is shipping. Before this role existed the discipline was distributed — testing appeared in DevOps, application platform, data and AI role definitions without anyone owning the standard — so practice varied by team and defects escaped through the gaps between them. This role sets the standard and is the escalation point when a team argues for an exception.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Cross-domain — testing standards, shared quality tooling, and estate-wide quality gates across every delivery team
+- **Experience Anchor:** 8+ years in test engineering or software engineering with demonstrated ownership of quality practice at organisation scale — operates independently within enterprise architecture standards
+- **Out of Scope:** Test strategy for a specific delivery area (Quality Engineering Senior Engineer-owned); CI/CD platform architecture (DevOps Architect-owned, this role defines what runs in it); security testing depth and threat modelling (Security and DevSecOps Architects-owned); release approval (Change / Release Manager-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead on investment and cross-team disputes; Enterprise Architect on standards that conflict with wider architecture direction
+- **Escalated To By:** Quality Engineering Senior Engineers on standards exceptions; delivery teams disputing an estate-wide gate
+
+## Business Impact
+
+- **Business Objective:** Make quality a property of the delivery system rather than of individual teams, so defect rates do not depend on which team happens to be shipping
+- **Value Metrics:** Estate-wide escaped defect rate, change failure rate, mean time to restore, consistency of quality practice across teams, tooling consolidation savings
+- **Key Stakeholders:** DevOps & Delivery Chapter Lead, Enterprise Architect, DevOps Architect, delivery team leads, Change / Release Manager, DevSecOps Architect
+- **Processes Supported:** Quality standards definition, test tooling selection and consolidation, quality gate governance, testability review of proposed architectures, quality metrics and DORA reporting
+
+## Key Responsibilities
+
+- Define the testing standards every delivery team works to: expected coverage levels, the balance of the test pyramid, and what must pass before a change reaches production
+- Select and consolidate shared test tooling, and retire the duplicated frameworks that accumulate when each team chooses its own
+- Design the estate-wide quality gates and the exception process, so that an exception is a visible decision rather than a quiet omission
+- Review proposed architectures for testability, and push back on designs that can only be verified in production
+- Set the strategy for test environments and test data across the estate, including anonymisation for production-like data
+- Define how quality is measured and reported, favouring DORA-aligned delivery signals over raw test counts
+- Partner with the DevOps Architect so quality gates fit the pipeline platform rather than fighting it, and with the DevSecOps Architect so security and quality gates do not duplicate each other
+- Govern quality practice adoption across teams, including where a team is meeting the letter of a standard but not its intent
+- Mentor Quality Engineering Senior Engineers and contribute to the engineering practices community
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Estate-wide testing standards, coverage expectations, and quality gate design | Test strategy for a specific delivery area (Senior Engineer-owned) |
+| Test tooling selection, consolidation, and retirement | CI/CD platform architecture and runner capacity (DevOps Architect-owned) |
+| The quality-gate exception process and which exceptions are granted | Security testing depth and threat coverage (Security / DevSecOps Architect-owned) |
+| Test environment and test data strategy across the estate | Release go/no-go decisions (Change / Release Manager-owned) |
+| Quality measurement and reporting model | Application and platform architecture decisions (respective Architects-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Deep knowledge of test architecture across levels: unit, contract, integration, end-to-end, performance, and where each earns its cost
+- Experience defining quality practice across multiple teams with differing languages and platforms
+- Strong understanding of CI/CD pipeline design and the relationship between feedback time and delivery performance
+- Ability to assess a proposed architecture for testability before it is built
+- Knowledge of test environment strategy, including ephemeral environments and service virtualisation
+- Familiarity with DORA metrics and the research linking quality practice to delivery outcomes
+- Understanding of data protection constraints on test data, and anonymisation approaches that satisfy them
+
+**Soft Skills & Leadership:**
+
+- Ability to set a standard that teams adopt because it helps them, not because it is mandated
+- Comfort holding a position on quality gates against delivery pressure, and knowing when an exception is legitimate
+- Translating quality practice into business language: change failure rate and restore time, not test counts
+
+**Technology Proficiency Levels:**
+
+**Expert level required:**
+
+- Test architecture and the practical design of the test pyramid at estate scale
+- Quality gate design in Azure DevOps Pipelines and GitHub Actions
+- Contract testing strategy between services (Pact or equivalent)
+
+**Proficient level required:**
+
+- End-to-end automation platforms (Playwright, Cypress) at a standards and selection level
+- Coverage and static analysis platforms (SonarQube) including quality-profile governance
+- Ephemeral test environments and service virtualisation (Testcontainers, WireMock, Kubernetes namespaces)
+- Performance testing strategy (k6, JMeter)
+
+**Working Knowledge required:**
+
+- Security testing integration points (SAST, DAST, SCA) owned by DevSecOps
+- Accessibility testing standards (WCAG) and tooling (axe, Lighthouse)
+- Test data anonymisation and synthetic data generation
+
+**Awareness level expected:**
+
+- Chaos and resilience testing as a complement to deterministic testing
+- AI-assisted test generation, and where it substitutes for coverage rather than adding it
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Quality Engineering Senior Engineer | Sets the estate-wide standards they design area test strategy within | Provides To |
+| DevOps Architect | Jointly ensures quality gates fit the pipeline platform rather than fighting it | Collaborates |
+| DevSecOps Architect | Aligns quality and security gates so they complement rather than duplicate | Collaborates |
+| Enterprise Architect | Works within enterprise architecture standards; escalates conflicts | Governed By |
+| Change / Release Manager | Supplies the quality signals that inform change risk classification | Provides To |
+| Engineering Practices Champion | Partners on adoption of quality practice across engineering teams | Collaborates |
+| DevOps & Delivery Chapter Lead | Escalates tooling investment and cross-team quality disputes | Escalates To |
+| Delivery Team Architects | Reviews proposed architectures for testability | Governed By |
+
+## Key Technologies
+
+- Test frameworks across platforms: xUnit, NUnit, JUnit, pytest, Jest
+- End-to-end automation: Playwright, Cypress, Selenium
+- Contract testing: Pact, Spring Cloud Contract
+- Service virtualisation: WireMock, Testcontainers
+- CI/CD quality gates: Azure DevOps Pipelines, GitHub Actions
+- Coverage and static analysis: SonarQube, JaCoCo, Coverlet
+- Performance testing: k6, JMeter, Gatling
+- Accessibility testing: axe, Lighthouse, WCAG conformance tooling
+- Quality and delivery reporting: Power BI, DORA metrics dashboards
+
+## Typical Day-to-Day Activities
+
+- Reviewing a proposed architecture for testability before it reaches build
+- Working with the DevOps Architect on where estate-wide gates sit in the pipeline
+- Adjudicating a quality-gate exception request from a delivery team
+- Assessing a candidate test tool against what the estate already runs
+- Reviewing quality and DORA metrics for patterns that point at a standards gap
+- Mentoring Quality Engineering Senior Engineers on test architecture
+- Contributing to the engineering practices community of practice
+- Updating testing standards as platforms and languages in the estate change
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Estate-wide change failure rate | ≤10% | Monthly |
+| Delivery teams meeting the coverage standard | ≥90% | Quarterly |
+| Distinct test frameworks in use across the estate (consolidation) | Decreasing trend | Quarterly |
+| Quality-gate exceptions granted | ≤5 open at any time | Monthly |
+| Mean time to restore after a change-induced incident | ≤4 hours | Monthly |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; standards, review and governance work is entirely tooling-based
+- **Collaboration Tools:** Microsoft Teams, Azure DevOps or GitHub, Confluence, SonarQube, Power BI
+- **On-Site Requirements:** Occasional on-site for architecture review boards, engineering practice forums, or cross-team workshops
+- **Time Zone Flexibility:** Standard business hours with flexibility for cross-regional architecture and practice forums
+- **On-Call / Operational Demands:** Not on-call; engaged in post-incident review where a systemic quality gap is implicated
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Quality Engineering Senior Engineer
+- DevOps Architect or Senior Engineer with a strong quality focus
+- Application platform Architect with test architecture depth
+- Engineering Practices Champion
+
+**Potential Next Roles:**
+
+- Enterprise Architect
+- DevOps & Delivery Chapter Lead
+- Head of Engineering Practice
+- Solution Architect
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- ISTQB Expert Level Test Management or Test Automation Engineer
+- Microsoft Certified: DevOps Engineer Expert (AZ-400) or equivalent for the estate's platform
+
+**Complementary Certifications:**
+
+- TOGAF Foundation for enterprise architecture alignment
+- Certified Kubernetes Application Developer (CKAD)
+
+**Learning Resources & Communities:**
+
+- Accelerate / DORA State of DevOps research on quality and delivery performance
+- Ministry of Testing community and conferences (ministryoftesting.com)
+- Continuous Delivery and testing practice literature (Humble, Farley, Fowler)

--- a/Roles/quality_engineering/quality_engineering_product_owner.md
+++ b/Roles/quality_engineering/quality_engineering_product_owner.md
@@ -1,0 +1,179 @@
+# Quality Engineering Product Owner
+
+| Field | Value |
+|---|---|
+| **Domain** | Quality Engineering |
+| **Chapter:** | DevOps & Delivery |
+| **Role Level** | Product Owner |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Quality Engineering Product Owner treats the organisation's testing capability as a product with its own backlog: the shared test frameworks, the quality-gate tooling, the test environment and data services that delivery teams consume. Without this role, quality tooling is improved only when someone finds spare capacity, which is why duplicated frameworks accumulate and test environments stay unreliable for years. The Product Owner prioritises that work against measured delivery pain rather than against whoever asks most persistently.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — quality tooling backlog, roadmap, and prioritisation of shared testing capability
+- **Experience Anchor:** 5+ years in product ownership or technical product management, ideally with delivery tooling or developer-experience exposure — operates independently on backlog and roadmap decisions
+- **Out of Scope:** Testing standards and tooling selection criteria (Quality Engineering Architect-owned); test strategy for a delivery area (Senior Engineer-owned); CI/CD platform roadmap (DevOps Product Owner-owned); release decisions (Change / Release Manager-owned)
+- **Escalates To:** DevOps & Delivery Chapter Lead — budget, headcount, and cross-domain roadmap trade-offs
+- **Escalated To By:** Quality Engineering Senior Engineers and Quality Engineers on ceremony direction and delivery transparency
+
+## Business Impact
+
+- **Business Objective:** Make the shared quality capability something teams choose to use because it is faster than rolling their own, so quality practice consolidates instead of fragmenting
+- **Value Metrics:** Adoption of shared test frameworks, test environment availability and provisioning time, reduction in duplicated tooling, quality tooling backlog delivery rate
+- **Key Stakeholders:** Quality Engineering Architect, DevOps Product Owner, delivery team leads as the consuming teams, DevOps & Delivery Chapter Lead, Procurement for tooling licences
+- **Processes Supported:** Quality tooling backlog management, test environment service roadmap, shared framework adoption, tooling procurement and licensing, agile ceremonies for the quality workstream
+
+## Key Responsibilities
+
+- Own and manage the quality engineering backlog: shared test frameworks, quality-gate tooling, test environment provisioning, and test data services
+- Develop the quality tooling roadmap aligned with the Architect's standards and the delivery estate's measured pain points
+- Gather requirements from delivery teams on where testing is slow, unreliable, or duplicated, and translate them into prioritised backlog items
+- Lead agile ceremonies for the quality engineering workstream: sprint or kanban planning, backlog refinement, and reviews
+- Prioritise investment in test environment reliability and provisioning time, which is consistently where delivery teams lose the most time
+- Track adoption of shared frameworks and identify where a team has rolled its own, treating that as a signal about the shared offering rather than as non-compliance
+- Coordinate tooling procurement and licensing for test platforms in partnership with the Chapter Lead and Procurement
+- Report quality tooling health and adoption to the Chapter Lead in delivery-impact terms
+- Align the roadmap with the DevOps Product Owner so quality tooling and pipeline platform work do not duplicate or block each other
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Quality tooling backlog, sprint prioritisation, and roadmap sequencing | Testing standards and tooling selection criteria (Architect-owned) |
+| Test environment service roadmap and provisioning-time targets | Test strategy for any specific delivery area (Senior Engineer-owned) |
+| Tooling procurement prioritisation and licence management | CI/CD platform roadmap (DevOps Product Owner-owned) |
+| Adoption reporting and how shared-framework uptake is measured | Release go/no-go decisions (Change / Release Manager-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Understanding of testing practice sufficient to scope tooling work: the test pyramid, quality gates, and why test environments dominate delivery friction
+- Familiarity with shared test tooling categories — frameworks, end-to-end platforms, contract testing, environment provisioning — at a capability rather than implementation level
+- Experience with agile product ownership: backlog management, user story writing with acceptance criteria, ceremony facilitation, roadmap communication
+- Ability to read delivery metrics (pipeline feedback time, environment wait time, change failure rate) and turn them into prioritisation arguments
+- Experience with product management and roadmapping tooling: Jira, Azure Boards, Confluence
+
+**Soft Skills & Leadership:**
+
+- Ability to prioritise against measured delivery pain rather than the loudest requesting team
+- Communication that bridges quality engineers and a Chapter Lead who needs delivery-risk framing
+- Willingness to treat low adoption of a shared tool as feedback on the tool, not as a compliance problem
+
+**Technology Proficiency Levels:**
+
+**Expert level required:**
+
+- Quality tooling backlog and sprint management (Jira, Azure Boards, Confluence)
+- Adoption and delivery-metric reporting for a shared capability
+
+**Proficient level required:**
+
+- Test environment provisioning approaches (ephemeral environments, containerised stacks) at a capability level
+- CI/CD quality-gate concepts (Azure DevOps Pipelines, GitHub Actions)
+- Shared test framework landscape (Playwright, Cypress, Pact, SonarQube) for roadmap decisions
+
+**Working Knowledge required:**
+
+- Test data management and anonymisation constraints under data protection rules
+- DORA delivery metrics and their relationship to quality investment
+
+**Awareness level expected:**
+
+- AI-assisted testing tooling and its licensing and cost model
+- Performance and accessibility testing platforms
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Quality Engineering Architect | Receives standards and tooling selection criteria the backlog must respect | Governed By |
+| Quality Engineering Senior Engineer | As the workstream's product owner, leading ceremonies and providing delivery direction | Provides To |
+| Quality Engineer | As the workstream's product owner, leading ceremonies and providing delivery direction | Provides To |
+| DevOps Product Owner | Aligns quality tooling and pipeline platform roadmaps to avoid duplicated or blocking work | Collaborates |
+| Delivery Teams | Gathers tooling pain points and delivers shared capability they consume | Provides To |
+| DevOps & Delivery Chapter Lead | Escalates budget, headcount, and cross-domain roadmap trade-offs | Escalates To |
+| Vendor TAM/PAM (test tooling vendors) | Product roadmap updates, support agreements, and licensing strategy | Collaborates |
+
+## Key Technologies
+
+- Backlog and ceremony tooling: Jira, Azure Boards, Confluence
+- CI/CD platforms at a capability level: Azure DevOps Pipelines, GitHub Actions
+- Shared test framework landscape: Playwright, Cypress, Pact, SonarQube
+- Test environment provisioning: Docker, Testcontainers, Kubernetes namespaces
+- Quality and delivery reporting: Power BI, DORA metrics dashboards
+- Test data management and anonymisation tooling
+
+## Typical Day-to-Day Activities
+
+- Grooming and prioritising the quality tooling backlog
+- Running sprint or kanban ceremonies with the quality engineering workstream
+- Meeting delivery teams to capture where testing is slow, flaky, or duplicated
+- Reviewing adoption metrics for shared frameworks and investigating low uptake
+- Working with the Architect to keep the backlog inside the standards it must respect
+- Aligning roadmap items with the DevOps Product Owner
+- Managing tooling licence renewals with Procurement
+- Preparing quality tooling roadmap updates for the Chapter Lead
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Backlog delivery rate | ≥85% of committed items | Per sprint |
+| Delivery teams using the shared test frameworks | ≥80% | Quarterly |
+| Test environment provisioning time | ≤30 minutes | Monthly |
+| Test environment availability during working hours | ≥98% | Monthly |
+| Duplicated test frameworks retired | ≥2 per year | Annual |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; backlog management and stakeholder engagement are entirely tooling-based
+- **Collaboration Tools:** Microsoft Teams, Jira or Azure Boards, Confluence, Power BI
+- **On-Site Requirements:** Occasional on-site for Chapter Lead planning sessions or vendor briefings
+- **Time Zone Flexibility:** Standard business hours with overlap for delivery-team ceremonies
+- **On-Call / Operational Demands:** Not on-call; stakeholder communication point during major test environment outages affecting delivery
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Quality Engineering Senior Engineer moving into product ownership
+- Product Owner in a DevOps, platform engineering, or developer-experience domain
+- Business Analyst with delivery tooling focus
+- Delivery or test manager transitioning to product ownership
+
+**Potential Next Roles:**
+
+- DevOps Product Owner
+- Platform Engineering Product Owner
+- DevOps & Delivery Chapter Lead
+- Head of Engineering Productivity
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Professional Scrum Product Owner (PSPO I) — Scrum.org
+- ISTQB Certified Tester Foundation Level for domain literacy
+
+**Complementary Certifications:**
+
+- SAFe Product Owner / Product Manager (POPM) for large programme contexts
+- Microsoft Certified: DevOps Engineer Expert (AZ-400) for platform context
+
+**Learning Resources & Communities:**
+
+- Scrum.org PSPO learning paths and Product Owner community
+- Accelerate / DORA research on delivery performance
+- Ministry of Testing community (ministryoftesting.com)

--- a/Roles/quality_engineering/quality_engineering_senior_engineer.md
+++ b/Roles/quality_engineering/quality_engineering_senior_engineer.md
@@ -1,0 +1,186 @@
+# Quality Engineering Senior Engineer
+
+| Field | Value |
+|---|---|
+| **Domain** | Quality Engineering |
+| **Chapter:** | DevOps & Delivery |
+| **Role Level** | Senior Engineer |
+| **Reports To** | DevOps & Delivery Chapter Lead |
+| **Direct Reports** | Quality Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Last Reviewed** | 2026-08 |
+
+---
+
+## Role Overview
+
+The Quality Engineering Senior Engineer owns the test strategy for a set of services or a delivery area: what is tested at which level, what the coverage expectations are, and where the quality gates sit in the pipeline. This role decides the shape of the test pyramid in practice — how much is caught by fast unit tests versus slower integration and end-to-end suites — and holds the line when delivery pressure argues for skipping gates. It is also the escalation point when a suite becomes unreliable enough that teams stop trusting it.
+
+## Role Scope & Boundaries
+
+- **Scope of Influence:** Domain — test strategy, coverage standards, and quality gate placement for an assigned delivery area
+- **Experience Anchor:** 5+ years in test automation or software engineering with demonstrated ownership of a test strategy — operates independently within the Architect's estate-wide standards
+- **Out of Scope:** Estate-wide quality standards and tooling selection (Quality Engineering Architect-owned); pipeline platform architecture (DevOps Architect-owned); release approval (Change / Release Manager-owned); security testing depth (DevSecOps Engineer-owned, this role integrates their gates)
+- **Escalates To:** Quality Engineering Architect on standards exceptions; DevOps & Delivery Chapter Lead on staffing and cross-team quality disputes
+- **Escalated To By:** Quality Engineers on flaky tests and coverage gaps; delivery teams disputing a quality gate that is blocking them
+
+## Business Impact
+
+- **Business Objective:** Ensure delivery speed and defect rates move in the same direction rather than trading against each other, by placing the right checks at the right point in the pipeline
+- **Value Metrics:** Escaped defect rate, mean time to detect a regression, pipeline feedback time, proportion of releases requiring a hotfix, test suite trust (measured by override and retry rates)
+- **Key Stakeholders:** DevOps & Delivery Chapter Lead, Quality Engineering Architect, delivery team leads, Change / Release Manager, DevSecOps Engineer
+- **Processes Supported:** Test strategy definition, quality gate design, defect triage, release verification, test environment strategy, quality metrics reporting
+
+## Key Responsibilities
+
+- Own the test strategy for an assigned delivery area: what is covered at unit, integration, contract, and end-to-end level, and why the balance sits where it does
+- Define coverage expectations and quality gate placement in delivery pipelines, in partnership with DevOps Engineers who own the pipeline platform
+- Review and approve test designs from Quality Engineers, and mentor them toward independent ownership
+- Hold the line on quality gates under delivery pressure, and escalate rather than silently weaken them when a release argues for an exception
+- Diagnose systemic suite problems — sustained flakiness, runaway runtime, coverage that has drifted from what the service now does
+- Lead defect triage for the assigned area, distinguishing a test gap from a design gap
+- Define the test environment and test data strategy, including how production-like data is obtained and anonymised
+- Report quality metrics to the Chapter Lead in terms of delivery risk rather than raw test counts
+- Integrate security and accessibility checks into the pipeline in partnership with DevSecOps and accessibility specialists
+
+## Key Decisions & Accountabilities
+
+> Clarifies what this role **owns** (decides independently) vs. **advises on** (input without final authority).
+
+| Owns | Advises On |
+|---|---|
+| Test strategy, coverage expectations, and quality gate placement for the assigned area | Estate-wide quality standards and tooling selection (Quality Engineering Architect-owned) |
+| Test environment and test data strategy for the assigned area | CI/CD platform architecture and runner capacity (DevOps Architect-owned) |
+| Defect triage outcomes and whether a gap is a test or a design problem | Release go/no-go decisions (Change / Release Manager-owned) |
+| Quality-gate exceptions, and whether one is granted or escalated | Security testing depth and threat coverage (DevSecOps Engineer-owned) |
+
+## Required Skills & Qualifications
+
+**Technical Skills:**
+
+- Strong programming ability in at least one language used across the supported delivery teams
+- Deep knowledge of test design: the test pyramid, contract testing, and when an end-to-end test earns its cost
+- Experience designing quality gates in CI/CD pipelines and reasoning about feedback time
+- Understanding of test environment provisioning and ephemeral environment patterns
+- Ability to diagnose systemic flakiness — concurrency, timing, shared state, environmental coupling
+- Familiarity with performance and load testing sufficient to place them appropriately in the pipeline
+
+**Soft Skills & Leadership:**
+
+- Willingness to be unpopular in the short term when a gate should hold
+- Mentoring engineers toward owning quality rather than delegating it to a test team
+- Translating quality metrics into delivery-risk language that a Chapter Lead can act on
+
+**Technology Proficiency Levels:**
+
+**Expert level required:**
+
+- Test design and the practical placement of the test pyramid
+- Test frameworks in the team's primary languages (xUnit/NUnit, JUnit, pytest, Jest)
+- Azure DevOps Pipelines or GitHub Actions quality-gate design
+
+**Proficient level required:**
+
+- Playwright or Cypress for end-to-end coverage
+- Contract testing (Pact or equivalent) between services
+- Containerised and ephemeral test environments (Docker, Testcontainers, Kubernetes namespaces)
+- Coverage and quality reporting (SonarQube, JaCoCo, Coverlet)
+
+**Working Knowledge required:**
+
+- Performance and load testing (k6, JMeter)
+- Security testing integration points (SAST, DAST) owned by DevSecOps
+- Accessibility testing tooling (axe, Lighthouse)
+
+**Awareness level expected:**
+
+- Chaos and resilience testing practices
+- AI-assisted test generation, and its failure modes as a coverage substitute
+
+## Interactions with Other Roles
+
+> **Interaction Mode** describes the direction/nature of the relationship: **Collaborates** (peer-to-peer), **Consumes From** (relies on the other role's output/service), **Provides To** (delivers a service the other role consumes), **Governed By** (subject to the other role's standards/approval), or **Escalates To** (routes unresolved issues upward).
+
+| Role | Nature of Interaction | Interaction Mode |
+|---|---|---|
+| Quality Engineering Architect | Works within estate-wide quality standards; escalates exceptions | Governed By |
+| Quality Engineer | Sets test strategy, reviews test designs, and mentors toward independent ownership | Provides To |
+| DevOps Senior Engineer | Jointly designs where quality gates sit in the delivery pipeline | Collaborates |
+| DevSecOps Engineer | Integrates security gates into the same pipeline without duplicating them | Collaborates |
+| Change / Release Manager | Supplies the test evidence that informs release risk classification | Provides To |
+| DevOps & Delivery Chapter Lead | Reports quality metrics and escalates cross-team quality disputes | Escalates To |
+| Delivery Teams | Receives defect and coverage feedback; negotiates testability of proposed changes | Collaborates |
+
+## Key Technologies
+
+- Test frameworks: xUnit, NUnit, JUnit, pytest, Jest
+- End-to-end automation: Playwright, Cypress, Selenium
+- Contract testing: Pact, Spring Cloud Contract
+- CI/CD quality gates: Azure DevOps Pipelines, GitHub Actions
+- Ephemeral test environments: Docker, Testcontainers, Kubernetes
+- Coverage and static analysis: SonarQube, JaCoCo, Coverlet
+- Performance testing: k6, JMeter
+- Accessibility testing: axe, Lighthouse
+- Defect and quality reporting: Jira, Azure Boards, Power BI
+
+## Typical Day-to-Day Activities
+
+- Reviewing test designs and pull requests from Quality Engineers
+- Investigating a systemic suite problem — sustained flakiness or a runtime that has crept past its budget
+- Negotiating with a delivery team about a gate that is blocking them, and deciding whether to hold or escalate
+- Leading defect triage for the assigned area
+- Working with DevOps Engineers on pipeline stage placement and feedback time
+- Refreshing the test environment and data strategy as services change
+- Preparing quality metrics for the Chapter Lead in delivery-risk terms
+- Mentoring Quality Engineers on test design and flake diagnosis
+
+## Key Performance Indicators
+
+| Metric | Target | Frequency |
+|---|---|---|
+| Escaped defect rate for the assigned area | Decreasing trend | Quarterly |
+| Pipeline feedback time (commit to quality-gate result) | ≤15 minutes | Weekly |
+| Releases requiring a hotfix within 48 hours | ≤5% | Monthly |
+| Quality-gate override/retry rate (a proxy for suite trust) | ≤2% | Monthly |
+| Flaky tests open at end of month across the area | ≤5 | Monthly |
+
+## Remote Work Considerations
+
+- **Remote Eligibility:** Fully remote eligible; strategy, review and diagnosis work is entirely tooling-based
+- **Collaboration Tools:** Microsoft Teams, Azure DevOps or GitHub, Jira, SonarQube, Power BI for quality reporting
+- **On-Site Requirements:** Occasional on-site for delivery-team workshops or hardware-dependent testing
+- **Time Zone Flexibility:** Standard business hours with overlap for delivery-team ceremonies across regions
+- **On-Call / Operational Demands:** Not on-call; available during major releases and for post-incident analysis where a test gap is implicated
+
+## Career Development Path
+
+**Previous Roles:**
+
+- Quality Engineer
+- Software Engineer with a strong testing and tooling focus
+- DevOps Engineer moving toward delivery quality
+- Automation Framework Engineer
+
+**Potential Next Roles:**
+
+- Quality Engineering Architect
+- DevOps Architect
+- Engineering Practices Champion
+- Delivery team technical lead
+
+## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- ISTQB Advanced Level Test Analyst or Test Automation Engineer
+- Microsoft Certified: DevOps Engineer Expert (AZ-400) or equivalent for the team's platform
+
+**Complementary Certifications:**
+
+- Certified Kubernetes Application Developer (CKAD)
+- Professional Scrum Developer (PSD)
+
+**Learning Resources & Communities:**
+
+- Ministry of Testing community and conferences (ministryoftesting.com)
+- Test Automation University (testautomationu.applitools.com)
+- Accelerate / DORA research on delivery performance and quality practices

--- a/Roles/service_desk/service_desk_lead.md
+++ b/Roles/service_desk/service_desk_lead.md
@@ -6,7 +6,7 @@
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Senior Engineer |
 | **Reports To** | End User & Workplace Chapter Lead |
-| **Direct Reports** | Service Desk Senior Analysts, Service Desk Analysts |
+| **Direct Reports** | Service Desk Senior Analysts, Service Desk Analysts (full line management, including hiring and career progression — a deliberate exception to the catalogue's usual model, see Role Scope & Boundaries) |
 | **Last Reviewed** | 2026-07 |
 
 ---
@@ -22,6 +22,7 @@ The Service Desk Lead owns the service desk as an operational function: staffing
 - **Out of Scope:** Does not own OS, endpoint, identity, or security engineering standards (owned by the respective domain architects); does not own the ITSM platform's technical architecture (owned by Service Management / ITSM Configuration, though this role owns how the desk uses it day-to-day); does not declare major incidents (owned by the Major Incident Manager, though this role owns the desk's detection-and-escalation path into that process).
 - **Escalates To:** End User & Workplace Chapter Lead (for staffing budget, cross-domain escalation disputes, or SLA target changes requiring chapter-level sign-off).
 - **Escalated To By:** Service Desk Senior Analysts (for recurring issues needing a process or standard-change fix, not just a ticket fix, and for staffing/coverage gaps).
+- **People-management exception:** across the rest of the catalogue, Senior Engineers provide day-to-day technical guidance while formal line management sits with the Chapter Lead. The Service Desk Lead is the deliberate exception and holds line management directly — hiring, onboarding and career progression for Analysts and Senior Analysts. The desk runs a shift rota with its own progression ladder and a headcount model driven by ticket volume rather than project demand, none of which a Chapter Lead one level removed can staff in real time. Confirmed as intentional rather than drift when the catalogue's management model was reviewed (#148).
 
 ## Business Impact
 

--- a/docs/CROSS_DOMAIN_INTERACTIONS.md
+++ b/docs/CROSS_DOMAIN_INTERACTIONS.md
@@ -30,6 +30,7 @@ The table below records which domain holds primary decision-making authority ove
 | Automation framework and reusable tooling standards (cross-domain) | DevOps (Automation Framework Engineer) | Infrastructure Automation Architect, Network Automation Architect, Security Automation Engineer |
 | Site reliability engineering practice and SLO/error-budget methodology | Modern Infrastructure (Site Reliability Engineer / Senior SRE) | DevOps, Database Management, Data Protection |
 | Service desk support model, staffing, and Tier-1/2/3 escalation boundaries | Service Desk (Service Desk Lead) | Client Platform, Endpoint Management, Modern Workplace, Service Management |
+| Testing standards, coverage expectations, and estate-wide quality gates | Quality Engineering | DevOps, App Platforms, Security, Data Engineering |
 | Hypervisor platform selection and virtual infrastructure standards | Virtualization | Server Hardware, Network, Data Management, Security |
 | Physical server platform, capacity, and refresh strategy | Server Hardware | Virtualization, Specialized Computing, Data Management, Network |
 | HPE-specific server tooling and firmware baselines (OneView, iLO) | HPE Server Hardware | Server Hardware, Network, Specialized Computing |
@@ -60,6 +61,9 @@ The pairs below represent the most frequent and consequential collaboration rela
 - **Service Management ↔ Data Protection** — major-incident coordination vs recovery execution: the Major Incident Manager runs the incident bridge and communications; the BC/DR Manager owns recovery plans, BIA coverage, and DR test governance; the affected service's engineers execute the technical recovery
 - **Data Management ↔ Security** — classification vs enforcement: the Data Governance Lead defines the classification scheme and data catalogue; Security implements the enforcing controls (DLP, access policy); the Data Privacy Officer sets the privacy requirements both must satisfy for personal data
 - **Service Management ↔ FinOps** — license and contract inputs to cloud cost governance: the Vendor / Supplier / IT Asset Manager provides the contract register, license entitlements, and renewal pipeline that FinOps consumes for commitment and cost optimisation decisions
+- **Quality Engineering ↔ DevOps** — quality gates live inside the delivery pipeline, so the two must be designed together: Quality Engineering decides what must pass and DevOps owns the platform it runs on. Splitting them is what produces gates teams route around
+- **Quality Engineering ↔ Security** — quality and security gates share a pipeline and a time budget; the split is that DevSecOps owns threat coverage and testing depth while Quality Engineering owns where the gate sits and what blocks a merge
+- **Quality Engineering ↔ App Platforms** — testability of application architecture: contract testing between services, and pushing back on designs that can only be verified in production
 - **Virtualization ↔ Server Hardware** — node specifications for hypervisor clusters (Nutanix, vSphere, Hyper-V hosts), firmware/HCL compatibility, and capacity planning for the physical estate the virtual platform runs on
 - **Virtualization ↔ Network** — virtual switching and overlay networking (NSX, distributed switches), east-west traffic design, and connectivity requirements for cluster and vMotion/live-migration traffic
 - **Virtualization ↔ Data Management** — virtual storage design: datastore and container layout, storage policy-based management, and the interaction between hypervisor-level and array-level protection

--- a/docs/SKILLS_PROGRESSION.md
+++ b/docs/SKILLS_PROGRESSION.md
@@ -229,6 +229,13 @@ Every domain in the catalog is listed below (alphabetically), with every role fi
 - Architect: `network_architect`, `network_automation_architect`
 - Product Owner: `network_product_owner`
 
+### Quality Engineering
+
+- Engineer: `quality_engineer`
+- Senior Engineer: `quality_engineering_senior_engineer`
+- Architect: `quality_engineering_architect`
+- Product Owner: `quality_engineering_product_owner`
+
 ### Security
 
 - Engineer: `devsecops_engineer`, `security_engineer`

--- a/index.html
+++ b/index.html
@@ -1661,7 +1661,7 @@
             label: 'DevOps & Delivery',
             icon:  '🔄',
             desc:  'Owns the software delivery toolchain, internal developer platforms, CI/CD standards, application platform engineering, and integration & middleware architecture. Accountable for DORA metrics and delivery flow across the organisation.',
-            domains: ['devops', 'app_platforms', 'integration_middleware'],
+            domains: ['devops', 'app_platforms', 'integration_middleware', 'quality_engineering'],
             leadFile: 'Roles/leadership/devops_delivery_chapter_lead.md',
         },
         data_ai: {
@@ -1720,6 +1720,7 @@
         FinOps:                                  '💰',
         infrastructure_onboarding_cross_platform:'🔌',
         integration_middleware:                  '🔗',
+        quality_engineering:                     '🧪',
         itsm_configuration:                      '📋',
         kubernetes:                              '☸️',
         modern_infrastructure:                   '🚀',

--- a/roleMeta.js
+++ b/roleMeta.js
@@ -32,6 +32,7 @@ const DOMAIN_LABELS = {
   FinOps:                                 'FinOps',
   infrastructure_onboarding_cross_platform: 'Infrastructure Onboarding',
   integration_middleware:                 'Integration & Middleware',
+  quality_engineering:                    'Quality Engineering',
   itsm_configuration:                     'ITSM & Configuration',
   kubernetes:                             'Kubernetes',
   modern_infrastructure:                  'Modern Infrastructure',

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -537,9 +537,9 @@ test('career sankey handles the real SKILLS_PROGRESSION.md', () => {
     const path = require('node:path');
     const md = fs.readFileSync(path.join(__dirname, '..', 'docs', 'SKILLS_PROGRESSION.md'), 'utf8');
     const ladders = parseProgressionLadders(md);
-    assert.equal(ladders.length, 33, 'all 33 domain ladders parse');
+    assert.equal(ladders.length, 34, 'all 34 domain ladders parse');
     const totalRoles = ladders.reduce((n, l) => n + Object.values(l.levels).flat().length, 0);
-    assert.equal(totalRoles, 222, 'parser sees every role the drift guard guarantees');
+    assert.equal(totalRoles, 226, 'parser sees every role the drift guard guarantees');
     const s = buildCareerSankey(ladders);
     assert.ok(s.nodes.length >= 8, 'all level rungs present');
     const engSr = s.links.find(l => l.source === 'Engineer' && l.target === 'Senior Engineer');
@@ -589,8 +589,8 @@ test('parseCareerPath parses every role file in the catalog', () => {
             if (cp.from.length && cp.to.length) withBoth++;
         }
     }
-    assert.equal(total, 222);
-    assert.equal(withBoth, 222, 'every role file yields both From and To lists');
+    assert.equal(total, 226);
+    assert.equal(withBoth, 226, 'every role file yields both From and To lists');
 });
 
 // ── sectionStartsOpen (#112) ──────────────────────────────


### PR DESCRIPTION
## Summary

Resolves the two open questions in #148 with the maintainer's decisions: **add QA/Test Engineering, decline the other three, and treat Service Desk Lead as a deliberate people-management exception.**

Catalogue: **222 → 226 roles, 33 → 34 domains.**

Closes #148

## Why QA was the one to add

It was the only genuine gap. No role owned testing, yet the content was everywhere:

| Role | Testing mentions |
|---|---|
| `dataops_specialist` | 20 |
| `automation_framework_engineer` | 19 |
| `api_strategy_architect` | 12 |
| `client_platform_senior_engineer` | 10 |

Distributed and unowned — the same shape as the Service Desk gap closed earlier. Added as a four-tier domain (Engineer / Senior Engineer / Architect / Product Owner) in **DevOps & Delivery**, where the testing content clusters.

## The other three were declined on evidence

- **Data Scientist / ML Engineer** — `mlops_engineer` already states it exists to *"enable data science and AI teams"*, placing them outside the catalogue. Adding the role would contradict content already written.
- **Technical Writer** — not named as an interaction partner by a **single one** of the 222 roles. The catalogue never reaches for one.
- **Sustainability / Green IT Lead** — `finops_architect` carries 16 sustainability mentions and owns carbon tracking. A separate lead would compete with an existing owner.

## The people-management question had a surprise

I expected Chapter Lead to be the sole people-manager. **It already wasn't.** 132 roles say line management "sits with the Chapter Lead", but `service_desk_lead` owns hiring, onboarding and career progression directly, without that qualifier.

Confirmed as deliberate rather than drift, and the reason is now written into the role so it is not re-flagged later: the desk runs a shift rota with its own progression ladder and a headcount model driven by ticket volume rather than project demand — none of which a Chapter Lead one level removed can staff in real time.

**No Engineering Manager role added.**

## The drift guards did their job

Adding a domain touches six registration points. I ran the suite before fixing any of them and it named all six, including the `CROSS_DOMAIN_INTERACTIONS` coverage guard added for #125 — catching the first new domain since it was written:

```
✖ every catalog role appears exactly once in the progression ladders
✖ every domain has a ladder heading
✖ every canonical domain appears in CROSS_DOMAIN_INTERACTIONS.md
✖ parseCareerPath parses every role file in the catalog
```

That is the guard paying for itself rather than being decoration.

## Test plan

- [x] `npm test` — **161/161** · `npm run validate` — 0 errors, 0 duplicate titles · `npm run check-counts` — README matches
- [x] Browser: 226 roles / 34 domains in the data and on the total tile; all four QE roles present at the right levels
- [x] `Quality Engineering Architect` renders with 11 collapsed sections, 13 TOC chips, **7 working cross-references**, 2 reporting chips
- [x] All four views include the new domain — Matrix 34 rows / 226 chips, Graph 39 nodes with Quality Engineering present, Careers chart and ladder table both reflect it