### PR TITLE
docs: split the run-on Technology Proficiency entries

### DIFF
--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -69,11 +69,16 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 
 **Expert level required:**
 
-- AWS Cost Explorer and Cost and Usage Report (CUR) for detailed billing analysis and waste identification, Azure Cost Management and Azure Advisor for rightsizing recommendations and anomaly investigation, Reserved instance, savings plan, and committed use discount mechanics across AWS, Azure, and GCP, Cloud resource tagging policy enforcement and non-compliant resource remediation workflows
+- AWS Cost Explorer and Cost and Usage Report (CUR) for detailed billing analysis and waste identification
+- Azure Cost Management and Azure Advisor for rightsizing recommendations and anomaly investigation
+- Reserved instance, savings plan, and committed use discount mechanics across AWS, Azure, and GCP
+- Cloud resource tagging policy enforcement and non-compliant resource remediation workflows
 
 **Proficient level required:**
 
-- Multi-cloud cost management platforms (CloudHealth by VMware, Apptio Cloudability) for consolidated waste and coverage reporting, Python and PowerShell scripting for idle resource cleanup, tagging remediation, and optimisation automation, Spot instance platforms (Spot.io Elastigroup/Ocean) for cost-efficient workload scheduling and interruption management
+- Multi-cloud cost management platforms (CloudHealth by VMware, Apptio Cloudability) for consolidated waste and coverage reporting
+- Python and PowerShell scripting for idle resource cleanup, tagging remediation, and optimisation automation
+- Spot instance platforms (Spot.io Elastigroup/Ocean) for cost-efficient workload scheduling and interruption management
 
 **Working Knowledge required:**
 

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -69,11 +69,16 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 
 **Expert level required:**
 
-- Power BI for cloud cost dashboards, chargeback reports, and scheduled stakeholder reporting (including RLS-based multi-tenant views), Microsoft Excel for financial modelling, TCO templates, and budget variance workbooks, AWS Cost and Usage Report (CUR), Azure Cost Management exports, and GCP BigQuery Billing Export for multi-cloud billing data analysis, SQL (Azure Synapse Analytics, Google BigQuery, Amazon Athena) for billing data querying, transformation, and aggregation
+- Power BI for cloud cost dashboards, chargeback reports, and scheduled stakeholder reporting (including RLS-based multi-tenant views)
+- Microsoft Excel for financial modelling, TCO templates, and budget variance workbooks
+- AWS Cost and Usage Report (CUR), Azure Cost Management exports, and GCP BigQuery Billing Export for multi-cloud billing data analysis
+- SQL (Azure Synapse Analytics, Google BigQuery, Amazon Athena) for billing data querying, transformation, and aggregation
 
 **Proficient level required:**
 
-- Tableau for executive visualisation and self-service cloud cost analytics portals, Python (Pandas, Matplotlib) for analytical scripting, billing pipeline automation, and ad hoc analysis, Apptio for IT financial management, TBM taxonomy, and cloud cost analytics
+- Tableau for executive visualisation and self-service cloud cost analytics portals
+- Python (Pandas, Matplotlib) for analytical scripting, billing pipeline automation, and ad hoc analysis
+- Apptio for IT financial management, TBM taxonomy, and cloud cost analytics
 
 **Working Knowledge required:**
 

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -71,7 +71,10 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 **Expert level required:**
 
-- Cloud cost monitoring and reporting tools (AWS Cost Explorer, Azure Cost Management, GCP Billing Console), Resource tagging implementation and cost allocation frameworks across AWS, Azure, and GCP, Budget alerting and anomaly detection configuration in cloud native and third-party FinOps platforms, Cloud provider billing systems and pricing models for accurate cost attribution
+- Cloud cost monitoring and reporting tools (AWS Cost Explorer, Azure Cost Management, GCP Billing Console)
+- Resource tagging implementation and cost allocation frameworks across AWS, Azure, and GCP
+- Budget alerting and anomaly detection configuration in cloud native and third-party FinOps platforms
+- Cloud provider billing systems and pricing models for accurate cost attribution
 
 **Proficient level required:**
 

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -68,7 +68,9 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 
 **Expert level required:**
 
-- Agile product ownership tools (Jira, Confluence) for FinOps backlog management, roadmap tracking, and sprint ceremonies, FinOps Foundation Framework and methodology for cloud financial accountability governance and maturity assessment, Stakeholder reporting and communication platforms (Power BI, Microsoft Teams) for cloud cost transparency and executive briefings
+- Agile product ownership tools (Jira, Confluence) for FinOps backlog management, roadmap tracking, and sprint ceremonies
+- FinOps Foundation Framework and methodology for cloud financial accountability governance and maturity assessment
+- Stakeholder reporting and communication platforms (Power BI, Microsoft Teams) for cloud cost transparency and executive briefings
 
 **Proficient level required:**
 

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -76,11 +76,14 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 
 **Proficient level required:**
 
-- Data visualization and analytics tools (Power BI, Tableau) for advanced cloud cost dashboards and executive reporting, Anomaly detection frameworks for identifying cost spikes, billing irregularities, and attribution errors, CI/CD pipeline integration for FinOps policy enforcement and automation deployment
+- Data visualization and analytics tools (Power BI, Tableau) for advanced cloud cost dashboards and executive reporting
+- Anomaly detection frameworks for identifying cost spikes, billing irregularities, and attribution errors
+- CI/CD pipeline integration for FinOps policy enforcement and automation deployment
 
 **Working Knowledge required:**
 
-- Cloud architecture principles across AWS, Azure, and GCP for evaluating the cost impact of design decisions, Machine learning concepts and tooling for cloud cost forecasting and anomaly prediction models
+- Cloud architecture principles across AWS, Azure, and GCP for evaluating the cost impact of design decisions
+- Machine learning concepts and tooling for cloud cost forecasting and anomaly prediction models
 
 **Awareness level expected:**
 

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -79,7 +79,9 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 **Working Knowledge required:**
 
-- HTML, CSS, and JavaScript (basic web development context), .NET CLI and MSBuild (build tooling and project management), dependency injection patterns in .NET applications
+- HTML, CSS, and JavaScript (basic web development context)
+- .NET CLI and MSBuild (build tooling and project management)
+- dependency injection patterns in .NET applications
 
 **Awareness level expected:**
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -66,11 +66,16 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 **Expert level required:**
 
