### PR TITLE
refactor: extract and cover the accessible list fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1535,6 +1535,7 @@
     // ── Shared pure view logic (viewer-logic.js, also under node:test) ──
     const {
         STALE_MONTHS, REFERENCE_DOC_PATTERN, LEVEL_ORDER, LEVEL_SHORT, pushRecent,
+        orgListHtml, graphListHtml,
         escapeHtml, badgeClass, monthsSinceReview, computeStaleRoles, resolveDocHref,
         rolesPerChapter, rolesPerLevel, buildOrgTree, parseInteractions, labelToChapter,
         parseProgressionLadders, buildCareerSankey, parseMobilityPaths, parseCareerPath,
@@ -1988,15 +1989,6 @@
         document.getElementById('orgListFallback').innerHTML = orgListHtml(tree);
     }
 
-    function orgListHtml(node) {
-        const label = node.file
-            ? `<span data-file="${escapeHtml(node.file)}" role="button" tabindex="0">${escapeHtml(node.name)}</span>`
-            : `<span class="org-node-label">${escapeHtml(node.name)}</span>`;
-        const meta = node.leadTitle && !node.file ? '' :
-            node.leadTitle ? ` — lead: ${escapeHtml(node.leadTitle)}` : '';
-        const kids = (node.children || []).map(c => orgListHtml(c)).join('');
-        return `<ul><li>${label}${meta}${kids ? kids : ''}</li></ul>`;
-    }
 
     // ── Overlay panels (#119) ────────────────────────────
     // Matrix, Stale, Org, Graph and Careers are mutually exclusive overlays.
@@ -2187,20 +2179,6 @@
         document.getElementById('graphListFallback').innerHTML = graphListHtml(graph, chapterOf);
     }
 
