### PR TITLE
release: 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-06
+
+Resolves the long-open question of which flagged role types belong in an
+infrastructure and platform catalogue.
+
+### Added
+
+- **Quality Engineering domain (#148).** Four roles — Engineer, Senior
+  Engineer, Architect, Product Owner — under DevOps & Delivery. It was the
+  one genuine gap of five candidates considered: no role owned testing,
+  yet the content was spread across the catalogue
+  (`dataops_specialist` 20 mentions, `automation_framework_engineer` 19,
+  `api_strategy_architect` 12). A discipline that is everywhere and owned
+  by nobody is the same shape as the Service Desk gap closed in 1.6.0.
+
+  Catalogue: **222 → 226 roles, 33 → 34 domains.**
+
+### Changed
+
+- **The Service Desk Lead's people-management exception is now documented
+  (#148).** The catalogue turned out to have two management models rather
+  than one: 132 roles state that formal line management "sits with the
+  Chapter Lead", but `service_desk_lead` owns hiring, onboarding and career
+  progression directly. Confirmed as deliberate rather than drift, with the
+  reason recorded in the role — the desk runs a shift rota with its own
+  progression ladder and volume-driven headcount, which a Chapter Lead one
+  level removed cannot staff in real time. No Engineering Manager role was
+  added.
+
+### Not added, and why
+
+Three candidates were declined on evidence rather than preference, each
+recorded on the issue so the question does not recur:
+
+- **Data Scientist / ML Engineer** — `mlops_engineer` already states it
+  exists to "enable data science and AI teams", placing them outside the
+  catalogue. Adding the role would contradict content already written.
+- **Technical Writer** — not named as an interaction partner by a single
+  one of the 222 roles.
+- **Sustainability / Green IT Lead** — `finops_architect` carries 16
+  sustainability mentions and owns carbon tracking; a separate lead would
+  compete with an existing owner.
+
+### Note on the drift guards
+
+Adding a domain touches six registration points. The suite was run before
+any of them were updated and named all six — including the
+`CROSS_DOMAIN_INTERACTIONS.md` coverage guard added in 1.10.0, catching the
+first new domain since it was written.
+
 ## [1.10.0] - 2026-08-05
 
 Content coverage: the relationship graph now shows the whole catalogue,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

Bumps `package.json` to 1.11.0 and adds the `[1.11.0]` CHANGELOG section.

Resolves the long-open question of which flagged role types belong in an infrastructure and platform catalogue. **Closes #148.**

**Catalogue: 222 → 226 roles, 33 → 34 domains.**

### What landed

**Quality Engineering domain** — four roles under DevOps & Delivery. The one genuine gap of five candidates: no role owned testing, yet the content was spread across the catalogue (`dataops_specialist` 20 mentions, `automation_framework_engineer` 19). A discipline that is everywhere and owned by nobody.

**The Service Desk Lead exception, documented.** The catalogue turned out to have two people-management models rather than one — 132 roles defer line management to the Chapter Lead, but `service_desk_lead` owns hiring and career progression directly. Recorded as deliberate, with the reason written in so it is not re-flagged as drift.

**Three candidates declined on evidence**, each recorded on the issue: Data Scientist (would contradict `mlops_engineer`'s existing statement), Technical Writer (named by zero of 222 roles), Sustainability Lead (`finops_architect` already owns it).

### Note worth keeping

Adding a domain touches six registration points. The suite was run *before* updating any of them and named all six — including the `CROSS_DOMAIN_INTERACTIONS.md` coverage guard added in 1.10.0, catching the first new domain since it was written.

## Test plan

- [x] `npm test` — 161/161
- [x] `npm run validate` — 0 errors, 0 duplicate titles (200 warnings are the #121 KPI drift report, non-blocking by design and tracked in #140)
- [x] `npm run check-counts` — README matches filesystem
- [x] Verified in-browser: 226 roles / 34 domains, all four views include the new domain, QE roles render with working cross-references