-- Amazon EC2, Auto Scaling groups, and Elastic Load Balancing for compute management, Amazon VPC, subnets, security groups, and route table configuration, AWS IAM (users, roles, policies, and service account management), Amazon S3 and core storage services (EBS, EFS, Glacier)
+- Amazon EC2, Auto Scaling groups, and Elastic Load Balancing for compute management
+- Amazon VPC, subnets, security groups, and route table configuration
+- AWS IAM (users, roles, policies, and service account management)
+- Amazon S3 and core storage services (EBS, EFS, Glacier)
 
 **Proficient level required:**
 
-- AWS CloudFormation and AWS CDK for infrastructure deployment within approved patterns, Amazon CloudWatch for monitoring, alerting, and log management, AWS Systems Manager for patching, parameter store, and operational management
+- AWS CloudFormation and AWS CDK for infrastructure deployment within approved patterns
+- Amazon CloudWatch for monitoring, alerting, and log management
+- AWS Systems Manager for patching, parameter store, and operational management
 
 **Working Knowledge required:**
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -66,11 +66,15 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 **Expert level required:**
 
-- Agile product ownership tools (Jira, Confluence) for AWS platform backlog, sprint ceremonies, and roadmap management, FinOps Foundation Framework for cloud financial accountability, cost governance, and chargeback prioritisation, AWS service portfolio and AWS Cloud Adoption Framework for strategic roadmap planning and adoption sequencing
+- Agile product ownership tools (Jira, Confluence) for AWS platform backlog, sprint ceremonies, and roadmap management
+- FinOps Foundation Framework for cloud financial accountability, cost governance, and chargeback prioritisation
+- AWS service portfolio and AWS Cloud Adoption Framework for strategic roadmap planning and adoption sequencing
 
 **Proficient level required:**
 
-- AWS Cost Explorer, AWS Budgets, and Cost and Usage Report (CUR) for cost visibility, anomaly awareness, and governance decisions, Power BI or Tableau for cloud platform performance dashboards and stakeholder reporting, AWS Control Tower and multi-account governance concepts for product scope and compliance decision-making
+- AWS Cost Explorer, AWS Budgets, and Cost and Usage Report (CUR) for cost visibility, anomaly awareness, and governance decisions
+- Power BI or Tableau for cloud platform performance dashboards and stakeholder reporting
+- AWS Control Tower and multi-account governance concepts for product scope and compliance decision-making
 
 **Working Knowledge required:**
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -66,7 +66,10 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 **Expert level required:**
 
-- Azure Virtual Machines, VM Scale Sets, and compute services management, Azure Virtual Networks, subnets, NSGs, and route table configuration, Microsoft Entra ID and Azure RBAC for identity and access management, ARM Templates and Bicep for infrastructure deployment
+- Azure Virtual Machines, VM Scale Sets, and compute services management
+- Azure Virtual Networks, subnets, NSGs, and route table configuration
+- Microsoft Entra ID and Azure RBAC for identity and access management
+- ARM Templates and Bicep for infrastructure deployment
 
 **Proficient level required:**
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -66,11 +66,15 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 **Expert level required:**
 
-- Agile product ownership tools (Jira, Confluence, Azure Boards) for Azure platform backlog, sprint planning, and roadmap tracking, FinOps Foundation Framework and Azure Cost Management for cloud financial accountability and cost governance, Microsoft Azure service portfolio and Azure Cloud Adoption Framework (CAF) for strategic roadmap planning and modernisation prioritisation
+- Agile product ownership tools (Jira, Confluence, Azure Boards) for Azure platform backlog, sprint planning, and roadmap tracking
+- FinOps Foundation Framework and Azure Cost Management for cloud financial accountability and cost governance
+- Microsoft Azure service portfolio and Azure Cloud Adoption Framework (CAF) for strategic roadmap planning and modernisation prioritisation
 
 **Proficient level required:**
 
-- Azure Cost Management, Azure Advisor, and Azure Budgets for cost visibility, governance decisions, and optimisation priority-setting, Power BI and Azure cost dashboards for platform performance reporting and stakeholder communication, Azure landing zone design and subscription governance concepts for informing product scope and compliance decisions
+- Azure Cost Management, Azure Advisor, and Azure Budgets for cost visibility, governance decisions, and optimisation priority-setting
+- Power BI and Azure cost dashboards for platform performance reporting and stakeholder communication
+- Azure landing zone design and subscription governance concepts for informing product scope and compliance decisions
 
 **Working Knowledge required:**
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -66,11 +66,16 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 **Expert level required:**
 
-- Infrastructure as Code (Terraform, Bicep, ARM templates) for complex Azure deployments, Advanced Azure networking (ExpressRoute, Virtual WAN, Azure Firewall, Private Endpoints), Azure security services (Microsoft Defender for Cloud, Microsoft Sentinel, Azure Key Vault), Microsoft Entra ID including PIM, Conditional Access, and hybrid identity
+- Infrastructure as Code (Terraform, Bicep, ARM templates) for complex Azure deployments
+- Advanced Azure networking (ExpressRoute, Virtual WAN, Azure Firewall, Private Endpoints)
+- Azure security services (Microsoft Defender for Cloud, Microsoft Sentinel, Azure Key Vault)
+- Microsoft Entra ID including PIM, Conditional Access, and hybrid identity
 
 **Proficient level required:**
 
-- Azure Kubernetes Service (AKS) and container services deployment and management, Azure DevOps and GitHub Actions for CI/CD pipeline implementation, Azure Monitor, Log Analytics, and Application Insights for full-stack observability
+- Azure Kubernetes Service (AKS) and container services deployment and management
+- Azure DevOps and GitHub Actions for CI/CD pipeline implementation
+- Azure Monitor, Log Analytics, and Application Insights for full-stack observability
 
 **Working Knowledge required:**
 

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -68,7 +68,9 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 
 **Expert level required:**
 
-- Azure, AWS, and GCP architecture governance frameworks (CAF, WAF, AWS Well-Architected, GCP Architecture Framework), Cloud governance platforms (Azure Policy, AWS Service Control Policies, GCP Organization Policy Service), CSPM tooling (Microsoft Defender for Cloud, AWS Security Hub, GCP Security Command Center)
+- Azure, AWS, and GCP architecture governance frameworks (CAF, WAF, AWS Well-Architected, GCP Architecture Framework)
+- Cloud governance platforms (Azure Policy, AWS Service Control Policies, GCP Organization Policy Service)
+- CSPM tooling (Microsoft Defender for Cloud, AWS Security Hub, GCP Security Command Center)
 
 **Proficient level required:**
 

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -69,7 +69,9 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 **Expert level required:**
 