-    function graphListHtml(graph, chapterOf) {
-        const byNode = graph.nodes.map(n => {
-            const rels = graph.links
-                .filter(l => l.source === n.name || l.target === n.name)
-                .map(l => {
-                    const other = l.source === n.name ? l.target : l.source;
-                    return `<li>${l.kind === 'collaborates' ? 'Collaborates with' : 'Consulted relationship with'} <b>${escapeHtml(other)}</b>: ${escapeHtml(l.labels.join('; '))}</li>`;
-                }).join('');
-            const notes = n.notes.map(x => `<li>${escapeHtml(x)}</li>`).join('');
-            const chapter = n.kind === 'external' ? 'External party' : (chapterOf[n.name] || 'Other');
-            return `<li><span class="org-node-label">${escapeHtml(n.name)}</span> — ${escapeHtml(chapter)}<ul>${rels}${notes}</ul></li>`;
-        }).join('');
-        return `<ul>${byNode}</ul>`;
-    }
 
 
     // ── Career path flow (ECharts sankey) ─────────────────

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -5,6 +5,8 @@ const assert = require('node:assert/strict');
 
 const {
     STALE_MONTHS,
+    orgListHtml,
+    graphListHtml,
     pushRecent,
     groupResources,
     EXEC_LEVELS,
@@ -1108,4 +1110,84 @@ test('pushRecent sanitises the list even when there is no entry to add', () => {
         [{ file: 'a.md', title: 'A', level: 'Engineer', domainLabel: 'D' }]
     );
     assert.deepEqual(pushRecent('garbage', null, 5), []);
+});
+
+// ── accessible list fallbacks (#118) ──────────────────────
+// These build the "View as list" content behind the Org and Graph charts —
+// what a screen-reader user gets instead of an ECharts canvas. They were
+// untested, and a regression in them is invisible to sighted testing.
+
+test('orgListHtml nests children as nested lists', () => {
+    const html = orgListHtml({ name: 'Root', children: [{ name: 'Child' }] });
+    assert.match(html, /<ul><li>.*Root.*<ul><li>.*Child.*<\/li><\/ul><\/li><\/ul>/s);
+});
+
+test('orgListHtml makes a node with a file keyboard-operable, and one without inert', () => {
+    const withFile = orgListHtml({ name: 'A Role', file: 'Roles/x/a.md' });
+    assert.match(withFile, /data-file="Roles\/x\/a\.md"/);
+    assert.match(withFile, /role="button"/);
+    assert.match(withFile, /tabindex="0"/);
+
+    const without = orgListHtml({ name: 'A Domain' });
+    assert.doesNotMatch(without, /role="button"/, 'a non-navigable node must not claim to be a button');
+});
+
+test('orgListHtml names the chapter lead on a chapter node', () => {
+    // buildOrgTree sets `file` and `leadTitle` together from the chapter's
+    // lead, so a chapter with a lead is both labelled and clickable.
+    const html = orgListHtml({ name: 'Chapter', file: 'Roles/leadership/lead.md', leadTitle: 'Chapter Lead' });
+    assert.match(html, /lead: Chapter Lead/);
+    assert.match(html, /data-file="Roles\/leadership\/lead\.md"/);
+});
+
+test('orgListHtml adds no lead line to a node without one', () => {
+    assert.doesNotMatch(orgListHtml({ name: 'Domain' }), /lead:/);
+    assert.doesNotMatch(orgListHtml({ name: 'Role', file: 'r.md' }), /lead:/);
+});
+
+test('orgListHtml escapes names and file paths', () => {
+    const html = orgListHtml({ name: '<img src=x onerror=alert(1)>', file: '"><script>' });
+    assert.doesNotMatch(html, /<img/);
+    assert.doesNotMatch(html, /<script>/);
+    assert.match(html, /&lt;img/);
+});
+
+test('graphListHtml lists each node with its relationships and chapter', () => {
+    const graph = {
+        nodes: [{ name: 'Alpha', kind: 'domain', notes: [] },
+                { name: 'Beta',  kind: 'domain', notes: [] }],
+        links: [{ source: 'Alpha', target: 'Beta', kind: 'collaborates', labels: ['shared work'] }],
+    };
+    const html = graphListHtml(graph, { Alpha: 'Chapter One', Beta: 'Chapter Two' });
+    assert.match(html, /Alpha/);
+    assert.match(html, /Chapter One/);
+    assert.match(html, /Collaborates with/);
+    assert.match(html, /shared work/);
+});
+
+test('graphListHtml describes a relationship from both sides', () => {
+    // The reader may arrive at either node, so the edge must appear under
+    // both — a directed rendering would hide half the graph.
+    const graph = {
+        nodes: [{ name: 'Alpha', kind: 'domain', notes: [] },
+                { name: 'Beta',  kind: 'domain', notes: [] }],
+        links: [{ source: 'Alpha', target: 'Beta', kind: 'consulted', labels: ['x'] }],
+    };
+    const html = graphListHtml(graph, {});
+    assert.equal((html.match(/Consulted relationship with/g) || []).length, 2);
+});
+
+test('graphListHtml labels an external party rather than guessing its chapter', () => {
+    const graph = { nodes: [{ name: 'Vendor', kind: 'external', notes: [] }], links: [] };
+    assert.match(graphListHtml(graph, {}), /External party/);
+});
+
+test('graphListHtml falls back to "Other" for a node with no chapter', () => {
+    const graph = { nodes: [{ name: 'Orphan', kind: 'domain', notes: [] }], links: [] };
+    assert.match(graphListHtml(graph, {}), /Other/);
+});
+
+test('graphListHtml renders node notes', () => {
+    const graph = { nodes: [{ name: 'Alpha', kind: 'domain', notes: ['consulted by all domains'] }], links: [] };
+    assert.match(graphListHtml(graph, {}), /consulted by all domains/);
 });

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -741,8 +741,51 @@
         return (kept ? [kept, ...prior] : prior).slice(0, max);
     }
 
+    // The accessible text fallbacks behind the Org and Graph charts (#118) —
+    // the "View as list" content a screen-reader user gets instead of an
+    // ECharts canvas. Pure string builders, extracted here so they are
+    // covered: a regression in them is invisible to sighted testing.
+
+    // Recursive nested list for the org tree. A node carrying a file is a
+    // role and becomes keyboard-operable; a node without one is a structural
+    // heading and must not claim to be a button.
+    function orgListHtml(node) {
+        const label = node.file
+            ? `<span data-file="${escapeHtml(node.file)}" role="button" tabindex="0">${escapeHtml(node.name)}</span>`
+            : `<span class="org-node-label">${escapeHtml(node.name)}</span>`;
+        // Only chapter nodes carry leadTitle, and buildOrgTree sets it from
+        // the same lead object as `file` — so in practice the two are always
+        // present together and the first branch never fires. Kept as written
+        // rather than simplified: this is an extraction, and collapsing a
+        // condition is a behaviour change dressed as tidying.
+        const meta = node.leadTitle && !node.file ? '' :
+            node.leadTitle ? ` — lead: ${escapeHtml(node.leadTitle)}` : '';
+        const kids = (node.children || []).map(c => orgListHtml(c)).join('');
+        return `<ul><li>${label}${meta}${kids ? kids : ''}</li></ul>`;
+    }
+
+    // Flat list of graph nodes, each with its relationships. Edges are
+    // undirected here on purpose: the reader may arrive at either end, so
+    // each edge is described under both nodes.
+    function graphListHtml(graph, chapterOf) {
+        const byNode = graph.nodes.map(n => {
+            const rels = graph.links
+                .filter(l => l.source === n.name || l.target === n.name)
+                .map(l => {
+                    const other = l.source === n.name ? l.target : l.source;
+                    return `<li>${l.kind === 'collaborates' ? 'Collaborates with' : 'Consulted relationship with'} <b>${escapeHtml(other)}</b>: ${escapeHtml(l.labels.join('; '))}</li>`;
+                }).join('');
+            const notes = (n.notes || []).map(x => `<li>${escapeHtml(x)}</li>`).join('');
+            const chapter = n.kind === 'external' ? 'External party' : ((chapterOf || {})[n.name] || 'Other');
+            return `<li><span class="org-node-label">${escapeHtml(n.name)}</span> — ${escapeHtml(chapter)}<ul>${rels}${notes}</ul></li>`;
+        }).join('');
+        return `<ul>${byNode}</ul>`;
+    }
+
     return {
         STALE_MONTHS,
+        orgListHtml,
+        graphListHtml,
         pushRecent,
         groupResources,
         EXEC_LEVELS,


### PR DESCRIPTION
## The issue's premise did not survive checking

#118 said ~1,900 lines of inline JS were extractable and named three priorities. **Two were already done, and the third does not work as described.**

| Named priority | Status |
|---|---|
| `renderMarkdown` — *"pure string→string, trivially testable"* | **Not testable as claimed** |
| search/filter predicates | **Already extracted** — `roleMatchesFilter` (#115) |
| `badgeClass` / level mappings | **Already in viewer-logic.js** when this was filed |

`renderMarkdown` is a one-line wrapper around `DOMPurify.sanitize(marked.parse(md))` — both browser globals from `/vendor/` script tags. Testing it under `node:test` needs a DOM, and `package.json` carries `dependencies: {}` by design. Moving it into `viewer-logic.js` would actively break that file's contract of staying DOM-free so it remains callable from tests with plain data.

Of 65 inline functions, a strict purity check finds 12 candidates, most of them false positives that call DOM helpers one level down.

Closes #118

## What was actually worth extracting

`orgListHtml` and `graphListHtml` — the **accessible text fallbacks** behind the Org and Graph charts. The "View as list" content a screen-reader user gets instead of an ECharts canvas.

They were pure, untested, and a regression in either is **invisible to sighted testing**. That makes them the highest-value untested code in the file, which the original framing missed entirely.

10 tests added covering nesting, keyboard affordances on navigable nodes, HTML escaping, undirected edge rendering, external-party labelling, and the no-chapter fallback.

## Writing the tests caught me misreading the code

I asserted that `orgListHtml` shows the chapter lead on non-role nodes. It does the opposite. Reading `buildOrgTree` showed why: `file` and `leadTitle` are set together from the same lead object, so the branch guarding `leadTitle && !file` is **unreachable**.

The code was right; my test and my comment were both wrong. The condition is kept **exactly as written** — this is an extraction, and collapsing an unreachable branch is a behaviour change dressed as tidying. The reasoning is recorded at the call site so the next reader does not have to re-derive it.

## Test plan

- [x] TDD — 10 tests written first, watched fail as `not defined`; one then failed against real behaviour and was corrected to match the code
- [x] `npm test` — **171/171** (was 161) · `npm run validate` — 0 errors, 0 duplicate titles
- [x] Inline copies removed — one implementation, not two (verified 0 remaining in `index.html`)
- [x] Browser: Org fallback renders **226** role items across 259 nested lists; Graph fallback renders **39** nodes including the new Quality Engineering domain; both charts still draw
- [x] No console errors

## What is deliberately left

The remaining inline code is DOM-coupled. Testing it means adding jsdom as a dev dependency — a decision worth making deliberately rather than smuggling in under a cleanup, and one that trades away this repo's zero-dependency property.