-- Multi-cloud architecture strategy across Azure, AWS, and GCP at enterprise scale (landing zones, governance, AI/ML, networking, security), Cloud governance at scale: policy-as-code, CSPM, and multi-cloud management platforms, Enterprise architecture frameworks (TOGAF, Zachman, ArchiMate) applied to cloud strategy
+- Multi-cloud architecture strategy across Azure, AWS, and GCP at enterprise scale (landing zones, governance, AI/ML, networking, security)
+- Cloud governance at scale: policy-as-code, CSPM, and multi-cloud management platforms
+- Enterprise architecture frameworks (TOGAF, Zachman, ArchiMate) applied to cloud strategy
 
 **Proficient level required:**
 
@@ -84,7 +86,8 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 **Awareness level expected:**
 
-- Emerging CNAPP, CIEM, and AIOps patterns for next-generation cloud security and operations, Cloud provider advisory programs (Microsoft MVP, AWS Hero, Google Developer Expert) and technology preview adoption signals
+- Emerging CNAPP, CIEM, and AIOps patterns for next-generation cloud security and operations
+- Cloud provider advisory programs (Microsoft MVP, AWS Hero, Google Developer Expert) and technology preview adoption signals
 
 ## Interactions with Other Roles
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -66,15 +66,21 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 **Expert level required:**
 
-- Google Compute Engine, managed instance groups, and instance lifecycle management, Google Kubernetes Engine (GKE) for container workload deployment and operations, Virtual Private Cloud (VPC) networking, firewall rules, Cloud NAT, and Cloud DNS, Cloud IAM and service accounts for resource access management
+- Google Compute Engine, managed instance groups, and instance lifecycle management
+- Google Kubernetes Engine (GKE) for container workload deployment and operations
+- Virtual Private Cloud (VPC) networking, firewall rules, Cloud NAT, and Cloud DNS
+- Cloud IAM and service accounts for resource access management
 
 **Proficient level required:**
 
-- Terraform and Google Cloud Deployment Manager for infrastructure as code deployments, Cloud Storage, Cloud SQL, and core GCP storage and database services, Google Cloud Monitoring, Cloud Logging, and Cloud Trace for observability
+- Terraform and Google Cloud Deployment Manager for infrastructure as code deployments
+- Cloud Storage, Cloud SQL, and core GCP storage and database services
+- Google Cloud Monitoring, Cloud Logging, and Cloud Trace for observability
 
 **Working Knowledge required:**
 
-- Cloud Functions, Cloud Run, and App Engine for serverless and PaaS workloads, GCP cost management tools (Billing Console, Budget Alerts, GCP Recommender)
+- Cloud Functions, Cloud Run, and App Engine for serverless and PaaS workloads
+- GCP cost management tools (Billing Console, Budget Alerts, GCP Recommender)
 
 **Awareness level expected:**
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -66,11 +66,15 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 **Expert level required:**
 
-- Agile product ownership tools (Jira, Confluence) for GCP platform backlog, sprint ceremonies, and roadmap management, FinOps Foundation Framework and GCP Billing Console for cloud financial accountability, cost governance, and optimisation prioritisation, GCP service portfolio (Compute Engine, GKE, BigQuery, data analytics, AI) for strategic roadmap planning and adoption sequencing
+- Agile product ownership tools (Jira, Confluence) for GCP platform backlog, sprint ceremonies, and roadmap management
+- FinOps Foundation Framework and GCP Billing Console for cloud financial accountability, cost governance, and optimisation prioritisation
+- GCP service portfolio (Compute Engine, GKE, BigQuery, data analytics, AI) for strategic roadmap planning and adoption sequencing
 
 **Proficient level required:**
 
-- GCP Billing Console, Budget Alerts, and GCP Recommender for cost governance, anomaly awareness, and optimisation priority-setting, Power BI, Looker Studio, or Tableau for cloud platform performance dashboards and stakeholder reporting, GCP organization hierarchy and project governance for product scope and compliance decision-making
+- GCP Billing Console, Budget Alerts, and GCP Recommender for cost governance, anomaly awareness, and optimisation priority-setting
+- Power BI, Looker Studio, or Tableau for cloud platform performance dashboards and stakeholder reporting
+- GCP organization hierarchy and project governance for product scope and compliance decision-making
 
 **Working Knowledge required:**
 

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -87,7 +87,9 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 
 **Proficient level required:**
 
-- pytest, Testinfra, and Terratest (infrastructure and IaC test automation), Ansible (roles, collections, and runbook automation), Backstage (scaffolder plugins and software templates)
+- pytest, Testinfra, and Terratest (infrastructure and IaC test automation)
+- Ansible (roles, collections, and runbook automation)
+- Backstage (scaffolder plugins and software templates)
 
 **Working Knowledge required:**
 

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -77,7 +77,9 @@ The Endpoint Management Engineer administers and maintains the organisation's en
 
 **Expert level required:**
 
-- Microsoft Intune configuration profiles, compliance policies, and app deployment, Windows Autopilot device registration and enrolment workflows, PowerShell scripting for endpoint remediation tasks
+- Microsoft Intune configuration profiles, compliance policies, and app deployment
+- Windows Autopilot device registration and enrolment workflows
+- PowerShell scripting for endpoint remediation tasks
 
 **Proficient level required:**
 

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -81,7 +81,9 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 
 **Proficient level required:**
 
-- Message routing, transformation, and error handling within integration platforms, SFTP file exchange and scheduled file processing patterns, Postman (API testing and integration validation)
+- Message routing, transformation, and error handling within integration platforms
+- SFTP file exchange and scheduled file processing patterns
+- Postman (API testing and integration validation)
 
 **Working Knowledge required:**
 

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -82,7 +82,9 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 
 **Proficient level required:**
 
-- Kubernetes storage (PersistentVolumes, PVCs, CSI drivers, StorageClasses), Prometheus and Grafana for cluster monitoring, alerting, and dashboards, Kubernetes security (Pod Security Standards, RBAC, Secrets management, image scanning)
+- Kubernetes storage (PersistentVolumes, PVCs, CSI drivers, StorageClasses)
+- Prometheus and Grafana for cluster monitoring, alerting, and dashboards
+- Kubernetes security (Pod Security Standards, RBAC, Secrets management, image scanning)
 
 **Working Knowledge required:**
 

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -74,11 +74,15 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 
 **Expert level required:**
 
-- Agile product ownership tools (Jira, Confluence) for Kubernetes platform backlog, roadmap, and sprint management, Kubernetes platform concepts (namespaces, workloads, resource quotas, RBAC, admission policies) for product decision-making, Container platform service catalogue and SLA definition for internal platform consumers
+- Agile product ownership tools (Jira, Confluence) for Kubernetes platform backlog, roadmap, and sprint management
+- Kubernetes platform concepts (namespaces, workloads, resource quotas, RBAC, admission policies) for product decision-making
+- Container platform service catalogue and SLA definition for internal platform consumers
 
 **Proficient level required:**
 
-- GitOps deployment model (ArgoCD, Flux) for understanding platform delivery patterns and acceptance criteria, Container monitoring and availability dashboards (Prometheus, Grafana) for SLA tracking and stakeholder reporting, Power BI or Tableau for container platform adoption, cost, and usage metrics
+- GitOps deployment model (ArgoCD, Flux) for understanding platform delivery patterns and acceptance criteria
+- Container monitoring and availability dashboards (Prometheus, Grafana) for SLA tracking and stakeholder reporting
+- Power BI or Tableau for container platform adoption, cost, and usage metrics
 
 **Working Knowledge required:**
 
@@ -87,7 +91,8 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 
 **Awareness level expected:**
 
-- Service mesh capabilities (Istio, Linkerd) for evaluating advanced platform feature roadmap items, FinOps tooling for Kubernetes cost visibility, namespace-level chargeback, and reserved capacity
+- Service mesh capabilities (Istio, Linkerd) for evaluating advanced platform feature roadmap items
+- FinOps tooling for Kubernetes cost visibility, namespace-level chargeback, and reserved capacity
 
 ## Interactions with Other Roles
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -76,7 +76,10 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 
 **Expert level required:**
 
-- Advanced Kubernetes (CRDs, Operators, admission controllers, API extension mechanisms), Service mesh implementations (Istio, Linkerd, Consul) for traffic management, mTLS, and observability, GitOps tools (ArgoCD, Flux, Fleet) for declarative multi-cluster management, Policy engines (OPA/Gatekeeper, Kyverno) for admission control and governance enforcement
+- Advanced Kubernetes (CRDs, Operators, admission controllers, API extension mechanisms)
+- Service mesh implementations (Istio, Linkerd, Consul) for traffic management, mTLS, and observability
+- GitOps tools (ArgoCD, Flux, Fleet) for declarative multi-cluster management
+- Policy engines (OPA/Gatekeeper, Kyverno) for admission control and governance enforcement
 
 **Proficient level required:**
 

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -96,7 +96,9 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 
 **Working Knowledge required:**
 
-- Istio and Envoy service mesh fault injection, GitHub Actions and Azure DevOps for CI chaos pipeline integration, Python, Go, and Bash for experiment automation and tooling
+- Istio and Envoy service mesh fault injection
+- GitHub Actions and Azure DevOps for CI chaos pipeline integration
+- Python, Go, and Bash for experiment automation and tooling
 
 **Awareness level expected:**
 

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -71,7 +71,10 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 **Expert level required:**
 
-- MLflow for experiment tracking, model registry, and pipeline orchestration, Kubeflow and Apache Airflow for ML workflow orchestration and scheduling, Kubernetes with GPU node pools for model training and serving, LLM serving platforms (vLLM, Azure AI Foundry, Amazon Bedrock, Vertex AI)
+- MLflow for experiment tracking, model registry, and pipeline orchestration
+- Kubeflow and Apache Airflow for ML workflow orchestration and scheduling
+- Kubernetes with GPU node pools for model training and serving
+- LLM serving platforms (vLLM, Azure AI Foundry, Amazon Bedrock, Vertex AI)
 
 **Proficient level required:**
 
@@ -82,7 +85,9 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 **Working Knowledge required:**
 
-- ONNX, TensorFlow Lite, and TinyML frameworks for edge model optimisation, Azure IoT Edge and AWS Greengrass for edge ML deployment pipelines, Responsible AI governance tooling and model risk management frameworks
+- ONNX, TensorFlow Lite, and TinyML frameworks for edge model optimisation
+- Azure IoT Edge and AWS Greengrass for edge ML deployment pipelines
+- Responsible AI governance tooling and model risk management frameworks
 
 **Awareness level expected:**
 

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -81,15 +81,23 @@ The Observability Architect designs and governs the organisation's full-stack ob
 
 **Expert level required:**
 
-- OpenTelemetry SDK, Collector pipelines, and semantic conventions for enterprise instrumentation standards, Prometheus and Thanos / Grafana Mimir for large-scale metrics storage and querying, SLO/SLI framework design with error budget policies and burn-rate alerting, Grafana stack (Loki, Tempo, dashboards) and Datadog/Dynatrace for enterprise-grade observability
+- OpenTelemetry SDK, Collector pipelines, and semantic conventions for enterprise instrumentation standards
+- Prometheus and Thanos / Grafana Mimir for large-scale metrics storage and querying
+- SLO/SLI framework design with error budget policies and burn-rate alerting
+- Grafana stack (Loki, Tempo, dashboards) and Datadog/Dynatrace for enterprise-grade observability
 
 **Proficient level required:**
 
-- Elastic Stack (Elasticsearch, Logstash, Kibana, Elastic APM) for log and APM architecture, Azure Monitor, Log Analytics Workspace, and Application Insights for cloud-native observability, Fluent Bit, Fluentd, and Vector for log pipeline agent design, Jaeger and Grafana Tempo for distributed tracing architecture
+- Elastic Stack (Elasticsearch, Logstash, Kibana, Elastic APM) for log and APM architecture
+- Azure Monitor, Log Analytics Workspace, and Application Insights for cloud-native observability
+- Fluent Bit, Fluentd, and Vector for log pipeline agent design
+- Jaeger and Grafana Tempo for distributed tracing architecture
 
 **Working Knowledge required:**
 
-- Kubernetes-native observability (kube-state-metrics, node exporter, service mesh telemetry), Alertmanager, PagerDuty, and OpsGenie for alerting governance and on-call routing, OpenTelemetry Collector edge deployment for resource-constrained environments
+- Kubernetes-native observability (kube-state-metrics, node exporter, service mesh telemetry)
+- Alertmanager, PagerDuty, and OpsGenie for alerting governance and on-call routing
+- OpenTelemetry Collector edge deployment for resource-constrained environments
 
 **Awareness level expected:**
 

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -75,7 +75,10 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 
 **Expert level required:**
 
-- Prometheus and Grafana for metrics collection, dashboard creation, and alerting rule configuration, Log aggregation systems (Elasticsearch/ELK Stack, Loki, Splunk) for centralised log management, PromQL and LogQL query languages for telemetry data analysis, Alert threshold configuration and noise reduction for actionable monitoring
+- Prometheus and Grafana for metrics collection, dashboard creation, and alerting rule configuration
+- Log aggregation systems (Elasticsearch/ELK Stack, Loki, Splunk) for centralised log management
+- PromQL and LogQL query languages for telemetry data analysis
+- Alert threshold configuration and noise reduction for actionable monitoring
 
 **Proficient level required:**
 
@@ -86,7 +89,9 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 
 **Working Knowledge required:**
 
-- Kubernetes monitoring stack (kube-state-metrics, node exporter, metrics-server), Alertmanager, PagerDuty, and OpsGenie for alert routing and on-call notification, Scripting and automation for monitoring configuration and dashboard-as-code
+- Kubernetes monitoring stack (kube-state-metrics, node exporter, metrics-server)
+- Alertmanager, PagerDuty, and OpsGenie for alert routing and on-call notification
+- Scripting and automation for monitoring configuration and dashboard-as-code
 
 **Awareness level expected:**
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -89,7 +89,9 @@ The Observability Product Owner manages the observability platform portfolio, de
 
 **Working Knowledge required:**
 
-- OpenTelemetry instrumentation concepts and team adoption patterns, Distributed tracing systems (Jaeger, Zipkin) and APM tool features, Time-series database concepts, cardinality management, and telemetry cost governance
+- OpenTelemetry instrumentation concepts and team adoption patterns
+- Distributed tracing systems (Jaeger, Zipkin) and APM tool features
+- Time-series database concepts, cardinality management, and telemetry cost governance
 
 **Awareness level expected:**
 

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -77,11 +77,17 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 
 **Expert level required:**
 
-- Prometheus, Grafana, and Thanos for advanced metrics collection, long-term storage, and SLO dashboarding, OpenTelemetry SDK and Collector for multi-signal distributed tracing and instrumentation, SLO/SLI implementation and error budget management for business-critical services, Datadog, Dynatrace, or New Relic for full-stack APM and enterprise observability
+- Prometheus, Grafana, and Thanos for advanced metrics collection, long-term storage, and SLO dashboarding
+- OpenTelemetry SDK and Collector for multi-signal distributed tracing and instrumentation
+- SLO/SLI implementation and error budget management for business-critical services
+- Datadog, Dynatrace, or New Relic for full-stack APM and enterprise observability
 
 **Proficient level required:**
 
-- Elastic Stack (Elasticsearch, Loki, Splunk) for advanced log aggregation and correlation analysis, Jaeger and Zipkin for distributed trace analysis in microservice architectures, Alertmanager, PagerDuty, and OpsGenie for advanced on-call routing and alert deduplication, Service mesh observability with Istio and Linkerd telemetry integration
+- Elastic Stack (Elasticsearch, Loki, Splunk) for advanced log aggregation and correlation analysis
+- Jaeger and Zipkin for distributed trace analysis in microservice architectures
+- Alertmanager, PagerDuty, and OpsGenie for advanced on-call routing and alert deduplication
+- Service mesh observability with Istio and Linkerd telemetry integration
 
 **Working Knowledge required:**
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -67,7 +67,10 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 **Expert level required:**
 
-- Kubernetes and container orchestration for platform component deployment and operations, CI/CD pipeline tools (GitHub Actions, GitLab CI, Jenkins) for developer self-service automation, Infrastructure as Code (Terraform, Pulumi) for platform component provisioning, Backstage or similar developer portal configuration, plugin management, and service catalog templates
+- Kubernetes and container orchestration for platform component deployment and operations
+- CI/CD pipeline tools (GitHub Actions, GitLab CI, Jenkins) for developer self-service automation
+- Infrastructure as Code (Terraform, Pulumi) for platform component provisioning
+- Backstage or similar developer portal configuration, plugin management, and service catalog templates
 
 **Proficient level required:**
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -67,7 +67,10 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 **Expert level required:**
 
-- Backstage or similar IDP portal at product management and strategic roadmap level, Jira and Confluence for backlog management, sprint planning, and engineering team ceremonies, , NIST CSF metrics and developer productivity measurement frameworks (deployment frequency, lead time, change failure rate), Developer satisfaction measurement (NPS surveys, SPACE framework analytics)
+- Backstage or similar IDP portal at product management and strategic roadmap level
+- Jira and Confluence for backlog management, sprint planning, and engineering team ceremonies
+- NIST CSF metrics and developer productivity measurement frameworks (deployment frequency, lead time, change failure rate)
+- Developer satisfaction measurement (NPS surveys, SPACE framework analytics)
 
 **Proficient level required:**
 

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -67,11 +67,17 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 
 **Expert level required:**
 
-- Backstage IDP framework including plugin development, software catalog, and scaffolding templates, Kubernetes and container orchestration for complex internal platform workloads, Terraform and Pulumi for advanced IaC automation and platform self-service provisioning, GitHub Actions and GitLab CI for CI/CD template design and golden path governance
+- Backstage IDP framework including plugin development, software catalog, and scaffolding templates
+- Kubernetes and container orchestration for complex internal platform workloads
+- Terraform and Pulumi for advanced IaC automation and platform self-service provisioning
+- GitHub Actions and GitLab CI for CI/CD template design and golden path governance
 
 **Proficient level required:**
 
-- Service mesh technologies (Istio, Linkerd) for platform-level traffic management and observability, Policy engines (OPA, Kyverno) for platform governance and Kubernetes admission control, ArgoCD and Flux for GitOps platform delivery and progressive rollouts, Helm, Kustomize, and Crossplane for Kubernetes workload management
+- Service mesh technologies (Istio, Linkerd) for platform-level traffic management and observability
+- Policy engines (OPA, Kyverno) for platform governance and Kubernetes admission control
+- ArgoCD and Flux for GitOps platform delivery and progressive rollouts
+- Helm, Kustomize, and Crossplane for Kubernetes workload management
 
 **Working Knowledge required:**
 

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -67,7 +67,10 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 **Expert level required:**
 
-- Prometheus and Grafana for SLI/SLO instrumentation, error budget dashboards, and reliability monitoring, Kubernetes for container platform reliability operations and resource management, SLO/SLI framework design and error budget policy implementation, Incident management platforms (PagerDuty, OpsGenie) and runbook automation
+- Prometheus and Grafana for SLI/SLO instrumentation, error budget dashboards, and reliability monitoring
+- Kubernetes for container platform reliability operations and resource management
+- SLO/SLI framework design and error budget policy implementation
+- Incident management platforms (PagerDuty, OpsGenie) and runbook automation
 
 **Proficient level required:**
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -84,11 +84,17 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 
 **Expert level required:**
 
-- Prometheus, Grafana, and Alertmanager for SLO instrumentation, error budget burn-rate alerting, and reliability dashboards, Kubernetes (Helm, Kustomize) for cluster reliability operations and resource management, OpenTelemetry for distributed tracing and multi-signal observability, SLO/SLI/SLA framework design and error budget policy implementation for business-critical services
+- Prometheus, Grafana, and Alertmanager for SLO instrumentation, error budget burn-rate alerting, and reliability dashboards
+- Kubernetes (Helm, Kustomize) for cluster reliability operations and resource management
+- OpenTelemetry for distributed tracing and multi-signal observability
+- SLO/SLI/SLA framework design and error budget policy implementation for business-critical services
 
 **Proficient level required:**
 
-- LitmusChaos, Chaos Mesh, and AWS FIS for chaos engineering experiment design and execution, PagerDuty and OpsGenie for on-call programme management and incident routing, k6 and Locust for load testing, capacity validation, and traffic modelling, Python and Go for SRE tooling development and runbook automation
+- LitmusChaos, Chaos Mesh, and AWS FIS for chaos engineering experiment design and execution
+- PagerDuty and OpsGenie for on-call programme management and incident routing
+- k6 and Locust for load testing, capacity validation, and traffic modelling
+- Python and Go for SRE tooling development and runbook automation
 
 **Working Knowledge required:**
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -80,7 +80,9 @@ The Server Hardware Engineer implements and maintains the physical server infras
 
 **Proficient level required:**
 
-- Server firmware and driver management, hardware diagnostics utilities, rack, power, and cooling solutions
+- Server firmware and driver management
+- hardware diagnostics utilities
+- rack, power, and cooling solutions
 
 **Working Knowledge required:**
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -83,7 +83,10 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 
 **Expert level required:**
 
-- Slurm or PBS Pro job scheduler administration, queue configuration, and resource policy management, Linux HPC system administration and cluster node imaging with xCAT or Bright Cluster Manager, Parallel file systems (Lustre, GPFS/Spectrum Scale, BeeGFS) operations, maintenance, and capacity management, HPC cluster management and automation using Ansible for configuration management
+- Slurm or PBS Pro job scheduler administration, queue configuration, and resource policy management
+- Linux HPC system administration and cluster node imaging with xCAT or Bright Cluster Manager
+- Parallel file systems (Lustre, GPFS/Spectrum Scale, BeeGFS) operations, maintenance, and capacity management
+- HPC cluster management and automation using Ansible for configuration management
 
 **Proficient level required:**
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -81,7 +81,10 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 
 **Expert level required:**
 
-- HPC cluster platform capabilities (Slurm, PBS Pro, job schedulers) at product planning and SLA governance level, Jira and Confluence for backlog management, research stakeholder engagement, and sprint planning, Cluster utilisation dashboards (Grafana, Prometheus) and reporting tools for data-driven capacity planning, ServiceNow and ITSM platforms for HPC service request and incident governance
+- HPC cluster platform capabilities (Slurm, PBS Pro, job schedulers) at product planning and SLA governance level
+- Jira and Confluence for backlog management, research stakeholder engagement, and sprint planning
+- Cluster utilisation dashboards (Grafana, Prometheus) and reporting tools for data-driven capacity planning
+- ServiceNow and ITSM platforms for HPC service request and incident governance
 
 **Proficient level required:**
 

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -79,7 +79,10 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 
 **Expert level required:**
 
-- Microsoft Hyper-V architecture, cluster design, and high availability configuration, System Center Virtual Machine Manager (SCVMM) for enterprise VM fleet and library management, Azure Stack HCI and Storage Spaces Direct (S2D) hyperconverged architecture, Windows Server Failover Clustering for Hyper-V environments
+- Microsoft Hyper-V architecture, cluster design, and high availability configuration
+- System Center Virtual Machine Manager (SCVMM) for enterprise VM fleet and library management
+- Azure Stack HCI and Storage Spaces Direct (S2D) hyperconverged architecture
+- Windows Server Failover Clustering for Hyper-V environments
 
 **Proficient level required:**
 

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -81,11 +81,17 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 
 **Expert level required:**
 
-- Microsoft Hyper-V host configuration, virtual machine provisioning, and lifecycle management, System Center Virtual Machine Manager (SCVMM) for VM operations and cluster management, Windows Server administration and update management with WSUS, PowerShell scripting for Hyper-V management and routine automation
+- Microsoft Hyper-V host configuration, virtual machine provisioning, and lifecycle management
+- System Center Virtual Machine Manager (SCVMM) for VM operations and cluster management
+- Windows Server administration and update management with WSUS
+- PowerShell scripting for Hyper-V management and routine automation
 
 **Proficient level required:**
 
-- Windows Server Failover Clustering and Hyper-V high availability configuration, Hyper-V Replica setup, configuration, and recovery procedure testing, Storage Spaces Direct (S2D) and Cluster Shared Volumes (CSV) management, Windows Admin Center for remote server and VM management
+- Windows Server Failover Clustering and Hyper-V high availability configuration
+- Hyper-V Replica setup, configuration, and recovery procedure testing
+- Storage Spaces Direct (S2D) and Cluster Shared Volumes (CSV) management
+- Windows Admin Center for remote server and VM management
 
 **Working Knowledge required:**
 

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -81,7 +81,10 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 
 **Expert level required:**
 
-- Microsoft Hyper-V platform capabilities and Windows Server licensing models for product governance, Jira and Confluence for agile backlog management, sprint planning, and roadmap communication, Azure Stack HCI platform roadmap and infrastructure investment strategy, Windows Server Datacenter and Standard licensing governance and cost optimisation
+- Microsoft Hyper-V platform capabilities and Windows Server licensing models for product governance
+- Jira and Confluence for agile backlog management, sprint planning, and roadmap communication
+- Azure Stack HCI platform roadmap and infrastructure investment strategy
+- Windows Server Datacenter and Standard licensing governance and cost optimisation
 
 **Proficient level required:**
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -84,11 +84,17 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 
 **Expert level required:**
 
-- Microsoft Hyper-V at advanced cluster configuration and performance optimisation level, Windows Server Failover Clustering and high availability implementation, System Center Virtual Machine Manager (SCVMM) advanced orchestration, templates, and library management, PowerShell Direct and advanced scripting for Hyper-V automation workflows
+- Microsoft Hyper-V at advanced cluster configuration and performance optimisation level
+- Windows Server Failover Clustering and high availability implementation
+- System Center Virtual Machine Manager (SCVMM) advanced orchestration, templates, and library management
+- PowerShell Direct and advanced scripting for Hyper-V automation workflows
 
 **Proficient level required:**
 
-- Storage Spaces Direct (S2D) and Azure Stack HCI implementation and performance tuning, Hyper-V Replica and disaster recovery configuration, failover testing, and runbook design, Shielded VMs and Virtualization-Based Security (VBS) deployment, Software-Defined Networking in Windows Server advanced configuration
+- Storage Spaces Direct (S2D) and Azure Stack HCI implementation and performance tuning
+- Hyper-V Replica and disaster recovery configuration, failover testing, and runbook design
+- Shielded VMs and Virtualization-Based Security (VBS) deployment
+- Software-Defined Networking in Windows Server advanced configuration
 
 **Working Knowledge required:**
 

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -74,7 +74,10 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 
 **Expert level required:**
 
-- Nutanix AOS and AHV hypervisor architecture, cluster design, and sizing methodology, Nutanix Prism Central for enterprise multi-cluster governance and policy automation, Nutanix Flow microsegmentation and network security architecture, Nutanix HCI disaster recovery design (Nutanix Leap, Metro Availability, Async DR)
+- Nutanix AOS and AHV hypervisor architecture, cluster design, and sizing methodology
+- Nutanix Prism Central for enterprise multi-cluster governance and policy automation
+- Nutanix Flow microsegmentation and network security architecture
+- Nutanix HCI disaster recovery design (Nutanix Leap, Metro Availability, Async DR)
 
 **Proficient level required:**
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -74,7 +74,10 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 
 **Expert level required:**
 
-- Nutanix AOS and AHV hypervisor for day-to-day cluster operations and maintenance, Nutanix Prism Element and Prism Central for VM provisioning, monitoring, and cluster management, Nutanix Foundation for node imaging and cluster deployment procedures, VM provisioning, template management, and storage container configuration
+- Nutanix AOS and AHV hypervisor for day-to-day cluster operations and maintenance
+- Nutanix Prism Element and Prism Central for VM provisioning, monitoring, and cluster management
+- Nutanix Foundation for node imaging and cluster deployment procedures
+- VM provisioning, template management, and storage container configuration
 
 **Proficient level required:**
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -66,7 +66,10 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 
 **Expert level required:**
 
-- Nutanix HCI platform capabilities, licensing models, and strategic roadmap management, Jira and Confluence for agile backlog management, sprint planning, and stakeholder communication, Nutanix Prism Central product features and service catalog governance, Nutanix node licensing and NX/third-party hardware cost management
+- Nutanix HCI platform capabilities, licensing models, and strategic roadmap management
+- Jira and Confluence for agile backlog management, sprint planning, and stakeholder communication
+- Nutanix Prism Central product features and service catalog governance
+- Nutanix node licensing and NX/third-party hardware cost management
 
 **Proficient level required:**
 

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -66,7 +66,10 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 
 **Expert level required:**
 
-- Nutanix AOS and AHV hypervisor at advanced configuration, performance tuning, and cluster optimisation level, Nutanix Prism Central multi-cluster management, automation, and advanced policy design, Nutanix Flow network security advanced microsegmentation and policy design, Nutanix Calm blueprint development and application lifecycle automation
+- Nutanix AOS and AHV hypervisor at advanced configuration, performance tuning, and cluster optimisation level
+- Nutanix Prism Central multi-cluster management, automation, and advanced policy design
+- Nutanix Flow network security advanced microsegmentation and policy design
+- Nutanix Calm blueprint development and application lifecycle automation
 
 **Proficient level required:**
 

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -74,11 +74,17 @@ The VMware Architect designs and oversees the organization's virtualization infr
 
 **Expert level required:**
 
-- VMware vSphere (ESXi, vCenter Server) architecture and SDDC design patterns, VMware NSX-T software-defined networking and microsegmentation architecture, VMware vSAN storage design, performance optimisation, and policy management, VMware Cloud Foundation (VCF) platform architecture and lifecycle management
+- VMware vSphere (ESXi, vCenter Server) architecture and SDDC design patterns
+- VMware NSX-T software-defined networking and microsegmentation architecture
+- VMware vSAN storage design, performance optimisation, and policy management
+- VMware Cloud Foundation (VCF) platform architecture and lifecycle management
 
 **Proficient level required:**
 
-- VMware vRealize Suite and Aria Suite for automation, operations, and lifecycle management, VMware Site Recovery Manager (SRM) and vSphere Replication for DR architecture, VMware Horizon VDI platform architecture and design, VMware HCX for workload mobility and cloud migration
+- VMware vRealize Suite and Aria Suite for automation, operations, and lifecycle management
+- VMware Site Recovery Manager (SRM) and vSphere Replication for DR architecture
+- VMware Horizon VDI platform architecture and design
+- VMware HCX for workload mobility and cloud migration
 
 **Working Knowledge required:**
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -74,11 +74,17 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 
 **Expert level required:**
 
-- VMware vSphere (ESXi, vCenter Server) for VM provisioning and daily operational management, Virtual machine lifecycle management including templates, snapshots, and customisation specifications, VMware Lifecycle Manager (vSphere Update Manager) for host patching and compliance baseline management, vSphere networking with Distributed vSwitches and port group configuration
+- VMware vSphere (ESXi, vCenter Server) for VM provisioning and daily operational management
+- Virtual machine lifecycle management including templates, snapshots, and customisation specifications
+- VMware Lifecycle Manager (vSphere Update Manager) for host patching and compliance baseline management
+- vSphere networking with Distributed vSwitches and port group configuration
 
 **Proficient level required:**
 
-- vSphere storage management (VMFS, NFS datastores, Storage DRS), vSphere resource pools, clusters, DRS, and HA configuration, VMware roles-based access control and permission management, vSphere performance dashboards and monitoring within vCenter Server
+- vSphere storage management (VMFS, NFS datastores, Storage DRS)
+- vSphere resource pools, clusters, DRS, and HA configuration
+- VMware roles-based access control and permission management
+- vSphere performance dashboards and monitoring within vCenter Server
 
 **Working Knowledge required:**
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -74,11 +74,17 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 
 **Expert level required:**
 
-- VMware vSphere platform capabilities and strategic product roadmap management, Jira and Confluence for agile backlog management, sprint ceremonies, and roadmap reporting, VMware and Broadcom licensing models, TCO analysis, and cost optimisation governance, vRealize Operations and Aria Suite dashboards for platform performance and capacity reporting
+- VMware vSphere platform capabilities and strategic product roadmap management
+- Jira and Confluence for agile backlog management, sprint ceremonies, and roadmap reporting
+- VMware and Broadcom licensing models, TCO analysis, and cost optimisation governance
+- vRealize Operations and Aria Suite dashboards for platform performance and capacity reporting
 
 **Proficient level required:**
 
-- VMware NSX-T, vSAN, and Cloud Foundation (VCF) product capabilities at service planning and SLA definition level, VMware Site Recovery Manager for DR governance and business continuity planning, vCenter Server and ESXi upgrade lifecycle planning and risk assessment, Stakeholder-facing capacity and utilisation reporting
+- VMware NSX-T, vSAN, and Cloud Foundation (VCF) product capabilities at service planning and SLA definition level
+- VMware Site Recovery Manager for DR governance and business continuity planning
+- vCenter Server and ESXi upgrade lifecycle planning and risk assessment
+- Stakeholder-facing capacity and utilisation reporting
 
 **Working Knowledge required:**
 
@@ -88,7 +94,8 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 
 **Awareness level expected:**
 
-- Broadcom VMware strategic direction, pricing changes, and alternative platform migration options, Azure VMware Solution and VMware Cloud on AWS for hybrid cloud positioning
+- Broadcom VMware strategic direction, pricing changes, and alternative platform migration options
+- Azure VMware Solution and VMware Cloud on AWS for hybrid cloud positioning
 
 ## Interactions with Other Roles
 

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -74,7 +74,10 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 
 **Expert level required:**
 
-- VMware vSphere (ESXi 7.0/8.0, vCenter Server) at advanced configuration, cluster design, and performance optimisation level, VMware vSAN storage design, deduplication, compression, and performance tuning, VMware NSX-T software-defined networking and microsegmentation implementation, PowerCLI scripting and automation for vSphere operational management and bulk tasks
+- VMware vSphere (ESXi 7.0/8.0, vCenter Server) at advanced configuration, cluster design, and performance optimisation level
+- VMware vSAN storage design, deduplication, compression, and performance tuning
+- VMware NSX-T software-defined networking and microsegmentation implementation
+- PowerCLI scripting and automation for vSphere operational management and bulk tasks
 
 **Proficient level required:**
 


### PR DESCRIPTION
## Summary

#122 deliberately kept 73 proficiency lines whole, because a mechanical top-level comma split would have shattered them — they are Oxford-comma **capability groups**, not flat tool lists, and splitting yields fragments like `and route table configuration`. This does the splitting by reading each one.

Closes #138

| | Before | After |
|---|---|---|
| Bullets | 73 | **254** across 47 files |
| Longest proficiency bullet | 476 chars | **161** |
| Bullets over 250 chars | 55 | **0** |
| Bullets beginning with a connective | — | **0** |

## The heuristic flagged 84, not 73 — and both numbers are right

Eleven of the 84 are **single capabilities that merely contain an Oxford comma**:

- `ISO 27001, NIST CSF, and SOC 2 control frameworks` — one thing
- `InfiniBand and OmniPath high-performance fabric administration, tuning, and fault diagnosis` — one thing
- `Vanta, Drata, or equivalent continuous compliance monitoring tooling` — one thing

Splitting those would be *worse* than leaving them. Excluding them leaves exactly the 73 the issue described.

## Split points are authored, not derived

I tried three mechanical rules first and each failed on real data:

- **Capitalisation** — splits acronym lists (`GDPR, CCPA/CPRA, and …`)
- **Capitalisation + word count** — splits `Amazon EC2, Auto Scaling groups, and Elastic Load Balancing for compute management` into three when it is **one** capability
- **Purpose-clause detection** — misses capabilities with no trailing `for X`

So each split is expressed as the substrings that begin each new capability. The applier asserts every marker is found **exactly once**, that markers appear **in document order**, and that the parts **rejoin to the original string** — a mistyped marker aborts rather than silently dropping text.

Also repairs a pre-existing `, ,` typo in `platform_engineering_product_owner` that produced an empty list segment.

## Note on measuring this

Re-running the detector afterwards reports *more* hits, not fewer — because it flags any bullet containing an Oxford comma, which now includes every correctly-split capability. It was only ever a shortlist for human review, never a success metric. The measures that mean something are the fragment count (**0**), the length distribution (max 476 → 161), and content preservation.

## Test plan

- [x] Dry run first — 73 split / 11 left single / 1 typo / 47 files, with every marker validated before anything was written
- [x] **All 47 files verified to have an identical word multiset before and after** — structure changed, content did not
- [x] **Zero** bullets now begin with `and`/`or`, so no split cut mid-phrase
- [x] `npm test` — 171/171 · `npm run validate` — 0 errors, 0 duplicate titles · `npm run check-counts` — README matches
- [x] Browser: `Observability Engineer` renders its Expert block as four distinct capabilities