### PR TITLE
docs: put every KPI section in a table with its gaps visible

### DIFF
--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -142,7 +142,7 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 | Metric | Target | Frequency |
 |---|---|---|
 | Percentage of cloud waste eliminated month-on-month | — | — |
-| Rightsizing recommendation adoption rate (% of recommendations implemented within SLA) | — | — |
+| Rightsizing recommendation adoption rate (% of recommendations implemented within SLA) | ≥95% (proposed) | Monthly |
 | Reserved instance and savings plan coverage percentage across eligible spend | — | — |
 | Cost anomaly resolution time (average hours from alert to resolution) | — | — |
 | Tagging compliance percentage across the cloud estate | — | — |

--- a/Roles/FinOps/cloud_cost_optimization_engineer.md
+++ b/Roles/FinOps/cloud_cost_optimization_engineer.md
@@ -139,14 +139,16 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 
 ## Key Performance Indicators
 
-- Percentage of cloud waste eliminated month-on-month
-- Rightsizing recommendation adoption rate (% of recommendations implemented within SLA)
-- Reserved instance and savings plan coverage percentage across eligible spend
-- Cost anomaly resolution time (average hours from alert to resolution)
-- Tagging compliance percentage across the cloud estate
-- Idle and orphaned resource cleanup rate (resources remediated per sprint)
-- Spot instance adoption rate across eligible non-production workloads
-- Savings delivered ($ value) against quarterly optimisation targets
+| Metric | Target | Frequency |
+|---|---|---|
+| Percentage of cloud waste eliminated month-on-month | — | — |
+| Rightsizing recommendation adoption rate (% of recommendations implemented within SLA) | — | — |
+| Reserved instance and savings plan coverage percentage across eligible spend | — | — |
+| Cost anomaly resolution time (average hours from alert to resolution) | — | — |
+| Tagging compliance percentage across the cloud estate | — | — |
+| Idle and orphaned resource cleanup rate (resources remediated per sprint) | — | Per sprint |
+| Spot instance adoption rate across eligible non-production workloads | — | — |
+| Savings delivered ($ value) against quarterly optimisation targets | — | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -141,14 +141,16 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 
 ## Key Performance Indicators
 
-- Forecast accuracy percentage (actual vs. forecast spend within agreed tolerance bands)
-- Chargeback report delivery SLA adherence (% of reports delivered on time each month)
-- Budget variance detection speed (average time from anomaly occurrence to stakeholder notification)
-- Unit cost trend analysis quality (stakeholder-assessed usefulness score)
-- Stakeholder satisfaction score (measured via periodic feedback surveys)
-- Data quality score for billing allocation and tagging completeness underlying reports
-- Number of ad hoc financial analysis requests completed within SLA per quarter
-- Reduction in manual reporting effort through automation improvements (hours saved)
+| Metric | Target | Frequency |
+|---|---|---|
+| Forecast accuracy percentage (actual vs. forecast spend within agreed tolerance bands) | — | — |
+| Chargeback report delivery SLA adherence (% of reports delivered on time each month) | — | — |
+| Budget variance detection speed (average time from anomaly occurrence to stakeholder notification) | — | — |
+| Unit cost trend analysis quality (stakeholder-assessed usefulness score) | — | — |
+| Stakeholder satisfaction score (measured via periodic feedback surveys) | — | — |
+| Data quality score for billing allocation and tagging completeness underlying reports | — | — |
+| Number of ad hoc financial analysis requests completed within SLA per quarter | — | — |
+| Reduction in manual reporting effort through automation improvements (hours saved) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -144,12 +144,12 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 | Metric | Target | Frequency |
 |---|---|---|
 | Forecast accuracy percentage (actual vs. forecast spend within agreed tolerance bands) | — | — |
-| Chargeback report delivery SLA adherence (% of reports delivered on time each month) | — | — |
+| Chargeback report delivery SLA adherence (% of reports delivered on time each month) | ≥95% (proposed) | Monthly |
 | Budget variance detection speed (average time from anomaly occurrence to stakeholder notification) | — | — |
 | Unit cost trend analysis quality (stakeholder-assessed usefulness score) | — | — |
-| Stakeholder satisfaction score (measured via periodic feedback surveys) | — | — |
+| Stakeholder satisfaction score (measured via periodic feedback surveys) | ≥85% (proposed) | Quarterly |
 | Data quality score for billing allocation and tagging completeness underlying reports | — | — |
-| Number of ad hoc financial analysis requests completed within SLA per quarter | — | — |
+| Number of ad hoc financial analysis requests completed within SLA per quarter | ≥95% (proposed) | Monthly |
 | Reduction in manual reporting effort through automation improvements (hours saved) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -143,16 +143,18 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 ## Key Performance Indicators
 
-- Cloud cost reduction achievements
-- Cost visibility and allocation accuracy
-- Unit economics improvements for cloud services
-- Forecast accuracy for cloud spending
-- Cloud resource utilization rates
-- Reserved capacity optimization percentage
-- Adoption of FinOps practices across the organization
-- Stakeholder satisfaction with cost transparency
-- Cost variance reduction
-- Successful implementation of FinOps frameworks
+| Metric | Target | Frequency |
+|---|---|---|
+| Cloud cost reduction achievements | — | — |
+| Cost visibility and allocation accuracy | — | — |
+| Unit economics improvements for cloud services | — | — |
+| Forecast accuracy for cloud spending | — | — |
+| Cloud resource utilization rates | — | — |
+| Reserved capacity optimization percentage | — | — |
+| Adoption of FinOps practices across the organization | — | — |
+| Stakeholder satisfaction with cost transparency | — | — |
+| Cost variance reduction | — | — |
+| Successful implementation of FinOps frameworks | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/FinOps/finops_architect.md
+++ b/Roles/FinOps/finops_architect.md
@@ -152,7 +152,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Cloud resource utilization rates | — | — |
 | Reserved capacity optimization percentage | — | — |
 | Adoption of FinOps practices across the organization | — | — |
-| Stakeholder satisfaction with cost transparency | — | — |
+| Stakeholder satisfaction with cost transparency | ≥85% (proposed) | Quarterly |
 | Cost variance reduction | — | — |
 | Successful implementation of FinOps frameworks | — | — |
 

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -143,16 +143,18 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 ## Key Performance Indicators
 
-- Accuracy of cost allocation and tagging
-- Cloud cost reduction achievements
-- Timeliness of cost reporting and analysis
-- Quality of cost optimization implementations
-- Effectiveness of monitoring and alerting setup
-- Resource tagging compliance percentage
-- Reserved/committed capacity optimization
-- Documentation quality and completeness
-- User satisfaction with cost management tools
-- Problem resolution time for billing issues
+| Metric | Target | Frequency |
+|---|---|---|
+| Accuracy of cost allocation and tagging | — | — |
+| Cloud cost reduction achievements | — | — |
+| Timeliness of cost reporting and analysis | — | — |
+| Quality of cost optimization implementations | — | — |
+| Effectiveness of monitoring and alerting setup | — | — |
+| Resource tagging compliance percentage | — | — |
+| Reserved/committed capacity optimization | — | — |
+| Documentation quality and completeness | — | — |
+| User satisfaction with cost management tools | — | — |
+| Problem resolution time for billing issues | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -153,7 +153,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Resource tagging compliance percentage | — | — |
 | Reserved/committed capacity optimization | — | — |
 | Documentation quality and completeness | — | — |
-| User satisfaction with cost management tools | — | — |
+| User satisfaction with cost management tools | ≥85% (proposed) | Quarterly |
 | Problem resolution time for billing issues | — | — |
 
 ## Remote Work Considerations

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -151,7 +151,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 |---|---|---|
 | Cloud cost reduction achievements | — | — |
 | Forecast accuracy for cloud spending | — | — |
-| Stakeholder satisfaction with cost transparency | — | — |
+| Stakeholder satisfaction with cost transparency | ≥85% (proposed) | Quarterly |
 | Cost allocation coverage and accuracy | — | — |
 | On-time delivery of FinOps roadmap items | — | — |
 | Adoption of FinOps practices across teams | — | — |

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -147,16 +147,18 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 
 ## Key Performance Indicators
 
-- Cloud cost reduction achievements
-- Forecast accuracy for cloud spending
-- Stakeholder satisfaction with cost transparency
-- Cost allocation coverage and accuracy
-- On-time delivery of FinOps roadmap items
-- Adoption of FinOps practices across teams
-- Quality of backlog management
-- Unit economics improvement metrics
-- Reserved/committed capacity optimization
-- FinOps maturity progression
+| Metric | Target | Frequency |
+|---|---|---|
+| Cloud cost reduction achievements | — | — |
+| Forecast accuracy for cloud spending | — | — |
+| Stakeholder satisfaction with cost transparency | — | — |
+| Cost allocation coverage and accuracy | — | — |
+| On-time delivery of FinOps roadmap items | — | — |
+| Adoption of FinOps practices across teams | — | — |
+| Quality of backlog management | — | — |
+| Unit economics improvement metrics | — | — |
+| Reserved/committed capacity optimization | — | — |
+| FinOps maturity progression | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -137,16 +137,18 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 
 ## Key Performance Indicators
 
-- Cloud cost reduction achievements
-- Automation coverage for FinOps processes
-- Accuracy of cost allocation systems
-- Time to resolve complex cost issues
-- Effectiveness of anomaly detection
-- Knowledge transfer to junior team members
-- Innovation in cost optimization approaches
-- Implementation quality of FinOps standards
-- Cross-team collaboration effectiveness
-- Data quality and reliability metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Cloud cost reduction achievements | — | — |
+| Automation coverage for FinOps processes | — | — |
+| Accuracy of cost allocation systems | — | — |
+| Time to resolve complex cost issues | — | — |
+| Effectiveness of anomaly detection | — | — |
+| Knowledge transfer to junior team members | — | — |
+| Innovation in cost optimization approaches | — | — |
+| Implementation quality of FinOps standards | — | — |
+| Cross-team collaboration effectiveness | — | — |
+| Data quality and reliability metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_governance_architect.md
+++ b/Roles/ai_governance/ai_governance_architect.md
@@ -142,12 +142,14 @@ The AI Governance Architect designs and governs the organisation's frameworks, p
 
 ## Key Performance Indicators
 
-- AI system inventory completeness (percentage of AI systems assessed and classified)
-- High-risk AI systems with completed documentation and controls in place
-- AI incident rate and severity
-- EU AI Act / regulatory compliance readiness score
-- AI supplier assessment coverage
-- Employee AI governance and acceptable use training completion rate
+| Metric | Target | Frequency |
+|---|---|---|
+| AI system inventory completeness (percentage of AI systems assessed and classified) | — | — |
+| High-risk AI systems with completed documentation and controls in place | — | — |
+| AI incident rate and severity | — | — |
+| EU AI Act / regulatory compliance readiness score | — | — |
+| AI supplier assessment coverage | — | — |
+| Employee AI governance and acceptable use training completion rate | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_governance_engineer.md
+++ b/Roles/ai_governance/ai_governance_engineer.md
@@ -140,12 +140,14 @@ The AI Governance Engineer is an entry-level practitioner role responsible for i
 
 ## Key Performance Indicators
 
-- AI risk register currency: ≥95% of in-scope AI systems with assessment completed within the required review cycle
-- Model card documentation completeness: 100% of production AI systems with a current, complete model card in the inventory
-- Bias evaluation coverage: all AI systems flagged for bias testing evaluated and results documented within the agreed schedule
-- Compliance evidence collection: 100% of required evidence artefacts collated at least 5 business days prior to audit deadlines
-- AI incident log accuracy: all logged incidents with complete required fields within 24 hours of identification
-- AI system inventory completeness: ≥98% of known AI systems tracked in the inventory with current status and last review date
+| Metric | Target | Frequency |
+|---|---|---|
+| AI risk register currency: ≥95% of in-scope AI systems with assessment completed within the required review cycle | ≥95% | — |
+| Model card documentation completeness: 100% of production AI systems with a current, complete model card in the inventory | 100% | — |
+| Bias evaluation coverage: all AI systems flagged for bias testing evaluated and results documented within the agreed schedule | — | — |
+| Compliance evidence collection: 100% of required evidence artefacts collated at least 5 business days prior to audit deadlines | 100% | — |
+| AI incident log accuracy: all logged incidents with complete required fields within 24 hours of identification | — | — |
+| AI system inventory completeness: ≥98% of known AI systems tracked in the inventory with current status and last review date | ≥98% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_governance_product_owner.md
+++ b/Roles/ai_governance/ai_governance_product_owner.md
@@ -136,13 +136,15 @@ The AI Governance Product Owner owns the AI governance product backlog, managing
 
 ## Key Performance Indicators
 
-- AI governance backlog delivery rate: ≥85% of committed sprint items delivered each sprint
-- Regulatory milestone delivery: 100% of EU AI Act / ISO 42001 compliance programme milestones met on schedule
-- AI risk register completeness: ≥95% of in-scope AI systems with assessments completed within the review cycle
-- Audit readiness: zero critical audit findings attributable to governance programme delivery gaps in annual internal or external audits
-- Governance tooling adoption: ≥80% of AI teams using governed processes (model cards, risk assessments) within 6 months of tooling launch
-- Time-to-compliance: new regulatory requirements translated into backlog items within 10 business days of guidance publication
-- Stakeholder satisfaction: AI governance programme NPS from Business Unit AI teams ≥7/10
+| Metric | Target | Frequency |
+|---|---|---|
+| AI governance backlog delivery rate: ≥85% of committed sprint items delivered each sprint | ≥85% | — |
+| Regulatory milestone delivery: 100% of EU AI Act / ISO 42001 compliance programme milestones met on schedule | 100% | — |
+| AI risk register completeness: ≥95% of in-scope AI systems with assessments completed within the review cycle | ≥95% | — |
+| Audit readiness: zero critical audit findings attributable to governance programme delivery gaps in annual internal or external audits | — | Annual |
+| Governance tooling adoption: ≥80% of AI teams using governed processes (model cards, risk assessments) within 6 months of tooling launch | ≥80% | — |
+| Time-to-compliance: new regulatory requirements translated into backlog items within 10 business days of guidance publication | — | — |
+| Stakeholder satisfaction: AI governance programme NPS from Business Unit AI teams ≥7/10 | ≥7 | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -132,13 +132,15 @@ The AI Governance Senior Engineer implements, operates, and continuously improve
 
 ## Key Performance Indicators
 
-- AI system inventory completeness (percentage of known AI systems assessed and classified)
-- Assessment cycle time (average days from request to completed risk assessment)
-- Bias testing coverage of in-scope production AI models
-- Audit finding rate and remediation time for AI governance findings
-- GenAI deployment compliance review completion rate
-- AI incident documentation completeness and timeliness
-- Governance tooling availability and data quality scores
+| Metric | Target | Frequency |
+|---|---|---|
+| AI system inventory completeness (percentage of known AI systems assessed and classified) | — | — |
+| Assessment cycle time (average days from request to completed risk assessment) | — | — |
+| Bias testing coverage of in-scope production AI models | — | — |
+| Audit finding rate and remediation time for AI governance findings | — | — |
+| GenAI deployment compliance review completion rate | — | — |
+| AI incident documentation completeness and timeliness | — | — |
+| Governance tooling availability and data quality scores | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -140,7 +140,7 @@ The AI Governance Senior Engineer implements, operates, and continuously improve
 | Audit finding rate and remediation time for AI governance findings | — | — |
 | GenAI deployment compliance review completion rate | — | — |
 | AI incident documentation completeness and timeliness | — | — |
-| Governance tooling availability and data quality scores | — | — |
+| Governance tooling availability and data quality scores | ≥99.9% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_platform_architect.md
+++ b/Roles/ai_governance/ai_platform_architect.md
@@ -144,13 +144,15 @@ The AI Platform Architect designs and governs the organisation's AI/ML platform 
 
 ## Key Performance Indicators
 
-- Model deployment lead time: median time from model registry approval to production endpoint availability — target ≤2 business days for standard deployment patterns
-- ML platform availability: ≥99.5% uptime for model serving and experiment tracking services per month
-- Feature store reuse rate: ≥40% of production ML features consumed from the shared feature store rather than per-team custom computation
-- MLOps pipeline adoption: ≥80% of production ML models deployed via governed CI/CT/CD pipelines within 12 months of standard publication
-- Time to provision ML experiment environment: median new experiment environment ready within 1 business day
-- AI infrastructure cost per model training job: tracked and within FinOps governance thresholds each quarter
-- Governance checkpoint compliance: 100% of high-risk AI models passed through bias evaluation and documentation pipeline before production deployment
+| Metric | Target | Frequency |
+|---|---|---|
+| Model deployment lead time: median time from model registry approval to production endpoint availability — target ≤2 business days for standard deployment patterns | ≤2 business days | — |
+| ML platform availability: ≥99.5% uptime for model serving and experiment tracking services per month | ≥99.5% | — |
+| Feature store reuse rate: ≥40% of production ML features consumed from the shared feature store rather than per-team custom computation | ≥40% | — |
+| MLOps pipeline adoption: ≥80% of production ML models deployed via governed CI/CT/CD pipelines within 12 months of standard publication | ≥80% | — |
+| Time to provision ML experiment environment: median new experiment environment ready within 1 business day | — | — |
+| AI infrastructure cost per model training job: tracked and within FinOps governance thresholds each quarter | — | — |
+| Governance checkpoint compliance: 100% of high-risk AI models passed through bias evaluation and documentation pipeline before production deployment | 100% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -143,14 +143,16 @@ The AI Platform Engineer builds and operates the organisation's AI/ML platform i
 
 ## Key Performance Indicators
 
-- ML platform uptime and availability (target SLA, e.g., ≥99.5%)
-- ML pipeline execution success rate (% of scheduled pipelines completing without failure)
-- Model deployment lead time (hours from training completion to production endpoint availability, trending down)
-- Mean time to restore (MTTR) for ML infrastructure incidents
-- Data scientist onboarding time to first successful experiment run (days, trending down)
-- Feature store pipeline data freshness SLA compliance (% of feature tables meeting published freshness SLO)
-- ML infrastructure cost per model training run (trending vs. prior period)
-- Number of platform incidents attributed to infrastructure misconfiguration (trending down)
+| Metric | Target | Frequency |
+|---|---|---|
+| ML platform uptime and availability (target SLA, e.g., ≥99.5%) | ≥99.5% | — |
+| ML pipeline execution success rate (% of scheduled pipelines completing without failure) | — | — |
+| Model deployment lead time (hours from training completion to production endpoint availability, trending down) | — | — |
+| Mean time to restore (MTTR) for ML infrastructure incidents | — | — |
+| Data scientist onboarding time to first successful experiment run (days, trending down) | — | — |
+| Feature store pipeline data freshness SLA compliance (% of feature tables meeting published freshness SLO) | — | — |
+| ML infrastructure cost per model training run (trending vs. prior period) | — | — |
+| Number of platform incidents attributed to infrastructure misconfiguration (trending down) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -147,10 +147,10 @@ The AI Platform Engineer builds and operates the organisation's AI/ML platform i
 |---|---|---|
 | ML platform uptime and availability (target SLA, e.g., ≥99.5%) | ≥99.5% | — |
 | ML pipeline execution success rate (% of scheduled pipelines completing without failure) | — | — |
-| Model deployment lead time (hours from training completion to production endpoint availability, trending down) | — | — |
-| Mean time to restore (MTTR) for ML infrastructure incidents | — | — |
+| Model deployment lead time (hours from training completion to production endpoint availability, trending down) | ≥99.9% (proposed) | Monthly |
+| Mean time to restore (MTTR) for ML infrastructure incidents | ≤4 hours (proposed) | Monthly |
 | Data scientist onboarding time to first successful experiment run (days, trending down) | — | — |
-| Feature store pipeline data freshness SLA compliance (% of feature tables meeting published freshness SLO) | — | — |
+| Feature store pipeline data freshness SLA compliance (% of feature tables meeting published freshness SLO) | ≥95% (proposed) | Monthly |
 | ML infrastructure cost per model training run (trending vs. prior period) | — | — |
 | Number of platform incidents attributed to infrastructure misconfiguration (trending down) | — | — |
 

--- a/Roles/ai_governance/responsible_ai_engineer.md
+++ b/Roles/ai_governance/responsible_ai_engineer.md
@@ -139,12 +139,14 @@ The Responsible AI Engineer implements the technical tooling, testing processes,
 
 ## Key Performance Indicators
 
-- Percentage of production AI models with current model cards and fairness evaluations
-- Bias and fairness test pass rate at model deployment gates
-- Explainability coverage for high-risk AI decision systems
-- Governance pipeline integration rate across ML projects
-- AI red teaming findings resolved before production deployment
-- PII scanning coverage in data pipelines feeding AI systems
+| Metric | Target | Frequency |
+|---|---|---|
+| Percentage of production AI models with current model cards and fairness evaluations | — | — |
+| Bias and fairness test pass rate at model deployment gates | — | — |
+| Explainability coverage for high-risk AI decision systems | — | — |
+| Governance pipeline integration rate across ML projects | — | — |
+| AI red teaming findings resolved before production deployment | — | — |
+| PII scanning coverage in data pipelines feeding AI systems | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -132,16 +132,18 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of API designs with business requirements
-- API platform performance and scalability
-- Security posture of API implementations
-- Adoption of API reference architectures and patterns
-- Reduction in API architectural risks and technical debt
-- Developer productivity improvement through standards
-- Innovation in API architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of API designs with business requirements | — | — |
+| API platform performance and scalability | — | — |
+| Security posture of API implementations | — | — |
+| Adoption of API reference architectures and patterns | — | — |
+| Reduction in API architectural risks and technical debt | — | — |
+| Developer productivity improvement through standards | — | — |
+| Innovation in API architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -132,16 +132,18 @@ The API Platform Engineer implements and maintains API management solutions acro
 
 ## Key Performance Indicators
 
-- API platform reliability and availability
-- API response time and performance metrics
-- Quality of API documentation
-- Time to resolve API-related issues
-- API security compliance
-- API consumer satisfaction
-- Successful API deployments
-- API test coverage
-- Knowledge sharing and collaboration effectiveness
-- Continuous learning and skill development
+| Metric | Target | Frequency |
+|---|---|---|
+| API platform reliability and availability | — | — |
+| API response time and performance metrics | — | — |
+| Quality of API documentation | — | — |
+| Time to resolve API-related issues | — | — |
+| API security compliance | — | — |
+| API consumer satisfaction | — | — |
+| Successful API deployments | — | — |
+| API test coverage | — | — |
+| Knowledge sharing and collaboration effectiveness | — | — |
+| Continuous learning and skill development | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -134,14 +134,14 @@ The API Platform Engineer implements and maintains API management solutions acro
 
 | Metric | Target | Frequency |
 |---|---|---|
-| API platform reliability and availability | — | — |
+| API platform reliability and availability | ≥99.9% (proposed) | Monthly |
 | API response time and performance metrics | — | — |
 | Quality of API documentation | — | — |
 | Time to resolve API-related issues | — | — |
 | API security compliance | — | — |
-| API consumer satisfaction | — | — |
+| API consumer satisfaction | ≥85% (proposed) | Quarterly |
 | Successful API deployments | — | — |
-| API test coverage | — | — |
+| API test coverage | ≥80% (proposed) | Monthly |
 | Knowledge sharing and collaboration effectiveness | — | — |
 | Continuous learning and skill development | — | — |
 

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -131,7 +131,7 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Developer satisfaction with API platform | — | — |
+| Developer satisfaction with API platform | ≥85% (proposed) | Quarterly |
 | API adoption rates across development teams | — | — |
 | Time-to-market improvement for API-dependent applications | — | — |
 | Reduction in integration effort through standardized APIs | — | — |

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -129,16 +129,18 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 
 ## Key Performance Indicators
 
-- Developer satisfaction with API platform
-- API adoption rates across development teams
-- Time-to-market improvement for API-dependent applications
-- Reduction in integration effort through standardized APIs
-- API platform reliability and performance metrics
-- API security vulnerability reduction
-- Successful delivery of API platform roadmap items
-- Business value delivery through API capabilities
-- Return on investment for API platform initiatives
-- Innovation in API capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| Developer satisfaction with API platform | — | — |
+| API adoption rates across development teams | — | — |
+| Time-to-market improvement for API-dependent applications | — | — |
+| Reduction in integration effort through standardized APIs | — | — |
+| API platform reliability and performance metrics | — | — |
+| API security vulnerability reduction | — | — |
+| Successful delivery of API platform roadmap items | — | — |
+| Business value delivery through API capabilities | — | — |
+| Return on investment for API platform initiatives | — | — |
+| Innovation in API capabilities | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -132,14 +132,14 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 
 | Metric | Target | Frequency |
 |---|---|---|
-| API platform availability and reliability metrics | — | — |
+| API platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | API response time and throughput performance | — | — |
 | Implementation quality of API solutions | — | — |
 | Time to resolution for complex API issues | — | — |
 | Knowledge transfer effectiveness to junior developers | — | — |
 | API security posture improvement | — | — |
 | Successful implementation of API standards | — | — |
-| Developer satisfaction with API platform | — | — |
+| Developer satisfaction with API platform | ≥85% (proposed) | Quarterly |
 | Reduction in API-related incidents | — | — |
 | Innovation in API platform capabilities | — | — |
 

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -130,16 +130,18 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 
 ## Key Performance Indicators
 
-- API platform availability and reliability metrics
-- API response time and throughput performance
-- Implementation quality of API solutions
-- Time to resolution for complex API issues
-- Knowledge transfer effectiveness to junior developers
-- API security posture improvement
-- Successful implementation of API standards
-- Developer satisfaction with API platform
-- Reduction in API-related incidents
-- Innovation in API platform capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| API platform availability and reliability metrics | — | — |
+| API response time and throughput performance | — | — |
+| Implementation quality of API solutions | — | — |
+| Time to resolution for complex API issues | — | — |
+| Knowledge transfer effectiveness to junior developers | — | — |
+| API security posture improvement | — | — |
+| Successful implementation of API standards | — | — |
+| Developer satisfaction with API platform | — | — |
+| Reduction in API-related incidents | — | — |
+| Innovation in API platform capabilities | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/api_strategy_architect.md
+++ b/Roles/app_platforms/api_strategy_architect.md
@@ -144,14 +144,16 @@ The API Strategy Architect defines and governs the organisation's end-to-end API
 
 ## Key Performance Indicators
 
-- API governance standard adoption rate: ≥85% of new APIs passing automated Spectral governance checks before publication
-- API contract compliance rate: ≥90% of published APIs conforming to the organisation's OpenAPI / AsyncAPI specification standards
-- Consumer-driven contract test coverage: ≥70% of externally consumed APIs covered by Pact contract tests within CI/CD pipelines within 12 months of standard publication
-- Time-to-publish for new external APIs: median time from design approval to published developer portal listing ≤10 business days
-- Developer portal API catalogue completeness: ≥95% of published APIs have complete documentation including examples, changelog, and deprecation notices
-- Breaking change incident rate: fewer than 3 breaking-change-related integration incidents per quarter attributable to API lifecycle policy gaps
-- API deprecation compliance: ≥90% of deprecated APIs retired on schedule per published deprecation timeline
-- API security governance coverage: 100% of externally published APIs reviewed against the API security governance framework before publication
+| Metric | Target | Frequency |
+|---|---|---|
+| API governance standard adoption rate: ≥85% of new APIs passing automated Spectral governance checks before publication | ≥85% | — |
+| API contract compliance rate: ≥90% of published APIs conforming to the organisation's OpenAPI / AsyncAPI specification standards | ≥90% | — |
+| Consumer-driven contract test coverage: ≥70% of externally consumed APIs covered by Pact contract tests within CI/CD pipelines within 12 months of standard publication | ≥70% | — |
+| Time-to-publish for new external APIs: median time from design approval to published developer portal listing ≤10 business days | ≤10 business days | — |
+| Developer portal API catalogue completeness: ≥95% of published APIs have complete documentation including examples, changelog, and deprecation notices | ≥95% | — |
+| Breaking change incident rate: fewer than 3 breaking-change-related integration incidents per quarter attributable to API lifecycle policy gaps | — | — |
+| API deprecation compliance: ≥90% of deprecated APIs retired on schedule per published deprecation timeline | ≥90% | — |
+| API security governance coverage: 100% of externally published APIs reviewed against the API security governance framework before publication | 100% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -129,16 +129,18 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of .NET designs with business requirements
-- Application performance and scalability
-- Security posture of .NET applications
-- Adoption of .NET reference architectures and patterns
-- Reduction in architectural risks and technical debt
-- Developer productivity improvement through standards
-- Innovation in .NET architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of .NET designs with business requirements | — | — |
+| Application performance and scalability | — | — |
+| Security posture of .NET applications | — | — |
+| Adoption of .NET reference architectures and patterns | — | — |
+| Reduction in architectural risks and technical debt | — | — |
+| Developer productivity improvement through standards | — | — |
+| Innovation in .NET architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -135,7 +135,7 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 |---|---|---|
 | Code quality and maintainability metrics | — | — |
 | Timely completion of development tasks | — | — |
-| Unit test coverage percentage | — | — |
+| Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
 | Documentation quality and completeness | — | — |
 | Adherence to .NET coding standards | — | — |

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -131,16 +131,18 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 ## Key Performance Indicators
 
-- Code quality and maintainability metrics
-- Timely completion of development tasks
-- Unit test coverage percentage
-- Number of defects in delivered code
-- Documentation quality and completeness
-- Adherence to .NET coding standards
-- Collaboration effectiveness with team
-- Knowledge sharing and skill development
-- Responsiveness to support requests
-- Application performance and resource usage
+| Metric | Target | Frequency |
+|---|---|---|
+| Code quality and maintainability metrics | — | — |
+| Timely completion of development tasks | — | — |
+| Unit test coverage percentage | — | — |
+| Number of defects in delivered code | — | — |
+| Documentation quality and completeness | — | — |
+| Adherence to .NET coding standards | — | — |
+| Collaboration effectiveness with team | — | — |
+| Knowledge sharing and skill development | — | — |
+| Responsiveness to support requests | — | — |
+| Application performance and resource usage | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -131,7 +131,7 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Developer satisfaction with .NET platform | — | — |
+| Developer satisfaction with .NET platform | ≥85% (proposed) | Quarterly |
 | Platform adoption rates across development teams | — | — |
 | Time-to-market improvement for applications | — | — |
 | Reduction in development effort through shared components | — | — |

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -129,16 +129,18 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 
 ## Key Performance Indicators
 
-- Developer satisfaction with .NET platform
-- Platform adoption rates across development teams
-- Time-to-market improvement for applications
-- Reduction in development effort through shared components
-- Platform reliability and performance metrics
-- Security vulnerability reduction in .NET applications
-- Successful delivery of platform roadmap items
-- Business value delivery through platform capabilities
-- Return on investment for platform initiatives
-- Innovation in .NET capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| Developer satisfaction with .NET platform | — | — |
+| Platform adoption rates across development teams | — | — |
+| Time-to-market improvement for applications | — | — |
+| Reduction in development effort through shared components | — | — |
+| Platform reliability and performance metrics | — | — |
+| Security vulnerability reduction in .NET applications | — | — |
+| Successful delivery of platform roadmap items | — | — |
+| Business value delivery through platform capabilities | — | — |
+| Return on investment for platform initiatives | — | — |
+| Innovation in .NET capabilities | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -129,16 +129,18 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 
 ## Key Performance Indicators
 
-- .NET platform reliability and performance metrics
-- Code quality and maintainability scores
-- Implementation quality of .NET solutions
-- Time to resolution for complex .NET issues
-- Knowledge transfer effectiveness to junior developers
-- .NET security posture improvement
-- Successful implementation of .NET standards
-- Reduction in technical debt
-- Innovation in .NET platform capabilities
-- Team productivity improvements through frameworks
+| Metric | Target | Frequency |
+|---|---|---|
+| .NET platform reliability and performance metrics | — | — |
+| Code quality and maintainability scores | — | — |
+| Implementation quality of .NET solutions | — | — |
+| Time to resolution for complex .NET issues | — | — |
+| Knowledge transfer effectiveness to junior developers | — | — |
+| .NET security posture improvement | — | — |
+| Successful implementation of .NET standards | — | — |
+| Reduction in technical debt | — | — |
+| Innovation in .NET platform capabilities | — | — |
+| Team productivity improvements through frameworks | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -129,16 +129,18 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of Java designs with business requirements
-- Application performance and scalability
-- Security posture of Java applications
-- Adoption of Java reference architectures and patterns
-- Reduction in architectural risks and technical debt
-- Developer productivity improvement through standards
-- Innovation in Java architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of Java designs with business requirements | — | — |
+| Application performance and scalability | — | — |
+| Security posture of Java applications | — | — |
+| Adoption of Java reference architectures and patterns | — | — |
+| Reduction in architectural risks and technical debt | — | — |
+| Developer productivity improvement through standards | — | — |
+| Innovation in Java architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -135,7 +135,7 @@ The Java Engineer implements and maintains Java-based applications and platform 
 |---|---|---|
 | Code quality and maintainability metrics | — | — |
 | Timely completion of development tasks | — | — |
-| Unit test coverage percentage | — | — |
+| Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
 | Documentation quality and completeness | — | — |
 | Adherence to Java coding standards | — | — |

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -131,16 +131,18 @@ The Java Engineer implements and maintains Java-based applications and platform 
 
 ## Key Performance Indicators
 
-- Code quality and maintainability metrics
-- Timely completion of development tasks
-- Unit test coverage percentage
-- Number of defects in delivered code
-- Documentation quality and completeness
-- Adherence to Java coding standards
-- Collaboration effectiveness with team
-- Knowledge sharing and skill development
-- Responsiveness to support requests
-- Application performance and resource usage
+| Metric | Target | Frequency |
+|---|---|---|
+| Code quality and maintainability metrics | — | — |
+| Timely completion of development tasks | — | — |
+| Unit test coverage percentage | — | — |
+| Number of defects in delivered code | — | — |
+| Documentation quality and completeness | — | — |
+| Adherence to Java coding standards | — | — |
+| Collaboration effectiveness with team | — | — |
+| Knowledge sharing and skill development | — | — |
+| Responsiveness to support requests | — | — |
+| Application performance and resource usage | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -132,7 +132,7 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Developer satisfaction with Java platform | — | — |
+| Developer satisfaction with Java platform | ≥85% (proposed) | Quarterly |
 | Platform adoption rates across development teams | — | — |
 | Time-to-market improvement for applications | — | — |
 | Reduction in development effort through shared components | — | — |

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -130,16 +130,18 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 
 ## Key Performance Indicators
 
-- Developer satisfaction with Java platform
-- Platform adoption rates across development teams
-- Time-to-market improvement for applications
-- Reduction in development effort through shared components
-- Platform reliability and performance metrics
-- Security vulnerability reduction in Java applications
-- Successful delivery of platform roadmap items
-- Business value delivery through platform capabilities
-- Return on investment for platform initiatives
-- Innovation in Java capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| Developer satisfaction with Java platform | — | — |
+| Platform adoption rates across development teams | — | — |
+| Time-to-market improvement for applications | — | — |
+| Reduction in development effort through shared components | — | — |
+| Platform reliability and performance metrics | — | — |
+| Security vulnerability reduction in Java applications | — | — |
+| Successful delivery of platform roadmap items | — | — |
+| Business value delivery through platform capabilities | — | — |
+| Return on investment for platform initiatives | — | — |
+| Innovation in Java capabilities | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -130,16 +130,18 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 
 ## Key Performance Indicators
 
-- Java platform reliability and performance metrics
-- Code quality and maintainability scores
-- Implementation quality of Java solutions
-- Time to resolution for complex Java issues
-- Knowledge transfer effectiveness to junior developers
-- Java security posture improvement
-- Successful implementation of Java standards
-- Reduction in technical debt
-- Innovation in Java platform capabilities
-- Team productivity improvements through frameworks
+| Metric | Target | Frequency |
+|---|---|---|
+| Java platform reliability and performance metrics | — | — |
+| Code quality and maintainability scores | — | — |
+| Implementation quality of Java solutions | — | — |
+| Time to resolution for complex Java issues | — | — |
+| Knowledge transfer effectiveness to junior developers | — | — |
+| Java security posture improvement | — | — |
+| Successful implementation of Java standards | — | — |
+| Reduction in technical debt | — | — |
+| Innovation in Java platform capabilities | — | — |
+| Team productivity improvements through frameworks | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -139,16 +139,18 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of cloud designs with business requirements
-- Cloud architecture scalability and reliability
-- Cost efficiency of designed cloud solutions
-- Security compliance of cloud architectures
-- Adoption of cloud reference architectures and patterns
-- Reduction in architectural risks and technical debt
-- Innovation in cloud architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of cloud designs with business requirements | — | — |
+| Cloud architecture scalability and reliability | — | — |
+| Cost efficiency of designed cloud solutions | — | — |
+| Security compliance of cloud architectures | — | — |
+| Adoption of cloud reference architectures and patterns | — | — |
+| Reduction in architectural risks and technical debt | — | — |
+| Innovation in cloud architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -130,7 +130,7 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| AWS environment uptime and reliability | — | — |
+| AWS environment uptime and reliability | ≥99.9% (proposed) | Monthly |
 | Time to provision new cloud resources | — | — |
 | Resolution time for cloud service incidents | — | — |
 | AWS cost management effectiveness | — | — |
@@ -138,7 +138,7 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 | Documentation quality for AWS configurations | — | — |
 | Successful implementation of standard patterns | — | — |
 | AWS resource utilization efficiency | — | — |
-| User satisfaction with AWS services | — | — |
+| User satisfaction with AWS services | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -128,16 +128,18 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 ## Key Performance Indicators
 
-- AWS environment uptime and reliability
-- Time to provision new cloud resources
-- Resolution time for cloud service incidents
-- AWS cost management effectiveness
-- Security compliance in AWS environments
-- Documentation quality for AWS configurations
-- Successful implementation of standard patterns
-- AWS resource utilization efficiency
-- User satisfaction with AWS services
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| AWS environment uptime and reliability | — | — |
+| Time to provision new cloud resources | — | — |
+| Resolution time for cloud service incidents | — | — |
+| AWS cost management effectiveness | — | — |
+| Security compliance in AWS environments | — | — |
+| Documentation quality for AWS configurations | — | — |
+| Successful implementation of standard patterns | — | — |
+| AWS resource utilization efficiency | — | — |
+| User satisfaction with AWS services | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -123,16 +123,18 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 ## Key Performance Indicators
 
-- AWS platform availability and reliability metrics
-- Cloud cost management effectiveness
-- Time-to-delivery for cloud services
-- Stakeholder satisfaction with AWS platform
-- Security compliance scores for AWS environment
-- Successful implementation of cloud governance
-- AWS service adoption rates
-- Cloud migration project success rates
-- AWS platform feature delivery against roadmap
-- Cloud platform operational efficiency
+| Metric | Target | Frequency |
+|---|---|---|
+| AWS platform availability and reliability metrics | — | — |
+| Cloud cost management effectiveness | — | — |
+| Time-to-delivery for cloud services | — | — |
+| Stakeholder satisfaction with AWS platform | — | — |
+| Security compliance scores for AWS environment | — | — |
+| Successful implementation of cloud governance | — | — |
+| AWS service adoption rates | — | — |
+| Cloud migration project success rates | — | — |
+| AWS platform feature delivery against roadmap | — | — |
+| Cloud platform operational efficiency | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -125,10 +125,10 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 | Metric | Target | Frequency |
 |---|---|---|
-| AWS platform availability and reliability metrics | — | — |
+| AWS platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
-| Stakeholder satisfaction with AWS platform | — | — |
+| Stakeholder satisfaction with AWS platform | ≥85% (proposed) | Quarterly |
 | Security compliance scores for AWS environment | — | — |
 | Successful implementation of cloud governance | — | — |
 | AWS service adoption rates | — | — |

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -130,7 +130,7 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 
 | Metric | Target | Frequency |
 |---|---|---|
-| AWS environment availability and reliability | — | — |
+| AWS environment availability and reliability | ≥99.9% (proposed) | Monthly |
 | Implementation quality of AWS solutions | — | — |
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
@@ -139,7 +139,7 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 | Successful implementation of AWS standards and patterns | — | — |
 | Project delivery timeliness and quality | — | — |
 | Technical innovation contribution | — | — |
-| Customer satisfaction with AWS services | — | — |
+| Customer satisfaction with AWS services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -128,16 +128,18 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 
 ## Key Performance Indicators
 
-- AWS environment availability and reliability
-- Implementation quality of AWS solutions
-- Time to resolve critical cloud incidents
-- Cost optimization achievements
-- Security posture improvement in AWS
-- Knowledge transfer effectiveness to junior engineers
-- Successful implementation of AWS standards and patterns
-- Project delivery timeliness and quality
-- Technical innovation contribution
-- Customer satisfaction with AWS services
+| Metric | Target | Frequency |
+|---|---|---|
+| AWS environment availability and reliability | — | — |
+| Implementation quality of AWS solutions | — | — |
+| Time to resolve critical cloud incidents | — | — |
+| Cost optimization achievements | — | — |
+| Security posture improvement in AWS | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Successful implementation of AWS standards and patterns | — | — |
+| Project delivery timeliness and quality | — | — |
+| Technical innovation contribution | — | — |
+| Customer satisfaction with AWS services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -133,16 +133,18 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of cloud designs with business requirements
-- Cloud architecture scalability and flexibility
-- Cost efficiency of designed cloud solutions
-- Security compliance of cloud architectures
-- Adoption of cloud reference architectures and patterns
-- Reduction in architectural risks and technical debt
-- Innovation in cloud architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of cloud designs with business requirements | — | — |
+| Cloud architecture scalability and flexibility | — | — |
+| Cost efficiency of designed cloud solutions | — | — |
+| Security compliance of cloud architectures | — | — |
+| Adoption of cloud reference architectures and patterns | — | — |
+| Reduction in architectural risks and technical debt | — | — |
+| Innovation in cloud architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -125,7 +125,7 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Azure environment availability and reliability | — | — |
+| Azure environment availability and reliability | ≥99.9% (proposed) | Monthly |
 | Time to provision new cloud resources | — | — |
 | Azure cost optimization efforts | — | — |
 | Resolution time for cloud service incidents | — | — |

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -123,16 +123,18 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 ## Key Performance Indicators
 
-- Azure environment availability and reliability
-- Time to provision new cloud resources
-- Azure cost optimization efforts
-- Resolution time for cloud service incidents
-- Quality of IaC implementation
-- Security compliance in Azure deployments
-- Documentation quality for Azure configurations
-- Successful implementation of standard patterns
-- Azure service monitoring coverage
-- Knowledge sharing with team members
+| Metric | Target | Frequency |
+|---|---|---|
+| Azure environment availability and reliability | — | — |
+| Time to provision new cloud resources | — | — |
+| Azure cost optimization efforts | — | — |
+| Resolution time for cloud service incidents | — | — |
+| Quality of IaC implementation | — | — |
+| Security compliance in Azure deployments | — | — |
+| Documentation quality for Azure configurations | — | — |
+| Successful implementation of standard patterns | — | — |
+| Azure service monitoring coverage | — | — |
+| Knowledge sharing with team members | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -125,10 +125,10 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Azure platform availability and reliability metrics | — | — |
+| Azure platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
-| Stakeholder satisfaction with Azure platform | — | — |
+| Stakeholder satisfaction with Azure platform | ≥85% (proposed) | Quarterly |
 | Security compliance scores for cloud environment | — | — |
 | Successful implementation of cloud governance | — | — |
 | PaaS service adoption rates | — | — |

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -123,16 +123,18 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 ## Key Performance Indicators
 
-- Azure platform availability and reliability metrics
-- Cloud cost management effectiveness
-- Time-to-delivery for cloud services
-- Stakeholder satisfaction with Azure platform
-- Security compliance scores for cloud environment
-- Successful implementation of cloud governance
-- PaaS service adoption rates
-- Cloud migration project success
-- Azure platform feature delivery against roadmap
-- Cloud platform operational efficiency
+| Metric | Target | Frequency |
+|---|---|---|
+| Azure platform availability and reliability metrics | — | — |
+| Cloud cost management effectiveness | — | — |
+| Time-to-delivery for cloud services | — | — |
+| Stakeholder satisfaction with Azure platform | — | — |
+| Security compliance scores for cloud environment | — | — |
+| Successful implementation of cloud governance | — | — |
+| PaaS service adoption rates | — | — |
+| Cloud migration project success | — | — |
+| Azure platform feature delivery against roadmap | — | — |
+| Cloud platform operational efficiency | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -130,7 +130,7 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Cloud environment availability and reliability metrics | — | — |
+| Cloud environment availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Implementation quality scores for Azure solutions | — | — |
 | Automation coverage percentage for cloud operations | — | — |
 | Cost optimization achievements (% reduction, efficiency gains) | — | — |
@@ -138,7 +138,7 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 | Mean time to resolution for complex cloud incidents | — | — |
 | Knowledge transfer effectiveness to junior engineers | — | — |
 | Timely delivery of Azure implementation projects | — | — |
-| Customer satisfaction scores for cloud services | — | — |
+| Customer satisfaction scores for cloud services | ≥85% (proposed) | Quarterly |
 | Innovation and continuous improvement contributions | — | — |
 
 ## Remote Work Considerations

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -128,16 +128,18 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 ## Key Performance Indicators
 
-- Cloud environment availability and reliability metrics
-- Implementation quality scores for Azure solutions
-- Automation coverage percentage for cloud operations
-- Cost optimization achievements (% reduction, efficiency gains)
-- Security compliance scores for Azure resources
-- Mean time to resolution for complex cloud incidents
-- Knowledge transfer effectiveness to junior engineers
-- Timely delivery of Azure implementation projects
-- Customer satisfaction scores for cloud services
-- Innovation and continuous improvement contributions
+| Metric | Target | Frequency |
+|---|---|---|
+| Cloud environment availability and reliability metrics | — | — |
+| Implementation quality scores for Azure solutions | — | — |
+| Automation coverage percentage for cloud operations | — | — |
+| Cost optimization achievements (% reduction, efficiency gains) | — | — |
+| Security compliance scores for Azure resources | — | — |
+| Mean time to resolution for complex cloud incidents | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Timely delivery of Azure implementation projects | — | — |
+| Customer satisfaction scores for cloud services | — | — |
+| Innovation and continuous improvement contributions | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -128,7 +128,7 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 | Architecture review cycle time and quality of approved designs | — | — |
 | Adoption rate of shared reference architectures across cloud platforms | — | — |
 | Number of cross-platform architectural inconsistencies identified and resolved | — | — |
-| Architect team satisfaction and professional development progress | — | — |
+| Architect team satisfaction and professional development progress | ≥85% (proposed) | Quarterly |
 | Reduction in escalated architectural issues reaching the Principal Cloud Architect | — | — |
 | Cross-platform cloud governance compliance rate | — | — |
 | Contribution to and maintenance of shared architectural standards library | — | — |

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -123,13 +123,15 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 
 ## Key Performance Indicators
 
-- Architecture review cycle time and quality of approved designs
-- Adoption rate of shared reference architectures across cloud platforms
-- Number of cross-platform architectural inconsistencies identified and resolved
-- Architect team satisfaction and professional development progress
-- Reduction in escalated architectural issues reaching the Principal Cloud Architect
-- Cross-platform cloud governance compliance rate
-- Contribution to and maintenance of shared architectural standards library
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture review cycle time and quality of approved designs | — | — |
+| Adoption rate of shared reference architectures across cloud platforms | — | — |
+| Number of cross-platform architectural inconsistencies identified and resolved | — | — |
+| Architect team satisfaction and professional development progress | — | — |
+| Reduction in escalated architectural issues reaching the Principal Cloud Architect | — | — |
+| Cross-platform cloud governance compliance rate | — | — |
+| Contribution to and maintenance of shared architectural standards library | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -128,14 +128,16 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 ## Key Performance Indicators
 
-- Multi-cloud strategy maturity and documentation completeness
-- Alignment of platform architect deliverables with defined strategic principles
-- Reduction in strategic architectural rework or re-platforming costs
-- Quality and coverage of architectural standards and guardrails
-- Cloud provider relationship depth and access to advisory programs
-- Leadership perception of cloud architecture clarity and direction
-- Innovation adoption rate: strategic technologies evaluated and formally adopted or rejected per year
-- Escalation resolution rate and time-to-decision for complex cloud architectural issues
+| Metric | Target | Frequency |
+|---|---|---|
+| Multi-cloud strategy maturity and documentation completeness | — | — |
+| Alignment of platform architect deliverables with defined strategic principles | — | — |
+| Reduction in strategic architectural rework or re-platforming costs | — | — |
+| Quality and coverage of architectural standards and guardrails | — | — |
+| Cloud provider relationship depth and access to advisory programs | — | — |
+| Leadership perception of cloud architecture clarity and direction | — | — |
+| Innovation adoption rate: strategic technologies evaluated and formally adopted or rejected per year | — | — |
+| Escalation resolution rate and time-to-decision for complex cloud architectural issues | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -133,16 +133,18 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of cloud designs with business requirements
-- Cloud architecture scalability and reliability
-- Cost efficiency of designed cloud solutions
-- Security compliance of cloud architectures
-- Adoption of cloud reference architectures and patterns
-- Reduction in architectural risks and technical debt
-- Innovation in cloud architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of cloud designs with business requirements | — | — |
+| Cloud architecture scalability and reliability | — | — |
+| Cost efficiency of designed cloud solutions | — | — |
+| Security compliance of cloud architectures | — | — |
+| Adoption of cloud reference architectures and patterns | — | — |
+| Reduction in architectural risks and technical debt | — | — |
+| Innovation in cloud architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -130,7 +130,7 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| GCP environment uptime and reliability | — | — |
+| GCP environment uptime and reliability | ≥99.9% (proposed) | Monthly |
 | Time to provision new cloud resources | — | — |
 | Resolution time for cloud service incidents | — | — |
 | GCP cost management effectiveness | — | — |
@@ -138,7 +138,7 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 | Documentation quality for GCP configurations | — | — |
 | Successful implementation of standard patterns | — | — |
 | GCP resource utilization efficiency | — | — |
-| User satisfaction with GCP services | — | — |
+| User satisfaction with GCP services | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -128,16 +128,18 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 ## Key Performance Indicators
 
-- GCP environment uptime and reliability
-- Time to provision new cloud resources
-- Resolution time for cloud service incidents
-- GCP cost management effectiveness
-- Security compliance in GCP environments
-- Documentation quality for GCP configurations
-- Successful implementation of standard patterns
-- GCP resource utilization efficiency
-- User satisfaction with GCP services
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| GCP environment uptime and reliability | — | — |
+| Time to provision new cloud resources | — | — |
+| Resolution time for cloud service incidents | — | — |
+| GCP cost management effectiveness | — | — |
+| Security compliance in GCP environments | — | — |
+| Documentation quality for GCP configurations | — | — |
+| Successful implementation of standard patterns | — | — |
+| GCP resource utilization efficiency | — | — |
+| User satisfaction with GCP services | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -129,10 +129,10 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 | Metric | Target | Frequency |
 |---|---|---|
-| GCP platform availability and reliability | — | — |
+| GCP platform availability and reliability | ≥99.9% (proposed) | Monthly |
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
-| Stakeholder satisfaction with GCP platform | — | — |
+| Stakeholder satisfaction with GCP platform | ≥85% (proposed) | Quarterly |
 | Security compliance scores for cloud environment | — | — |
 | Successful implementation of cloud governance | — | — |
 | GCP service adoption rates | — | — |

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -127,16 +127,18 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 ## Key Performance Indicators
 
-- GCP platform availability and reliability
-- Cloud cost management effectiveness
-- Time-to-delivery for cloud services
-- Stakeholder satisfaction with GCP platform
-- Security compliance scores for cloud environment
-- Successful implementation of cloud governance
-- GCP service adoption rates
-- Cloud migration project success
-- GCP platform feature delivery against roadmap
-- Cloud platform operational efficiency
+| Metric | Target | Frequency |
+|---|---|---|
+| GCP platform availability and reliability | — | — |
+| Cloud cost management effectiveness | — | — |
+| Time-to-delivery for cloud services | — | — |
+| Stakeholder satisfaction with GCP platform | — | — |
+| Security compliance scores for cloud environment | — | — |
+| Successful implementation of cloud governance | — | — |
+| GCP service adoption rates | — | — |
+| Cloud migration project success | — | — |
+| GCP platform feature delivery against roadmap | — | — |
+| Cloud platform operational efficiency | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -130,7 +130,7 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 
 | Metric | Target | Frequency |
 |---|---|---|
-| GCP environment availability and reliability | — | — |
+| GCP environment availability and reliability | ≥99.9% (proposed) | Monthly |
 | Implementation quality of GCP solutions | — | — |
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
@@ -139,7 +139,7 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 | Successful implementation of GCP standards and patterns | — | — |
 | Project delivery timeliness and quality | — | — |
 | Technical innovation contribution | — | — |
-| Customer satisfaction with GCP services | — | — |
+| Customer satisfaction with GCP services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -128,16 +128,18 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 
 ## Key Performance Indicators
 
-- GCP environment availability and reliability
-- Implementation quality of GCP solutions
-- Time to resolve critical cloud incidents
-- Cost optimization achievements
-- Security posture improvement in GCP
-- Knowledge transfer effectiveness to junior engineers
-- Successful implementation of GCP standards and patterns
-- Project delivery timeliness and quality
-- Technical innovation contribution
-- Customer satisfaction with GCP services
+| Metric | Target | Frequency |
+|---|---|---|
+| GCP environment availability and reliability | — | — |
+| Implementation quality of GCP solutions | — | — |
+| Time to resolve critical cloud incidents | — | — |
+| Cost optimization achievements | — | — |
+| Security posture improvement in GCP | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Successful implementation of GCP standards and patterns | — | — |
+| Project delivery timeliness and quality | — | — |
+| Technical innovation contribution | — | — |
+| Customer satisfaction with GCP services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -139,8 +139,8 @@ The Data Engineer designs, builds, and maintains the data pipelines, transformat
 |---|---|---|
 | Pipeline availability for owned data products | — | — |
 | Data quality test pass rate for owned models | — | — |
-| Data freshness SLA compliance | — | — |
-| Analyst satisfaction with data quality and timeliness | — | — |
+| Data freshness SLA compliance | ≥95% (proposed) | Monthly |
+| Analyst satisfaction with data quality and timeliness | ≥85% (proposed) | Quarterly |
 | Data documentation completeness in the catalogue | — | — |
 | Query performance and cost efficiency of owned data models | — | — |
 

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -135,12 +135,14 @@ The Data Engineer designs, builds, and maintains the data pipelines, transformat
 
 ## Key Performance Indicators
 
-- Pipeline availability for owned data products
-- Data quality test pass rate for owned models
-- Data freshness SLA compliance
-- Analyst satisfaction with data quality and timeliness
-- Data documentation completeness in the catalogue
-- Query performance and cost efficiency of owned data models
+| Metric | Target | Frequency |
+|---|---|---|
+| Pipeline availability for owned data products | — | — |
+| Data quality test pass rate for owned models | — | — |
+| Data freshness SLA compliance | — | — |
+| Analyst satisfaction with data quality and timeliness | — | — |
+| Data documentation completeness in the catalogue | — | — |
+| Query performance and cost efficiency of owned data models | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -135,8 +135,8 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 | Data product delivery velocity (sprint throughput) | — | — |
 | Data product adoption rate (active consumers by product) | — | — |
 | Data platform cost per TB processed (trend: optimising) | — | — |
-| Data pipeline availability SLA compliance | — | — |
-| Stakeholder satisfaction score with data platform | — | — |
+| Data pipeline availability SLA compliance | ≥95% (proposed) | Monthly |
+| Stakeholder satisfaction score with data platform | ≥85% (proposed) | Quarterly |
 | Roadmap milestone delivery against plan | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -130,12 +130,14 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 
 ## Key Performance Indicators
 
-- Data product delivery velocity (sprint throughput)
-- Data product adoption rate (active consumers by product)
-- Data platform cost per TB processed (trend: optimising)
-- Data pipeline availability SLA compliance
-- Stakeholder satisfaction score with data platform
-- Roadmap milestone delivery against plan
+| Metric | Target | Frequency |
+|---|---|---|
+| Data product delivery velocity (sprint throughput) | — | — |
+| Data product adoption rate (active consumers by product) | — | — |
+| Data platform cost per TB processed (trend: optimising) | — | — |
+| Data pipeline availability SLA compliance | — | — |
+| Stakeholder satisfaction score with data platform | — | — |
+| Roadmap milestone delivery against plan | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -143,14 +143,16 @@ The Data Mesh Architect designs and governs the organisation's data mesh archite
 
 ## Key Performance Indicators
 
-- Number of active domain data products published to the mesh (trending growth month-over-month)
-- Data product SLA compliance rate (% of data products meeting their published quality and freshness SLOs)
-- Time-to-production for new domain data products (days from initiation to first consumer, trending down)
-- Data catalogue coverage (% of domain data products with complete metadata, lineage, and ownership records)
-- Cross-domain data product consumption rate (number of active cross-domain data product subscriptions)
-- Data contract compliance rate (% of data product interfaces backed by validated and enforced data contracts)
-- Data observability incident rate per domain data product (trending down)
-- Domain team self-serve capability score (onboarding time and central platform dependency reduction)
+| Metric | Target | Frequency |
+|---|---|---|
+| Number of active domain data products published to the mesh (trending growth month-over-month) | — | — |
+| Data product SLA compliance rate (% of data products meeting their published quality and freshness SLOs) | — | — |
+| Time-to-production for new domain data products (days from initiation to first consumer, trending down) | — | — |
+| Data catalogue coverage (% of domain data products with complete metadata, lineage, and ownership records) | — | — |
+| Cross-domain data product consumption rate (number of active cross-domain data product subscriptions) | — | — |
+| Data contract compliance rate (% of data product interfaces backed by validated and enforced data contracts) | — | — |
+| Data observability incident rate per domain data product (trending down) | — | — |
+| Domain team self-serve capability score (onboarding time and central platform dependency reduction) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -146,7 +146,7 @@ The Data Mesh Architect designs and governs the organisation's data mesh archite
 | Metric | Target | Frequency |
 |---|---|---|
 | Number of active domain data products published to the mesh (trending growth month-over-month) | — | — |
-| Data product SLA compliance rate (% of data products meeting their published quality and freshness SLOs) | — | — |
+| Data product SLA compliance rate (% of data products meeting their published quality and freshness SLOs) | ≥95% (proposed) | Monthly |
 | Time-to-production for new domain data products (days from initiation to first consumer, trending down) | — | — |
 | Data catalogue coverage (% of domain data products with complete metadata, lineage, and ownership records) | — | — |
 | Cross-domain data product consumption rate (number of active cross-domain data product subscriptions) | — | — |

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -139,14 +139,16 @@ The Data Platform Architect designs and governs the organisation's enterprise da
 
 ## Key Performance Indicators
 
-- Data platform SLA availability
-- Time-to-production for new data products
-- Data platform cost per TB processed
-- Data quality score across Gold tier datasets
-- Data governance completeness (catalogued and classified datasets %)
-- Engineering team adoption of platform standards
-- Data platform cost per TB of data processed (trending month-over-month vs. volume growth)
-- ML feature pipeline production lead time (time from feature request to production availability)
+| Metric | Target | Frequency |
+|---|---|---|
+| Data platform SLA availability | — | — |
+| Time-to-production for new data products | — | — |
+| Data platform cost per TB processed | — | — |
+| Data quality score across Gold tier datasets | — | — |
+| Data governance completeness (catalogued and classified datasets %) | — | — |
+| Engineering team adoption of platform standards | — | — |
+| Data platform cost per TB of data processed (trending month-over-month vs. volume growth) | — | — |
+| ML feature pipeline production lead time (time from feature request to production availability) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -141,14 +141,14 @@ The Data Platform Architect designs and governs the organisation's enterprise da
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Data platform SLA availability | — | — |
+| Data platform SLA availability | ≥95% (proposed) | Monthly |
 | Time-to-production for new data products | — | — |
 | Data platform cost per TB processed | — | — |
 | Data quality score across Gold tier datasets | — | — |
 | Data governance completeness (catalogued and classified datasets %) | — | — |
 | Engineering team adoption of platform standards | — | — |
 | Data platform cost per TB of data processed (trending month-over-month vs. volume growth) | — | — |
-| ML feature pipeline production lead time (time from feature request to production availability) | — | — |
+| ML feature pipeline production lead time (time from feature request to production availability) | ≥99.9% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -145,14 +145,14 @@ The Data Platform Engineer builds, maintains, and optimises the shared data plat
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Data platform availability SLA (uptime % for Databricks, ingestion pipelines, and shared platform components) | — | — |
+| Data platform availability SLA (uptime % for Databricks, ingestion pipelines, and shared platform components) | ≥95% (proposed) | Monthly |
 | Data ingestion pipeline success rate (% of scheduled ingestion jobs completing without failure) | — | — |
 | Time-to-provision for new data engineering environments (days from request to ready, trending down) | — | — |
 | Data platform cost per TB processed (trending month-over-month vs. data volume growth) | — | — |
 | Platform-caused incident rate (number of incidents caused by shared platform failures, trending down) | — | — |
 | Lakehouse table health score (% of tables meeting compaction, freshness, and partitioning standards) | — | — |
-| Infrastructure-as-code coverage (% of data platform resources managed via Terraform) | — | — |
-| Mean time to restore (MTTR) for data platform infrastructure incidents | — | — |
+| Infrastructure-as-code coverage (% of data platform resources managed via Terraform) | ≥80% (proposed) | Monthly |
+| Mean time to restore (MTTR) for data platform infrastructure incidents | ≤4 hours (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -143,14 +143,16 @@ The Data Platform Engineer builds, maintains, and optimises the shared data plat
 
 ## Key Performance Indicators
 
-- Data platform availability SLA (uptime % for Databricks, ingestion pipelines, and shared platform components)
-- Data ingestion pipeline success rate (% of scheduled ingestion jobs completing without failure)
-- Time-to-provision for new data engineering environments (days from request to ready, trending down)
-- Data platform cost per TB processed (trending month-over-month vs. data volume growth)
-- Platform-caused incident rate (number of incidents caused by shared platform failures, trending down)
-- Lakehouse table health score (% of tables meeting compaction, freshness, and partitioning standards)
-- Infrastructure-as-code coverage (% of data platform resources managed via Terraform)
-- Mean time to restore (MTTR) for data platform infrastructure incidents
+| Metric | Target | Frequency |
+|---|---|---|
+| Data platform availability SLA (uptime % for Databricks, ingestion pipelines, and shared platform components) | — | — |
+| Data ingestion pipeline success rate (% of scheduled ingestion jobs completing without failure) | — | — |
+| Time-to-provision for new data engineering environments (days from request to ready, trending down) | — | — |
+| Data platform cost per TB processed (trending month-over-month vs. data volume growth) | — | — |
+| Platform-caused incident rate (number of incidents caused by shared platform failures, trending down) | — | — |
+| Lakehouse table health score (% of tables meeting compaction, freshness, and partitioning standards) | — | — |
+| Infrastructure-as-code coverage (% of data platform resources managed via Terraform) | — | — |
+| Mean time to restore (MTTR) for data platform infrastructure incidents | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_senior_engineer.md
+++ b/Roles/data_engineering/data_senior_engineer.md
@@ -139,12 +139,14 @@ The Data Senior Engineer leads complex data engineering initiatives, drives data
 
 ## Key Performance Indicators
 
-- Data product delivery throughput (team-level velocity)
-- Data quality test coverage across owned data domains (target: >90%)
-- Pipeline performance and cost efficiency of owned components
-- Code review coverage and quality gate adherence within team
-- Mentoring: junior engineer progression metrics
-- Reusable framework and component adoption by data engineering team
+| Metric | Target | Frequency |
+|---|---|---|
+| Data product delivery throughput (team-level velocity) | — | — |
+| Data quality test coverage across owned data domains (target: >90%) | >90% | — |
+| Pipeline performance and cost efficiency of owned components | — | — |
+| Code review coverage and quality gate adherence within team | — | — |
+| Mentoring: junior engineer progression metrics | — | — |
+| Reusable framework and component adoption by data engineering team | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -146,14 +146,14 @@ The DataOps Specialist applies DevOps and agile engineering principles to data p
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Data pipeline SLA compliance rate (% of pipelines meeting their published SLO targets) | — | — |
+| Data pipeline SLA compliance rate (% of pipelines meeting their published SLO targets) | ≥95% (proposed) | Monthly |
 | Data quality score across critical Gold tier datasets (% of dbt and Great Expectations checks passing) | — | — |
-| Pipeline MTTR (mean time to restore failed data pipelines, in hours) | — | — |
-| Deployment frequency for data pipeline changes (releases per week/month, trending up) | — | — |
+| Pipeline MTTR (mean time to restore failed data pipelines, in hours) | ≤4 hours (proposed) | Monthly |
+| Deployment frequency for data pipeline changes (releases per week/month, trending up) | Weekly or better (proposed) | Monthly |
 | Data incident volume trending (number of data quality incidents per month, trending down) | — | — |
 | Time-to-detect (TTD) for data quality anomalies (minutes/hours from issue occurrence to alert firing) | — | — |
-| Automated test coverage rate (% of transformation logic covered by automated data quality tests) | — | — |
-| Post-incident review completion rate (% of severity-1 incidents with completed PIR within SLA) | — | — |
+| Automated test coverage rate (% of transformation logic covered by automated data quality tests) | ≥80% (proposed) | Monthly |
+| Post-incident review completion rate (% of severity-1 incidents with completed PIR within SLA) | ≥95% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -144,14 +144,16 @@ The DataOps Specialist applies DevOps and agile engineering principles to data p
 
 ## Key Performance Indicators
 
-- Data pipeline SLA compliance rate (% of pipelines meeting their published SLO targets)
-- Data quality score across critical Gold tier datasets (% of dbt and Great Expectations checks passing)
-- Pipeline MTTR (mean time to restore failed data pipelines, in hours)
-- Deployment frequency for data pipeline changes (releases per week/month, trending up)
-- Data incident volume trending (number of data quality incidents per month, trending down)
-- Time-to-detect (TTD) for data quality anomalies (minutes/hours from issue occurrence to alert firing)
-- Automated test coverage rate (% of transformation logic covered by automated data quality tests)
-- Post-incident review completion rate (% of severity-1 incidents with completed PIR within SLA)
+| Metric | Target | Frequency |
+|---|---|---|
+| Data pipeline SLA compliance rate (% of pipelines meeting their published SLO targets) | — | — |
+| Data quality score across critical Gold tier datasets (% of dbt and Great Expectations checks passing) | — | — |
+| Pipeline MTTR (mean time to restore failed data pipelines, in hours) | — | — |
+| Deployment frequency for data pipeline changes (releases per week/month, trending up) | — | — |
+| Data incident volume trending (number of data quality incidents per month, trending down) | — | — |
+| Time-to-detect (TTD) for data quality anomalies (minutes/hours from issue occurrence to alert firing) | — | — |
+| Automated test coverage rate (% of transformation logic covered by automated data quality tests) | — | — |
+| Post-incident review completion rate (% of severity-1 incidents with completed PIR within SLA) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -128,16 +128,18 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of solutions with business requirements
-- Storage architecture scalability and flexibility
-- Cost efficiency of designed solutions
-- Storage performance and availability metrics
-- Adoption of reference architectures and standards
-- Reduction in architectural risks and complexity
-- Innovation in storage approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of solutions with business requirements | — | — |
+| Storage architecture scalability and flexibility | — | — |
+| Cost efficiency of designed solutions | — | — |
+| Storage performance and availability metrics | — | — |
+| Adoption of reference architectures and standards | — | — |
+| Reduction in architectural risks and complexity | — | — |
+| Innovation in storage approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -134,7 +134,7 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 | Alignment of solutions with business requirements | — | — |
 | Storage architecture scalability and flexibility | — | — |
 | Cost efficiency of designed solutions | — | — |
-| Storage performance and availability metrics | — | — |
+| Storage performance and availability metrics | ≥99.9% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
 | Reduction in architectural risks and complexity | — | — |
 | Innovation in storage approaches | — | — |

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -124,16 +124,18 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 
 ## Key Performance Indicators
 
-- Qumulo cluster availability and uptime
-- Storage provisioning accuracy and timeliness
-- Resolution time for storage incidents
-- File system performance optimization
-- Documentation quality and completeness
-- Successful execution of maintenance activities
-- Data protection implementation quality
-- User satisfaction with file services
-- Knowledge sharing and collaboration
-- Capacity utilization efficiency
+| Metric | Target | Frequency |
+|---|---|---|
+| Qumulo cluster availability and uptime | — | — |
+| Storage provisioning accuracy and timeliness | — | — |
+| Resolution time for storage incidents | — | — |
+| File system performance optimization | — | — |
+| Documentation quality and completeness | — | — |
+| Successful execution of maintenance activities | — | — |
+| Data protection implementation quality | — | — |
+| User satisfaction with file services | — | — |
+| Knowledge sharing and collaboration | — | — |
+| Capacity utilization efficiency | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -126,14 +126,14 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Qumulo cluster availability and uptime | — | — |
+| Qumulo cluster availability and uptime | ≥99.9% (proposed) | Monthly |
 | Storage provisioning accuracy and timeliness | — | — |
 | Resolution time for storage incidents | — | — |
 | File system performance optimization | — | — |
 | Documentation quality and completeness | — | — |
 | Successful execution of maintenance activities | — | — |
 | Data protection implementation quality | — | — |
-| User satisfaction with file services | — | — |
+| User satisfaction with file services | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 | Capacity utilization efficiency | — | — |
 

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -147,16 +147,18 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 
 ## Key Performance Indicators
 
-- Storage platform availability and reliability metrics
-- Capacity planning accuracy
-- Storage cost per TB efficiency metrics
-- Stakeholder satisfaction with storage services
-- Time to provision new storage resources
-- Storage service levels achievement
-- Implementation quality of storage solutions
-- Cost optimization achievements
-- Backlog health and delivery metrics
-- Innovation in storage services delivery
+| Metric | Target | Frequency |
+|---|---|---|
+| Storage platform availability and reliability metrics | — | — |
+| Capacity planning accuracy | — | — |
+| Storage cost per TB efficiency metrics | — | — |
+| Stakeholder satisfaction with storage services | — | — |
+| Time to provision new storage resources | — | — |
+| Storage service levels achievement | — | — |
+| Implementation quality of storage solutions | — | — |
+| Cost optimization achievements | — | — |
+| Backlog health and delivery metrics | — | — |
+| Innovation in storage services delivery | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -149,10 +149,10 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Storage platform availability and reliability metrics | — | — |
+| Storage platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Capacity planning accuracy | — | — |
 | Storage cost per TB efficiency metrics | — | — |
-| Stakeholder satisfaction with storage services | — | — |
+| Stakeholder satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Time to provision new storage resources | — | — |
 | Storage service levels achievement | — | — |
 | Implementation quality of storage solutions | — | — |

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -133,16 +133,18 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 
 ## Key Performance Indicators
 
-- Storage availability and reliability metrics
-- Implementation quality of storage solutions
-- Time to resolution for complex storage issues
-- Qumulo performance optimization results
-- Knowledge transfer effectiveness to engineers
-- Storage automation level and efficiency
-- Success rate of data migrations
-- Documentation quality and completeness
-- Innovation in Qumulo implementation approaches
-- Customer satisfaction with file storage services
+| Metric | Target | Frequency |
+|---|---|---|
+| Storage availability and reliability metrics | — | — |
+| Implementation quality of storage solutions | — | — |
+| Time to resolution for complex storage issues | — | — |
+| Qumulo performance optimization results | — | — |
+| Knowledge transfer effectiveness to engineers | — | — |
+| Storage automation level and efficiency | — | — |
+| Success rate of data migrations | — | — |
+| Documentation quality and completeness | — | — |
+| Innovation in Qumulo implementation approaches | — | — |
+| Customer satisfaction with file storage services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -135,7 +135,7 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Storage availability and reliability metrics | — | — |
+| Storage availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Implementation quality of storage solutions | — | — |
 | Time to resolution for complex storage issues | — | — |
 | Qumulo performance optimization results | — | — |
@@ -144,7 +144,7 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 | Success rate of data migrations | — | — |
 | Documentation quality and completeness | — | — |
 | Innovation in Qumulo implementation approaches | — | — |
-| Customer satisfaction with file storage services | — | — |
+| Customer satisfaction with file storage services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -146,7 +146,7 @@ The Storage Architect is responsible for designing and governing the organisatio
 | Storage-related incident count (trend: decreasing) | — | — |
 | Capacity forecast accuracy (target: within 10% of actuals at 6-month horizon) | 10% | — |
 | Storage cost per TB (trend: optimising) | — | — |
-| SLA compliance for storage performance tiers | — | — |
+| SLA compliance for storage performance tiers | ≥95% (proposed) | Monthly |
 | Percentage of Kubernetes persistent volumes using approved CSI/StorageClass standards | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -140,12 +140,14 @@ The Storage Architect is responsible for designing and governing the organisatio
 
 ## Key Performance Indicators
 
-- Storage utilisation efficiency (target: >70% average utilisation)
-- Storage-related incident count (trend: decreasing)
-- Capacity forecast accuracy (target: within 10% of actuals at 6-month horizon)
-- Storage cost per TB (trend: optimising)
-- SLA compliance for storage performance tiers
-- Percentage of Kubernetes persistent volumes using approved CSI/StorageClass standards
+| Metric | Target | Frequency |
+|---|---|---|
+| Storage utilisation efficiency (target: >70% average utilisation) | >70% | — |
+| Storage-related incident count (trend: decreasing) | — | — |
+| Capacity forecast accuracy (target: within 10% of actuals at 6-month horizon) | 10% | — |
+| Storage cost per TB (trend: optimising) | — | — |
+| SLA compliance for storage performance tiers | — | — |
+| Percentage of Kubernetes persistent volumes using approved CSI/StorageClass standards | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -132,7 +132,7 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Storage system availability and uptime | — | — |
+| Storage system availability and uptime | ≥99.9% (proposed) | Monthly |
 | Storage provisioning accuracy and timeliness | — | — |
 | Resolution time for storage incidents | — | — |
 | Storage utilization efficiency | — | — |
@@ -140,7 +140,7 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 | Successful execution of maintenance activities | — | — |
 | Storage performance consistency | — | — |
 | Data protection implementation quality | — | — |
-| User satisfaction with storage services | — | — |
+| User satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -130,16 +130,18 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 
 ## Key Performance Indicators
 
-- Storage system availability and uptime
-- Storage provisioning accuracy and timeliness
-- Resolution time for storage incidents
-- Storage utilization efficiency
-- Documentation quality and completeness
-- Successful execution of maintenance activities
-- Storage performance consistency
-- Data protection implementation quality
-- User satisfaction with storage services
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Storage system availability and uptime | — | — |
+| Storage provisioning accuracy and timeliness | — | — |
+| Resolution time for storage incidents | — | — |
+| Storage utilization efficiency | — | — |
+| Documentation quality and completeness | — | — |
+| Successful execution of maintenance activities | — | — |
+| Storage performance consistency | — | — |
+| Data protection implementation quality | — | — |
+| User satisfaction with storage services | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -129,16 +129,18 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 
 ## Key Performance Indicators
 
-- Storage platform availability and reliability
-- Capacity planning accuracy
-- Storage cost efficiency metrics
-- Stakeholder satisfaction with storage services
-- Time to provision new storage resources
-- Storage service levels achievement
-- Implementation quality of storage solutions
-- Cost optimization achievements
-- Backlog health and delivery metrics
-- Innovation in storage services delivery
+| Metric | Target | Frequency |
+|---|---|---|
+| Storage platform availability and reliability | — | — |
+| Capacity planning accuracy | — | — |
+| Storage cost efficiency metrics | — | — |
+| Stakeholder satisfaction with storage services | — | — |
+| Time to provision new storage resources | — | — |
+| Storage service levels achievement | — | — |
+| Implementation quality of storage solutions | — | — |
+| Cost optimization achievements | — | — |
+| Backlog health and delivery metrics | — | — |
+| Innovation in storage services delivery | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -131,10 +131,10 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Storage platform availability and reliability | — | — |
+| Storage platform availability and reliability | ≥99.9% (proposed) | Monthly |
 | Capacity planning accuracy | — | — |
 | Storage cost efficiency metrics | — | — |
-| Stakeholder satisfaction with storage services | — | — |
+| Stakeholder satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Time to provision new storage resources | — | — |
 | Storage service levels achievement | — | — |
 | Implementation quality of storage solutions | — | — |

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -129,16 +129,18 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 
 ## Key Performance Indicators
 
-- Storage environment availability and reliability
-- Storage performance optimization results
-- Implementation quality of storage solutions
-- Time to resolution for complex storage issues
-- Knowledge transfer effectiveness to storage engineers
-- Storage automation coverage and efficiency
-- Success rate of storage migrations and transitions
-- Storage capacity utilization efficiency
-- Customer satisfaction with storage services
-- Innovation in storage implementation approaches
+| Metric | Target | Frequency |
+|---|---|---|
+| Storage environment availability and reliability | — | — |
+| Storage performance optimization results | — | — |
+| Implementation quality of storage solutions | — | — |
+| Time to resolution for complex storage issues | — | — |
+| Knowledge transfer effectiveness to storage engineers | — | — |
+| Storage automation coverage and efficiency | — | — |
+| Success rate of storage migrations and transitions | — | — |
+| Storage capacity utilization efficiency | — | — |
+| Customer satisfaction with storage services | — | — |
+| Innovation in storage implementation approaches | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -131,7 +131,7 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Storage environment availability and reliability | — | — |
+| Storage environment availability and reliability | ≥99.9% (proposed) | Monthly |
 | Storage performance optimization results | — | — |
 | Implementation quality of storage solutions | — | — |
 | Time to resolution for complex storage issues | — | — |
@@ -139,7 +139,7 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 | Storage automation coverage and efficiency | — | — |
 | Success rate of storage migrations and transitions | — | — |
 | Storage capacity utilization efficiency | — | — |
-| Customer satisfaction with storage services | — | — |
+| Customer satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Innovation in storage implementation approaches | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -127,16 +127,18 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 ## Key Performance Indicators
 
-- Backup success rate improvement trends
-- Mean time to detect (MTTD) backup issues
-- Mean time to resolve (MTTR) backup failures
-- Reduction in backup incidents over time
-- Recovery testing success rates
-- Monitoring coverage for backup systems
-- Automation level of reliability processes
-- Accuracy of reliability metrics
-- SLO/SLA achievement for backup services
-- Knowledge sharing effectiveness
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate improvement trends | — | — |
+| Mean time to detect (MTTD) backup issues | — | — |
+| Mean time to resolve (MTTR) backup failures | — | — |
+| Reduction in backup incidents over time | — | — |
+| Recovery testing success rates | — | — |
+| Monitoring coverage for backup systems | — | — |
+| Automation level of reliability processes | — | — |
+| Accuracy of reliability metrics | — | — |
+| SLO/SLA achievement for backup services | — | — |
+| Knowledge sharing effectiveness | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -129,15 +129,15 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate improvement trends | — | — |
-| Mean time to detect (MTTD) backup issues | — | — |
-| Mean time to resolve (MTTR) backup failures | — | — |
+| Backup success rate improvement trends | ≥99% (proposed) | Monthly |
+| Mean time to detect (MTTD) backup issues | ≤24 hours (proposed) | Monthly |
+| Mean time to resolve (MTTR) backup failures | ≤4 hours (proposed) | Monthly |
 | Reduction in backup incidents over time | — | — |
-| Recovery testing success rates | — | — |
+| Recovery testing success rates | ≥99% (proposed) | Monthly |
 | Monitoring coverage for backup systems | — | — |
 | Automation level of reliability processes | — | — |
 | Accuracy of reliability metrics | — | — |
-| SLO/SLA achievement for backup services | — | — |
+| SLO/SLA achievement for backup services | ≥95% (proposed) | Monthly |
 | Knowledge sharing effectiveness | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -128,16 +128,18 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of solutions with business requirements
-- Backup architecture scalability and flexibility
-- Cost efficiency of designed solutions
-- Recovery capabilities meeting or exceeding SLAs
-- Adoption of reference architectures and standards
-- Reduction in architectural risks and complexity
-- Innovation in data protection approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of solutions with business requirements | — | — |
+| Backup architecture scalability and flexibility | — | — |
+| Cost efficiency of designed solutions | — | — |
+| Recovery capabilities meeting or exceeding SLAs | — | — |
+| Adoption of reference architectures and standards | — | — |
+| Reduction in architectural risks and complexity | — | — |
+| Innovation in data protection approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -130,8 +130,8 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate percentage | — | — |
-| Time to restore data when requested | — | — |
+| Backup success rate percentage | ≥99% (proposed) | Monthly |
+| Time to restore data when requested | ≤4 hours (proposed) | Monthly |
 | Compliance with backup window requirements | — | — |
 | Storage efficiency metrics (compression, deduplication) | — | — |
 | Agent deployment success rate | — | — |
@@ -139,7 +139,7 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 | Documentation quality and completeness | — | — |
 | Backup storage utilization management | — | — |
 | Successful completion of scheduled maintenance | — | — |
-| User satisfaction with restore services | — | — |
+| User satisfaction with restore services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -128,16 +128,18 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 
 ## Key Performance Indicators
 
-- Backup success rate percentage
-- Time to restore data when requested
-- Compliance with backup window requirements
-- Storage efficiency metrics (compression, deduplication)
-- Agent deployment success rate
-- Problem resolution time for backup failures
-- Documentation quality and completeness
-- Backup storage utilization management
-- Successful completion of scheduled maintenance
-- User satisfaction with restore services
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate percentage | — | — |
+| Time to restore data when requested | — | — |
+| Compliance with backup window requirements | — | — |
+| Storage efficiency metrics (compression, deduplication) | — | — |
+| Agent deployment success rate | — | — |
+| Problem resolution time for backup failures | — | — |
+| Documentation quality and completeness | — | — |
+| Backup storage utilization management | — | — |
+| Successful completion of scheduled maintenance | — | — |
+| User satisfaction with restore services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -145,16 +145,18 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 
 ## Key Performance Indicators
 
-- Backup success rate percentage
-- Recovery time objective (RTO) achievements
-- Recovery point objective (RPO) achievements
-- Stakeholder satisfaction with data protection services
-- Backup compliance and audit readiness
-- Data protection cost efficiency
-- Storage optimization metrics (deduplication ratios)
-- Successful delivery of backup roadmap items
-- Implementation of backup automation
-- Backup platform availability and reliability
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate percentage | — | — |
+| Recovery time objective (RTO) achievements | — | — |
+| Recovery point objective (RPO) achievements | — | — |
+| Stakeholder satisfaction with data protection services | — | — |
+| Backup compliance and audit readiness | — | — |
+| Data protection cost efficiency | — | — |
+| Storage optimization metrics (deduplication ratios) | — | — |
+| Successful delivery of backup roadmap items | — | — |
+| Implementation of backup automation | — | — |
+| Backup platform availability and reliability | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -147,16 +147,16 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate percentage | — | — |
+| Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievements | — | — |
 | Recovery point objective (RPO) achievements | — | — |
-| Stakeholder satisfaction with data protection services | — | — |
+| Stakeholder satisfaction with data protection services | ≥85% (proposed) | Quarterly |
 | Backup compliance and audit readiness | — | — |
 | Data protection cost efficiency | — | — |
 | Storage optimization metrics (deduplication ratios) | — | — |
 | Successful delivery of backup roadmap items | — | — |
 | Implementation of backup automation | — | — |
-| Backup platform availability and reliability | — | — |
+| Backup platform availability and reliability | ≥99.9% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -127,16 +127,18 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 
 ## Key Performance Indicators
 
-- Backup success rate and reliability
-- Recovery time objective (RTO) achievement
-- Recovery point objective (RPO) achievement
-- Backup window optimization
-- Implementation quality of data protection solutions
-- Time to resolution for complex backup incidents
-- Knowledge transfer effectiveness to junior engineers
-- Automation level of backup operations
-- Successful recovery testing completion rates
-- Storage efficiency metrics (deduplication, compression)
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate and reliability | — | — |
+| Recovery time objective (RTO) achievement | — | — |
+| Recovery point objective (RPO) achievement | — | — |
+| Backup window optimization | — | — |
+| Implementation quality of data protection solutions | — | — |
+| Time to resolution for complex backup incidents | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Automation level of backup operations | — | — |
+| Successful recovery testing completion rates | — | — |
+| Storage efficiency metrics (deduplication, compression) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -129,7 +129,7 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate and reliability | — | — |
+| Backup success rate and reliability | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievement | — | — |
 | Recovery point objective (RPO) achievement | — | — |
 | Backup window optimization | — | — |
@@ -137,7 +137,7 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 | Time to resolution for complex backup incidents | — | — |
 | Knowledge transfer effectiveness to junior engineers | — | — |
 | Automation level of backup operations | — | — |
-| Successful recovery testing completion rates | — | — |
+| Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Storage efficiency metrics (deduplication, compression) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -127,16 +127,18 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of solutions with business requirements
-- Backup architecture scalability and flexibility
-- Cost efficiency of designed solutions
-- Recovery capabilities meeting or exceeding SLAs
-- Adoption of reference architectures and standards
-- Reduction in data protection architectural risks
-- Innovation in backup approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of solutions with business requirements | — | — |
+| Backup architecture scalability and flexibility | — | — |
+| Cost efficiency of designed solutions | — | — |
+| Recovery capabilities meeting or exceeding SLAs | — | — |
+| Adoption of reference architectures and standards | — | — |
+| Reduction in data protection architectural risks | — | — |
+| Innovation in backup approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -122,16 +122,18 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 
 ## Key Performance Indicators
 
-- Backup success rate percentage
-- Backup completion within scheduled windows
-- Recovery time performance
-- Accurate implementation of backup policies
-- Documentation quality and completeness
-- Response time to backup failures
-- Recovery testing success rates
-- Adherence to data retention requirements
-- User satisfaction with backup/recovery services
-- Efficiency of storage utilization for backups
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate percentage | — | — |
+| Backup completion within scheduled windows | — | — |
+| Recovery time performance | — | — |
+| Accurate implementation of backup policies | — | — |
+| Documentation quality and completeness | — | — |
+| Response time to backup failures | — | — |
+| Recovery testing success rates | — | — |
+| Adherence to data retention requirements | — | — |
+| User satisfaction with backup/recovery services | — | — |
+| Efficiency of storage utilization for backups | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -124,15 +124,15 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate percentage | — | — |
+| Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Backup completion within scheduled windows | — | — |
 | Recovery time performance | — | — |
 | Accurate implementation of backup policies | — | — |
 | Documentation quality and completeness | — | — |
 | Response time to backup failures | — | — |
-| Recovery testing success rates | — | — |
+| Recovery testing success rates | ≥99% (proposed) | Monthly |
 | Adherence to data retention requirements | — | — |
-| User satisfaction with backup/recovery services | — | — |
+| User satisfaction with backup/recovery services | ≥85% (proposed) | Quarterly |
 | Efficiency of storage utilization for backups | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -139,12 +139,12 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate percentage | — | — |
+| Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievements | — | — |
 | Recovery point objective (RPO) achievements | — | — |
-| Stakeholder satisfaction with recovery capabilities | — | — |
+| Stakeholder satisfaction with recovery capabilities | ≥85% (proposed) | Quarterly |
 | Data protection compliance scores | — | — |
-| Successful recovery testing completion rates | — | — |
+| Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Backup storage efficiency metrics | — | — |
 | Incident reduction in backup operations | — | — |
 | Implementation of backup automation | — | — |

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -137,16 +137,18 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 
 ## Key Performance Indicators
 
-- Backup success rate percentage
-- Recovery time objective (RTO) achievements
-- Recovery point objective (RPO) achievements
-- Stakeholder satisfaction with recovery capabilities
-- Data protection compliance scores
-- Successful recovery testing completion rates
-- Backup storage efficiency metrics
-- Incident reduction in backup operations
-- Implementation of backup automation
-- Cross-team collaboration effectiveness
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate percentage | — | — |
+| Recovery time objective (RTO) achievements | — | — |
+| Recovery point objective (RPO) achievements | — | — |
+| Stakeholder satisfaction with recovery capabilities | — | — |
+| Data protection compliance scores | — | — |
+| Successful recovery testing completion rates | — | — |
+| Backup storage efficiency metrics | — | — |
+| Incident reduction in backup operations | — | — |
+| Implementation of backup automation | — | — |
+| Cross-team collaboration effectiveness | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -125,7 +125,7 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate and reliability metrics | — | — |
+| Backup success rate and reliability metrics | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievement | — | — |
 | Recovery point objective (RPO) achievement | — | — |
 | Backup storage efficiency (deduplication ratios) | — | — |
@@ -133,7 +133,7 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 | Time to resolution for complex backup incidents | — | — |
 | Knowledge transfer effectiveness to junior engineers | — | — |
 | Automation level of backup operations | — | — |
-| Successful recovery testing completion rates | — | — |
+| Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Business continuity improvement metrics | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -123,16 +123,18 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 
 ## Key Performance Indicators
 
-- Backup success rate and reliability metrics
-- Recovery time objective (RTO) achievement
-- Recovery point objective (RPO) achievement
-- Backup storage efficiency (deduplication ratios)
-- Implementation quality of data protection solutions
-- Time to resolution for complex backup incidents
-- Knowledge transfer effectiveness to junior engineers
-- Automation level of backup operations
-- Successful recovery testing completion rates
-- Business continuity improvement metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Backup success rate and reliability metrics | — | — |
+| Recovery time objective (RTO) achievement | — | — |
+| Recovery point objective (RPO) achievement | — | — |
+| Backup storage efficiency (deduplication ratios) | — | — |
+| Implementation quality of data protection solutions | — | — |
+| Time to resolution for complex backup incidents | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Automation level of backup operations | — | — |
+| Successful recovery testing completion rates | — | — |
+| Business continuity improvement metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -129,16 +129,18 @@ The Database Architect designs comprehensive data management strategies and arch
 
 ## Key Performance Indicators
 
-- Database architecture design quality and effectiveness
-- Alignment of database designs with business requirements
-- Database performance, scalability, and reliability
-- Data security and compliance framework effectiveness
-- Adoption of database reference architectures and patterns
-- Reduction in data-related architectural risks
-- Database modernization progress and benefits
-- Innovation in data management approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Database architecture design quality and effectiveness | — | — |
+| Alignment of database designs with business requirements | — | — |
+| Database performance, scalability, and reliability | — | — |
+| Data security and compliance framework effectiveness | — | — |
+| Adoption of database reference architectures and patterns | — | — |
+| Reduction in data-related architectural risks | — | — |
+| Database modernization progress and benefits | — | — |
+| Innovation in data management approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -136,16 +136,18 @@ The Database Engineer implements and maintains database systems across the organ
 
 ## Key Performance Indicators
 
-- Database availability and uptime metrics
-- Database backup success rate
-- Query performance and optimization
-- Time to resolve database incidents
-- Database patch compliance percentage
-- Documentation quality and completeness
-- User satisfaction with database services
-- Implementation quality of standard configurations
-- Security compliance with database policies
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Database availability and uptime metrics | — | — |
+| Database backup success rate | — | — |
+| Query performance and optimization | — | — |
+| Time to resolve database incidents | — | — |
+| Database patch compliance percentage | — | — |
+| Documentation quality and completeness | — | — |
+| User satisfaction with database services | — | — |
+| Implementation quality of standard configurations | — | — |
+| Security compliance with database policies | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -138,13 +138,13 @@ The Database Engineer implements and maintains database systems across the organ
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Database availability and uptime metrics | — | — |
-| Database backup success rate | — | — |
+| Database availability and uptime metrics | ≥99.9% (proposed) | Monthly |
+| Database backup success rate | ≥99% (proposed) | Monthly |
 | Query performance and optimization | — | — |
 | Time to resolve database incidents | — | — |
-| Database patch compliance percentage | — | — |
+| Database patch compliance percentage | ≥95% (proposed) | Monthly |
 | Documentation quality and completeness | — | — |
-| User satisfaction with database services | — | — |
+| User satisfaction with database services | ≥85% (proposed) | Quarterly |
 | Implementation quality of standard configurations | — | — |
 | Security compliance with database policies | — | — |
 | Knowledge sharing and collaboration | — | — |

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -145,16 +145,18 @@ The Database Product Owner manages the portfolio of database platforms and data 
 
 ## Key Performance Indicators
 
-- Database platform availability and reliability metrics
-- Query performance optimization results
-- Time to provision new database environments
-- Database incident reduction trends
-- Cost efficiency of database resources
-- Successful delivery of database roadmap items
-- Stakeholder satisfaction with database services
-- Database automation and self-service capabilities
-- Backup and recovery effectiveness metrics
-- Database security compliance scores
+| Metric | Target | Frequency |
+|---|---|---|
+| Database platform availability and reliability metrics | — | — |
+| Query performance optimization results | — | — |
+| Time to provision new database environments | — | — |
+| Database incident reduction trends | — | — |
+| Cost efficiency of database resources | — | — |
+| Successful delivery of database roadmap items | — | — |
+| Stakeholder satisfaction with database services | — | — |
+| Database automation and self-service capabilities | — | — |
+| Backup and recovery effectiveness metrics | — | — |
+| Database security compliance scores | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -147,13 +147,13 @@ The Database Product Owner manages the portfolio of database platforms and data 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Database platform availability and reliability metrics | — | — |
+| Database platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Query performance optimization results | — | — |
 | Time to provision new database environments | — | — |
 | Database incident reduction trends | — | — |
 | Cost efficiency of database resources | — | — |
 | Successful delivery of database roadmap items | — | — |
-| Stakeholder satisfaction with database services | — | — |
+| Stakeholder satisfaction with database services | ≥85% (proposed) | Quarterly |
 | Database automation and self-service capabilities | — | — |
 | Backup and recovery effectiveness metrics | — | — |
 | Database security compliance scores | — | — |

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -129,16 +129,18 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 
 ## Key Performance Indicators
 
-- Database uptime and availability metrics
-- Mean time to detect (MTTD) database issues
-- Mean time to resolve (MTTR) database failures
-- Query performance optimization results
-- Successful automated recovery percentage
-- Reduction in database incidents over time
-- Database scaling effectiveness
-- Automated operations percentage
-- SLO/SLA achievement for database services
-- Knowledge sharing effectiveness
+| Metric | Target | Frequency |
+|---|---|---|
+| Database uptime and availability metrics | — | — |
+| Mean time to detect (MTTD) database issues | — | — |
+| Mean time to resolve (MTTR) database failures | — | — |
+| Query performance optimization results | — | — |
+| Successful automated recovery percentage | — | — |
+| Reduction in database incidents over time | — | — |
+| Database scaling effectiveness | — | — |
+| Automated operations percentage | — | — |
+| SLO/SLA achievement for database services | — | — |
+| Knowledge sharing effectiveness | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -131,15 +131,15 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Database uptime and availability metrics | — | — |
-| Mean time to detect (MTTD) database issues | — | — |
-| Mean time to resolve (MTTR) database failures | — | — |
+| Database uptime and availability metrics | ≥99.9% (proposed) | Monthly |
+| Mean time to detect (MTTD) database issues | ≤24 hours (proposed) | Monthly |
+| Mean time to resolve (MTTR) database failures | ≤4 hours (proposed) | Monthly |
 | Query performance optimization results | — | — |
 | Successful automated recovery percentage | — | — |
 | Reduction in database incidents over time | — | — |
 | Database scaling effectiveness | — | — |
 | Automated operations percentage | — | — |
-| SLO/SLA achievement for database services | — | — |
+| SLO/SLA achievement for database services | ≥95% (proposed) | Monthly |
 | Knowledge sharing effectiveness | — | — |
 
 ## Remote Work Considerations

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -133,16 +133,18 @@ The Database Senior Engineer leads the implementation and optimization of comple
 
 ## Key Performance Indicators
 
-- Database availability and performance metrics
-- Query performance optimization results
-- Implementation quality of database solutions
-- Mean time to resolution for critical database issues
-- Knowledge transfer effectiveness to database engineers
-- Automation coverage for database operations
-- Success rate of database migrations
-- Reduction in database-related incidents
-- Security compliance scores for database environments
-- Data integrity and recoverability metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Database availability and performance metrics | — | — |
+| Query performance optimization results | — | — |
+| Implementation quality of database solutions | — | — |
+| Mean time to resolution for critical database issues | — | — |
+| Knowledge transfer effectiveness to database engineers | — | — |
+| Automation coverage for database operations | — | — |
+| Success rate of database migrations | — | — |
+| Reduction in database-related incidents | — | — |
+| Security compliance scores for database environments | — | — |
+| Data integrity and recoverability metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -135,7 +135,7 @@ The Database Senior Engineer leads the implementation and optimization of comple
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Database availability and performance metrics | — | — |
+| Database availability and performance metrics | ≥99.9% (proposed) | Monthly |
 | Query performance optimization results | — | — |
 | Implementation quality of database solutions | — | — |
 | Mean time to resolution for critical database issues | — | — |

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -155,12 +155,12 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 |---|---|---|
 | **Framework adoption rate** — percentage of engineering teams actively consuming at least one shared framework or library (target: continuous growth quarter-over-quarter) | — | — |
 | **Time saved per automation task** — measured via consumer surveys or telemetry comparing framework-enabled vs. bespoke automation build time | — | — |
-| **Test coverage enabled** — aggregate test coverage attributable to shared test frameworks across consuming repositories | — | — |
+| **Test coverage enabled** — aggregate test coverage attributable to shared test frameworks across consuming repositories | ≥80% (proposed) | Monthly |
 | **Framework defect rate** — number of production defects or breaking regressions introduced per framework release, tracked per quarter | — | — |
 | **Onboarding time to first automation** — median time for a new consumer team to go from zero to first passing automation run using a shared framework | — | — |
 | **Reusable workflow adoption** — percentage of CI/CD pipelines in the organisation referencing shared GitHub Actions reusable workflows rather than duplicated inline definitions | — | — |
 | **Documentation completeness** — percentage of published framework components with up-to-date usage documentation and at least one worked example | — | — |
-| **Consumer satisfaction** — periodic NPS or satisfaction score from engineering teams who consume the automation frameworks | — | — |
+| **Consumer satisfaction** — periodic NPS or satisfaction score from engineering teams who consume the automation frameworks | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -151,14 +151,16 @@ The Automation Framework Engineer designs, builds, and maintains the reusable au
 
 ## Key Performance Indicators
 
-- **Framework adoption rate** — percentage of engineering teams actively consuming at least one shared framework or library (target: continuous growth quarter-over-quarter)
-- **Time saved per automation task** — measured via consumer surveys or telemetry comparing framework-enabled vs. bespoke automation build time
-- **Test coverage enabled** — aggregate test coverage attributable to shared test frameworks across consuming repositories
-- **Framework defect rate** — number of production defects or breaking regressions introduced per framework release, tracked per quarter
-- **Onboarding time to first automation** — median time for a new consumer team to go from zero to first passing automation run using a shared framework
-- **Reusable workflow adoption** — percentage of CI/CD pipelines in the organisation referencing shared GitHub Actions reusable workflows rather than duplicated inline definitions
-- **Documentation completeness** — percentage of published framework components with up-to-date usage documentation and at least one worked example
-- **Consumer satisfaction** — periodic NPS or satisfaction score from engineering teams who consume the automation frameworks
+| Metric | Target | Frequency |
+|---|---|---|
+| **Framework adoption rate** — percentage of engineering teams actively consuming at least one shared framework or library (target: continuous growth quarter-over-quarter) | — | — |
+| **Time saved per automation task** — measured via consumer surveys or telemetry comparing framework-enabled vs. bespoke automation build time | — | — |
+| **Test coverage enabled** — aggregate test coverage attributable to shared test frameworks across consuming repositories | — | — |
+| **Framework defect rate** — number of production defects or breaking regressions introduced per framework release, tracked per quarter | — | — |
+| **Onboarding time to first automation** — median time for a new consumer team to go from zero to first passing automation run using a shared framework | — | — |
+| **Reusable workflow adoption** — percentage of CI/CD pipelines in the organisation referencing shared GitHub Actions reusable workflows rather than duplicated inline definitions | — | — |
+| **Documentation completeness** — percentage of published framework components with up-to-date usage documentation and at least one worked example | — | — |
+| **Consumer satisfaction** — periodic NPS or satisfaction score from engineering teams who consume the automation frameworks | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/devops/developer_experience_engineer.md
+++ b/Roles/devops/developer_experience_engineer.md
@@ -139,14 +139,16 @@ The Developer Experience Engineer designs, builds, and operates internal develop
 
 ## Key Performance Indicators
 
-- Deployment frequency improvement across teams using IDP golden paths: target ≥20% increase year-on-year
-- Lead time for changes for teams onboarded to golden paths: target ≤1 day median lead time for standard service changes
-- IDP self-service adoption rate: ≥70% of new services onboarded via golden path templates within 6 months
-- Developer satisfaction score (SPACE survey or equivalent): ≥4.0/5.0 for platform tooling satisfaction
-- Mean time to onboard a new service to the IDP: target ≤3 business days end-to-end
-- Number of manual platform requests (tickets, Slack requests) eliminated per quarter through self-service automation
-- Golden path template coverage: ≥80% of supported application archetypes covered by maintained golden paths
-- Platform tooling incident rate: fewer than 2 developer-impacting IDP outages per quarter
+| Metric | Target | Frequency |
+|---|---|---|
+| Deployment frequency improvement across teams using IDP golden paths: target ≥20% increase year-on-year | ≥20% | — |
+| Lead time for changes for teams onboarded to golden paths: target ≤1 day median lead time for standard service changes | ≤1 day | — |
+| IDP self-service adoption rate: ≥70% of new services onboarded via golden path templates within 6 months | ≥70% | — |
+| Developer satisfaction score (SPACE survey or equivalent): ≥4.0/5.0 for platform tooling satisfaction | ≥4.0 | — |
+| Mean time to onboard a new service to the IDP: target ≤3 business days end-to-end | ≤3 business days | — |
+| Number of manual platform requests (tickets, Slack requests) eliminated per quarter through self-service automation | — | — |
+| Golden path template coverage: ≥80% of supported application archetypes covered by maintained golden paths | ≥80% | — |
+| Platform tooling incident rate: fewer than 2 developer-impacting IDP outages per quarter | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -143,7 +143,7 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 | Number of novel pipeline patterns adopted and operationalized per quarter; percentage of teams using self-service golden path tooling | — | — |
 | Technical leadership effectiveness | — | — |
 | Knowledge transfer to engineering teams | — | — |
-| Improvement in delivery metrics (lead time, MTTR, etc.) | — | — |
+| Improvement in delivery metrics (lead time, MTTR, etc.) | ≤4 hours (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -132,16 +132,18 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of DevOps designs with business requirements
-- Delivery pipeline efficiency and reliability
-- Security integration in DevOps workflows
-- Adoption of DevOps reference architectures and patterns
-- Reduction in delivery-related incidents
-- Number of novel pipeline patterns adopted and operationalized per quarter; percentage of teams using self-service golden path tooling
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
-- Improvement in delivery metrics (lead time, MTTR, etc.)
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of DevOps designs with business requirements | — | — |
+| Delivery pipeline efficiency and reliability | — | — |
+| Security integration in DevOps workflows | — | — |
+| Adoption of DevOps reference architectures and patterns | — | — |
+| Reduction in delivery-related incidents | — | — |
+| Number of novel pipeline patterns adopted and operationalized per quarter; percentage of teams using self-service golden path tooling | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
+| Improvement in delivery metrics (lead time, MTTR, etc.) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -110,12 +110,14 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 
 ## Key Performance Indicators
 
-- Reliability and performance of CI/CD pipelines
-- Time to resolve pipeline and automation issues
-- Quality of DevOps documentation and runbooks
-- Successful implementation of standard pipeline patterns
-- Effectiveness of deployment automation
-- Support responsiveness to development teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Reliability and performance of CI/CD pipelines | — | — |
+| Time to resolve pipeline and automation issues | — | — |
+| Quality of DevOps documentation and runbooks | — | — |
+| Successful implementation of standard pipeline patterns | — | — |
+| Effectiveness of deployment automation | — | — |
+| Support responsiveness to development teams | — | — |
 
 ## Key Technologies
 

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -109,12 +109,14 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 
 ## Key Performance Indicators
 
-- DevOps platform adoption rates across teams
-- Successful delivery of roadmap initiatives
-- Stakeholder satisfaction with DevOps services
-- Quality of backlog management and prioritization
-- Measurable improvement in software delivery metrics
-- Effectiveness of DevOps training and enablement programs
+| Metric | Target | Frequency |
+|---|---|---|
+| DevOps platform adoption rates across teams | — | — |
+| Successful delivery of roadmap initiatives | — | — |
+| Stakeholder satisfaction with DevOps services | — | — |
+| Quality of backlog management and prioritization | — | — |
+| Measurable improvement in software delivery metrics | — | — |
+| Effectiveness of DevOps training and enablement programs | — | — |
 
 ## Key Technologies
 

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -113,7 +113,7 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 |---|---|---|
 | DevOps platform adoption rates across teams | — | — |
 | Successful delivery of roadmap initiatives | — | — |
-| Stakeholder satisfaction with DevOps services | — | — |
+| Stakeholder satisfaction with DevOps services | ≥85% (proposed) | Quarterly |
 | Quality of backlog management and prioritization | — | — |
 | Measurable improvement in software delivery metrics | — | — |
 | Effectiveness of DevOps training and enablement programs | — | — |

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -113,13 +113,15 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 
 ## Key Performance Indicators
 
-- Successful implementation of advanced DevOps solutions
-- Improvements in deployment frequency and reliability
-- Quality of pipeline templates and reusable components
-- Effectiveness of self-service DevOps capabilities
-- Quality of technical leadership and mentorship
-- Contribution to DevOps standards and best practices
-- Innovation in delivery automation approaches
+| Metric | Target | Frequency |
+|---|---|---|
+| Successful implementation of advanced DevOps solutions | — | — |
+| Improvements in deployment frequency and reliability | — | — |
+| Quality of pipeline templates and reusable components | — | — |
+| Effectiveness of self-service DevOps capabilities | — | — |
+| Quality of technical leadership and mentorship | — | — |
+| Contribution to DevOps standards and best practices | — | — |
+| Innovation in delivery automation approaches | — | — |
 
 ## Key Technologies
 

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -116,7 +116,7 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 | Metric | Target | Frequency |
 |---|---|---|
 | Successful implementation of advanced DevOps solutions | — | — |
-| Improvements in deployment frequency and reliability | — | — |
+| Improvements in deployment frequency and reliability | Weekly or better (proposed) | Monthly |
 | Quality of pipeline templates and reusable components | — | — |
 | Effectiveness of self-service DevOps capabilities | — | — |
 | Quality of technical leadership and mentorship | — | — |

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -139,14 +139,16 @@ The Platform Reliability Engineer applies site reliability engineering (SRE) pri
 
 ## Key Performance Indicators
 
-- Platform SLO achievement rate: ≥99% of defined platform SLOs met per quarter across CI/CD infrastructure, developer portal, and self-service APIs
-- Mean time to recover (MTTR) for platform P1/P2 incidents: target ≤30 minutes for CI/CD infrastructure, ≤60 minutes for developer portal
-- Platform error budget burn rate: no service consuming more than 50% of monthly error budget without a reliability improvement plan in place
-- Chaos engineering coverage: ≥80% of critical platform components validated by at least one chaos experiment per quarter
-- Developer-reported platform reliability satisfaction score: ≥4.0/5.0 on internal developer platform surveys
-- Post-incident review completion rate: 100% of P1/P2 platform incidents have a published blameless review within 5 business days
-- Runbook coverage: ≥90% of paging alerts have an associated runbook linked in the alert annotation
-- Platform-caused deployment failures: fewer than 5 confirmed platform-originated deployment failures per month across all teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Platform SLO achievement rate: ≥99% of defined platform SLOs met per quarter across CI/CD infrastructure, developer portal, and self-service APIs | ≥99% | — |
+| Mean time to recover (MTTR) for platform P1/P2 incidents: target ≤30 minutes for CI/CD infrastructure, ≤60 minutes for developer portal | ≤30 minutes | — |
+| Platform error budget burn rate: no service consuming more than 50% of monthly error budget without a reliability improvement plan in place | 50% | Monthly |
+| Chaos engineering coverage: ≥80% of critical platform components validated by at least one chaos experiment per quarter | ≥80% | — |
+| Developer-reported platform reliability satisfaction score: ≥4.0/5.0 on internal developer platform surveys | ≥4.0 | — |
+| Post-incident review completion rate: 100% of P1/P2 platform incidents have a published blameless review within 5 business days | 100% | — |
+| Runbook coverage: ≥90% of paging alerts have an associated runbook linked in the alert annotation | ≥90% | — |
+| Platform-caused deployment failures: fewer than 5 confirmed platform-originated deployment failures per month across all teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -123,16 +123,18 @@ The Windows Active Directory Architect designs AD structure, security models, an
 
 ## Key Performance Indicators
 
-- Success of Active Directory design implementations
-- Availability and reliability of directory services
-- Security posture of AD infrastructure
-- Adoption of AD standards and best practices
-- Quality of architecture documentation
-- Time-to-resolution for complex AD design issues
-- Successful completion of AD migrations
-- Business satisfaction with identity infrastructure
-- Reduction in security incidents related to directory services
-- Knowledge transfer effectiveness to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Success of Active Directory design implementations | — | — |
+| Availability and reliability of directory services | — | — |
+| Security posture of AD infrastructure | — | — |
+| Adoption of AD standards and best practices | — | — |
+| Quality of architecture documentation | — | — |
+| Time-to-resolution for complex AD design issues | — | — |
+| Successful completion of AD migrations | — | — |
+| Business satisfaction with identity infrastructure | — | — |
+| Reduction in security incidents related to directory services | — | — |
+| Knowledge transfer effectiveness to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -126,13 +126,13 @@ The Windows Active Directory Architect designs AD structure, security models, an
 | Metric | Target | Frequency |
 |---|---|---|
 | Success of Active Directory design implementations | — | — |
-| Availability and reliability of directory services | — | — |
+| Availability and reliability of directory services | ≥99.9% (proposed) | Monthly |
 | Security posture of AD infrastructure | — | — |
 | Adoption of AD standards and best practices | — | — |
 | Quality of architecture documentation | — | — |
 | Time-to-resolution for complex AD design issues | — | — |
 | Successful completion of AD migrations | — | — |
-| Business satisfaction with identity infrastructure | — | — |
+| Business satisfaction with identity infrastructure | ≥85% (proposed) | Quarterly |
 | Reduction in security incidents related to directory services | — | — |
 | Knowledge transfer effectiveness to engineering teams | — | — |
 

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -130,15 +130,15 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Active Directory availability and uptime | — | — |
+| Active Directory availability and uptime | ≥99.9% (proposed) | Monthly |
 | User provisioning and deprovisioning efficiency | — | — |
 | Group Policy implementation accuracy | — | — |
-| Directory service backup success rate | — | — |
+| Directory service backup success rate | ≥99% (proposed) | Monthly |
 | Time to resolve Active Directory incidents | — | — |
 | Documentation quality and completeness | — | — |
 | Active Directory security posture | — | — |
 | Successful implementation of directory standards | — | — |
-| User satisfaction with identity services | — | — |
+| User satisfaction with identity services | ≥85% (proposed) | Quarterly |
 | Domain controller health and performance | — | — |
 
 ## Remote Work Considerations

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -128,16 +128,18 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 
 ## Key Performance Indicators
 
-- Active Directory availability and uptime
-- User provisioning and deprovisioning efficiency
-- Group Policy implementation accuracy
-- Directory service backup success rate
-- Time to resolve Active Directory incidents
-- Documentation quality and completeness
-- Active Directory security posture
-- Successful implementation of directory standards
-- User satisfaction with identity services
-- Domain controller health and performance
+| Metric | Target | Frequency |
+|---|---|---|
+| Active Directory availability and uptime | — | — |
+| User provisioning and deprovisioning efficiency | — | — |
+| Group Policy implementation accuracy | — | — |
+| Directory service backup success rate | — | — |
+| Time to resolve Active Directory incidents | — | — |
+| Documentation quality and completeness | — | — |
+| Active Directory security posture | — | — |
+| Successful implementation of directory standards | — | — |
+| User satisfaction with identity services | — | — |
+| Domain controller health and performance | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -123,16 +123,18 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 
 ## Key Performance Indicators
 
-- Active Directory availability and reliability
-- Authentication success rates
-- Directory services incident reduction
-- Group Policy implementation effectiveness
-- Time to provision/deprovision user accounts
-- Directory security compliance scores
-- Stakeholder satisfaction with AD services
-- Successful delivery of AD roadmap items
-- AD automation level achievement
-- Knowledge sharing and training effectiveness
+| Metric | Target | Frequency |
+|---|---|---|
+| Active Directory availability and reliability | — | — |
+| Authentication success rates | — | — |
+| Directory services incident reduction | — | — |
+| Group Policy implementation effectiveness | — | — |
+| Time to provision/deprovision user accounts | — | — |
+| Directory security compliance scores | — | — |
+| Stakeholder satisfaction with AD services | — | — |
+| Successful delivery of AD roadmap items | — | — |
+| AD automation level achievement | — | — |
+| Knowledge sharing and training effectiveness | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -125,13 +125,13 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Active Directory availability and reliability | — | — |
+| Active Directory availability and reliability | ≥99.9% (proposed) | Monthly |
 | Authentication success rates | — | — |
 | Directory services incident reduction | — | — |
 | Group Policy implementation effectiveness | — | — |
 | Time to provision/deprovision user accounts | — | — |
 | Directory security compliance scores | — | — |
-| Stakeholder satisfaction with AD services | — | — |
+| Stakeholder satisfaction with AD services | ≥85% (proposed) | Quarterly |
 | Successful delivery of AD roadmap items | — | — |
 | AD automation level achievement | — | — |
 | Knowledge sharing and training effectiveness | — | — |

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -125,7 +125,7 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Directory services availability and reliability | — | — |
+| Directory services availability and reliability | ≥99.9% (proposed) | Monthly |
 | Authentication system performance metrics | — | — |
 | Security compliance scores for directory services | — | — |
 | Implementation quality of AD projects | — | — |

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -123,16 +123,18 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 
 ## Key Performance Indicators
 
-- Directory services availability and reliability
-- Authentication system performance metrics
-- Security compliance scores for directory services
-- Implementation quality of AD projects
-- Mean time to resolution for complex AD incidents
-- Knowledge transfer effectiveness to junior engineers
-- Automation level of AD management tasks
-- Success rate of AD migrations and upgrades
-- Reduction in security vulnerabilities through hardening
-- Timely implementation of directory service enhancements
+| Metric | Target | Frequency |
+|---|---|---|
+| Directory services availability and reliability | — | — |
+| Authentication system performance metrics | — | — |
+| Security compliance scores for directory services | — | — |
+| Implementation quality of AD projects | — | — |
+| Mean time to resolution for complex AD incidents | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Automation level of AD management tasks | — | — |
+| Success rate of AD migrations and upgrades | — | — |
+| Reduction in security vulnerabilities through hardening | — | — |
+| Timely implementation of directory service enhancements | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/endpoint_management/endpoint_management_architect.md
+++ b/Roles/endpoint_management/endpoint_management_architect.md
@@ -144,12 +144,14 @@ The Endpoint Management Architect is responsible for the strategic design, gover
 
 ## Key Performance Indicators
 
-- Device compliance rate across managed estate (target: >98%)
-- Critical patch deployment time (target: <72 hours for critical CVEs)
-- Autopilot/zero-touch provisioning success rate (target: >95%)
-- Percentage of devices managed cloud-native via Intune (migration progress metric)
-- Helpdesk tickets related to endpoint management (trend: decreasing)
-- Security baseline policy coverage across endpoint fleet
+| Metric | Target | Frequency |
+|---|---|---|
+| Device compliance rate across managed estate (target: >98%) | >98% | — |
+| Critical patch deployment time (target: <72 hours for critical CVEs) | <72 hours | — |
+| Autopilot/zero-touch provisioning success rate (target: >95%) | >95% | — |
+| Percentage of devices managed cloud-native via Intune (migration progress metric) | — | — |
+| Helpdesk tickets related to endpoint management (trend: decreasing) | — | — |
+| Security baseline policy coverage across endpoint fleet | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -135,7 +135,7 @@ The Endpoint Management Engineer administers and maintains the organisation's en
 | Metric | Target | Frequency |
 |---|---|---|
 | Device compliance rate on assigned platforms | — | — |
-| Patch deployment success rate within SLA | — | — |
+| Patch deployment success rate within SLA | ≥95% (proposed) | Monthly |
 | Application deployment success rate | — | — |
 | Help desk escalation response and resolution time | — | — |
 | Accuracy and completeness of documentation maintained | — | — |

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -132,11 +132,13 @@ The Endpoint Management Engineer administers and maintains the organisation's en
 
 ## Key Performance Indicators
 
-- Device compliance rate on assigned platforms
-- Patch deployment success rate within SLA
-- Application deployment success rate
-- Help desk escalation response and resolution time
-- Accuracy and completeness of documentation maintained
+| Metric | Target | Frequency |
+|---|---|---|
+| Device compliance rate on assigned platforms | — | — |
+| Patch deployment success rate within SLA | — | — |
+| Application deployment success rate | — | — |
+| Help desk escalation response and resolution time | — | — |
+| Accuracy and completeness of documentation maintained | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/endpoint_management/endpoint_management_product_owner.md
+++ b/Roles/endpoint_management/endpoint_management_product_owner.md
@@ -130,11 +130,13 @@ The Endpoint Management Product Owner (PO) owns the product vision, roadmap, and
 
 ## Key Performance Indicators
 
-- Backlog health (stories ready for sprint, acceptances defined)
-- Platform roadmap milestone delivery against plan
-- Device compliance rate trend (month-over-month)
-- Stakeholder satisfaction with platform communication and delivery
-- Cost per managed device (trend: optimising)
+| Metric | Target | Frequency |
+|---|---|---|
+| Backlog health (stories ready for sprint, acceptances defined) | — | — |
+| Platform roadmap milestone delivery against plan | — | — |
+| Device compliance rate trend (month-over-month) | — | — |
+| Stakeholder satisfaction with platform communication and delivery | — | — |
+| Cost per managed device (trend: optimising) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/endpoint_management/endpoint_management_product_owner.md
+++ b/Roles/endpoint_management/endpoint_management_product_owner.md
@@ -135,7 +135,7 @@ The Endpoint Management Product Owner (PO) owns the product vision, roadmap, and
 | Backlog health (stories ready for sprint, acceptances defined) | — | — |
 | Platform roadmap milestone delivery against plan | — | — |
 | Device compliance rate trend (month-over-month) | — | — |
-| Stakeholder satisfaction with platform communication and delivery | — | — |
+| Stakeholder satisfaction with platform communication and delivery | ≥85% (proposed) | Quarterly |
 | Cost per managed device (trend: optimising) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/endpoint_management/endpoint_management_senior_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_senior_engineer.md
@@ -140,12 +140,14 @@ The Endpoint Management Senior Engineer designs, implements, and maintains compl
 
 ## Key Performance Indicators
 
-- Device compliance percentage across managed platforms (target: >97%)
-- Patch ring completion rate within defined SLAs
-- Autopilot success rate (target: >95%)
-- Application deployment success rate
-- Escalation ticket resolution time
-- Number of automated remediation scripts deployed (increasing trend)
+| Metric | Target | Frequency |
+|---|---|---|
+| Device compliance percentage across managed platforms (target: >97%) | >97% | — |
+| Patch ring completion rate within defined SLAs | — | — |
+| Autopilot success rate (target: >95%) | >95% | — |
+| Application deployment success rate | — | — |
+| Escalation ticket resolution time | — | — |
+| Number of automated remediation scripts deployed (increasing trend) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -136,7 +136,7 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 
 | Metric | Target | Frequency |
 |---|---|---|
-| SCCM infrastructure availability and health | — | — |
+| SCCM infrastructure availability and health | ≥99.9% (proposed) | Monthly |
 | Application deployment success rates | — | — |
 | Software update compliance percentages | — | — |
 | Operating system deployment reliability | — | — |

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -134,16 +134,18 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 
 ## Key Performance Indicators
 
-- SCCM infrastructure availability and health
-- Application deployment success rates
-- Software update compliance percentages
-- Operating system deployment reliability
-- Client health metrics
-- Configuration baseline compliance
-- Documentation quality and completeness
-- Issue resolution time for SCCM-related problems
-- Endpoint inventory accuracy
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| SCCM infrastructure availability and health | — | — |
+| Application deployment success rates | — | — |
+| Software update compliance percentages | — | — |
+| Operating system deployment reliability | — | — |
+| Client health metrics | — | — |
+| Configuration baseline compliance | — | — |
+| Documentation quality and completeness | — | — |
+| Issue resolution time for SCCM-related problems | — | — |
+| Endpoint inventory accuracy | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -138,7 +138,7 @@ The Enterprise Architect develops and maintains the overall technological vision
 | Time-to-market improvements from architectural enablement | — | — |
 | Cost efficiencies achieved through architecture optimization | — | — |
 | Solution delivery success rates with architectural governance | — | — |
-| Stakeholder satisfaction with architectural guidance | — | — |
+| Stakeholder satisfaction with architectural guidance | ≥85% (proposed) | Quarterly |
 | Enterprise architecture maturity progression | — | — |
 | Innovation enablement through architecture | — | — |
 | Quality of documentation and knowledge sharing | — | — |

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -130,16 +130,18 @@ The Enterprise Architect develops and maintains the overall technological vision
 
 ## Key Performance Indicators
 
-- Business-IT strategic alignment effectiveness
-- Architecture reuse and standardization metrics
-- Technical debt reduction through architectural governance
-- Time-to-market improvements from architectural enablement
-- Cost efficiencies achieved through architecture optimization
-- Solution delivery success rates with architectural governance
-- Stakeholder satisfaction with architectural guidance
-- Enterprise architecture maturity progression
-- Innovation enablement through architecture
-- Quality of documentation and knowledge sharing
+| Metric | Target | Frequency |
+|---|---|---|
+| Business-IT strategic alignment effectiveness | — | — |
+| Architecture reuse and standardization metrics | — | — |
+| Technical debt reduction through architectural governance | — | — |
+| Time-to-market improvements from architectural enablement | — | — |
+| Cost efficiencies achieved through architecture optimization | — | — |
+| Solution delivery success rates with architectural governance | — | — |
+| Stakeholder satisfaction with architectural guidance | — | — |
+| Enterprise architecture maturity progression | — | — |
+| Innovation enablement through architecture | — | — |
+| Quality of documentation and knowledge sharing | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -131,14 +131,16 @@ The Enterprise Architecture Senior Engineer operates at the intersection of tech
 
 ## Key Performance Indicators
 
-- Architecture repository completeness and data quality score
-- Architecture review board cycle time (days from submission to decision)
-- Reference architecture adoption rate across delivery projects
-- Technology radar publication frequency and currency
-- Stakeholder satisfaction with architecture governance support and tooling
-- Standards documentation coverage (percentage of domains with current reference architectures)
-- Action item closure rate from architecture review board decisions
-- Architecture community of practice engagement metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture repository completeness and data quality score | — | — |
+| Architecture review board cycle time (days from submission to decision) | — | — |
+| Reference architecture adoption rate across delivery projects | — | — |
+| Technology radar publication frequency and currency | — | — |
+| Stakeholder satisfaction with architecture governance support and tooling | — | — |
+| Standards documentation coverage (percentage of domains with current reference architectures) | — | — |
+| Action item closure rate from architecture review board decisions | — | — |
+| Architecture community of practice engagement metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -137,7 +137,7 @@ The Enterprise Architecture Senior Engineer operates at the intersection of tech
 | Architecture review board cycle time (days from submission to decision) | — | — |
 | Reference architecture adoption rate across delivery projects | — | — |
 | Technology radar publication frequency and currency | — | — |
-| Stakeholder satisfaction with architecture governance support and tooling | — | — |
+| Stakeholder satisfaction with architecture governance support and tooling | ≥85% (proposed) | Quarterly |
 | Standards documentation coverage (percentage of domains with current reference architectures) | — | — |
 | Action item closure rate from architecture review board decisions | — | — |
 | Architecture community of practice engagement metrics | — | — |

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -144,7 +144,7 @@ The Solution Architect is responsible for designing end-to-end technical solutio
 |---|---|---|
 | Solution design approval time at Architecture Review Board | — | — |
 | Post-go-live defect rate attributable to design issues | — | — |
-| Stakeholder satisfaction scores on design quality and communication | — | — |
+| Stakeholder satisfaction scores on design quality and communication | ≥85% (proposed) | Quarterly |
 | Accuracy of solution cost estimates (budget vs. actuals) | — | — |
 | NFR compliance rate of delivered solutions in first 3 months | — | — |
 | Volume of solutions successfully delivered per year | — | — |

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -140,12 +140,14 @@ The Solution Architect is responsible for designing end-to-end technical solutio
 
 ## Key Performance Indicators
 
-- Solution design approval time at Architecture Review Board
-- Post-go-live defect rate attributable to design issues
-- Stakeholder satisfaction scores on design quality and communication
-- Accuracy of solution cost estimates (budget vs. actuals)
-- NFR compliance rate of delivered solutions in first 3 months
-- Volume of solutions successfully delivered per year
+| Metric | Target | Frequency |
+|---|---|---|
+| Solution design approval time at Architecture Review Board | — | — |
+| Post-go-live defect rate attributable to design issues | — | — |
+| Stakeholder satisfaction scores on design quality and communication | — | — |
+| Accuracy of solution cost estimates (budget vs. actuals) | — | — |
+| NFR compliance rate of delivered solutions in first 3 months | — | — |
+| Volume of solutions successfully delivered per year | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -129,16 +129,18 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of designs with business requirements
-- Onboarding architecture scalability and flexibility
-- Standardization level across infrastructure domains
-- Time-to-provision improvements through architecture
-- Reduction in architectural complexity
-- Adoption of reference architectures and patterns
-- Innovation in infrastructure provisioning approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of designs with business requirements | — | — |
+| Onboarding architecture scalability and flexibility | — | — |
+| Standardization level across infrastructure domains | — | — |
+| Time-to-provision improvements through architecture | — | — |
+| Reduction in architectural complexity | — | — |
+| Adoption of reference architectures and patterns | — | — |
+| Innovation in infrastructure provisioning approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -130,16 +130,18 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 
 ## Key Performance Indicators
 
-- Infrastructure provisioning time metrics
-- Provisioning request success rate
-- Documentation quality and completeness
-- User satisfaction with provisioning services
-- Automation coverage for standard deployments
-- Time to resolve provisioning incidents
-- Quality of service catalog items and descriptions
-- Self-service adoption metrics
-- Adherence to infrastructure standards
-- Process improvement contributions
+| Metric | Target | Frequency |
+|---|---|---|
+| Infrastructure provisioning time metrics | — | — |
+| Provisioning request success rate | — | — |
+| Documentation quality and completeness | — | — |
+| User satisfaction with provisioning services | — | — |
+| Automation coverage for standard deployments | — | — |
+| Time to resolve provisioning incidents | — | — |
+| Quality of service catalog items and descriptions | — | — |
+| Self-service adoption metrics | — | — |
+| Adherence to infrastructure standards | — | — |
+| Process improvement contributions | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -135,7 +135,7 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 | Infrastructure provisioning time metrics | — | — |
 | Provisioning request success rate | — | — |
 | Documentation quality and completeness | — | — |
-| User satisfaction with provisioning services | — | — |
+| User satisfaction with provisioning services | ≥85% (proposed) | Quarterly |
 | Automation coverage for standard deployments | — | — |
 | Time to resolve provisioning incidents | — | — |
 | Quality of service catalog items and descriptions | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -132,16 +132,18 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 
 ## Key Performance Indicators
 
-- Infrastructure provisioning time metrics
-- Service request fulfillment time
-- User satisfaction with onboarding processes
-- Automation level of provisioning workflows
-- Self-service adoption metrics
-- Cost savings through standardization
-- Request accuracy and first-time completions
-- Onboarding documentation quality
-- Infrastructure standards compliance
-- Successful delivery of roadmap initiatives
+| Metric | Target | Frequency |
+|---|---|---|
+| Infrastructure provisioning time metrics | — | — |
+| Service request fulfillment time | — | — |
+| User satisfaction with onboarding processes | — | — |
+| Automation level of provisioning workflows | — | — |
+| Self-service adoption metrics | — | — |
+| Cost savings through standardization | — | — |
+| Request accuracy and first-time completions | — | — |
+| Onboarding documentation quality | — | — |
+| Infrastructure standards compliance | — | — |
+| Successful delivery of roadmap initiatives | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -136,7 +136,7 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 |---|---|---|
 | Infrastructure provisioning time metrics | — | — |
 | Service request fulfillment time | — | — |
-| User satisfaction with onboarding processes | — | — |
+| User satisfaction with onboarding processes | ≥85% (proposed) | Quarterly |
 | Automation level of provisioning workflows | — | — |
 | Self-service adoption metrics | — | — |
 | Cost savings through standardization | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -141,7 +141,7 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 | Standardization level of infrastructure deployments | — | — |
 | Innovation in onboarding approaches | — | — |
 | Cross-platform integration effectiveness | — | — |
-| Stakeholder satisfaction with onboarding processes | — | — |
+| Stakeholder satisfaction with onboarding processes | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -130,16 +130,18 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 
 ## Key Performance Indicators
 
-- Infrastructure provisioning time efficiency
-- Automation coverage across infrastructure domains
-- Provisioning success rate and reliability
-- Implementation quality of onboarding solutions
-- Resolution time for onboarding incidents
-- Knowledge transfer effectiveness to engineers
-- Standardization level of infrastructure deployments
-- Innovation in onboarding approaches
-- Cross-platform integration effectiveness
-- Stakeholder satisfaction with onboarding processes
+| Metric | Target | Frequency |
+|---|---|---|
+| Infrastructure provisioning time efficiency | — | — |
+| Automation coverage across infrastructure domains | — | — |
+| Provisioning success rate and reliability | — | — |
+| Implementation quality of onboarding solutions | — | — |
+| Resolution time for onboarding incidents | — | — |
+| Knowledge transfer effectiveness to engineers | — | — |
+| Standardization level of infrastructure deployments | — | — |
+| Innovation in onboarding approaches | — | — |
+| Cross-platform integration effectiveness | — | — |
+| Stakeholder satisfaction with onboarding processes | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/integration_middleware/integration_architect.md
+++ b/Roles/integration_middleware/integration_architect.md
@@ -142,12 +142,14 @@ The Integration Architect designs and governs the organisation's enterprise inte
 
 ## Key Performance Indicators
 
-- Integration platform availability (target: 99.9%+)
-- API governance compliance rate (APIs adhering to standards)
-- Point-to-point integration reduction (governed integrations as percentage of total)
-- Integration-related incident rate (trend: decreasing)
-- Mean time to integrate new applications
-- API developer portal adoption (external/internal consumers)
+| Metric | Target | Frequency |
+|---|---|---|
+| Integration platform availability (target: 99.9%+) | 99.9% | — |
+| API governance compliance rate (APIs adhering to standards) | — | — |
+| Point-to-point integration reduction (governed integrations as percentage of total) | — | — |
+| Integration-related incident rate (trend: decreasing) | — | — |
+| Mean time to integrate new applications | — | — |
+| API developer portal adoption (external/internal consumers) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -126,10 +126,12 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 
 ## Key Performance Indicators
 
-- Integration flow availability for monitored flows
-- Error response and resolution time
-- Documentation currency for assigned integrations
-- Escalation rate (trend: decreasing as skills develop)
+| Metric | Target | Frequency |
+|---|---|---|
+| Integration flow availability for monitored flows | — | — |
+| Error response and resolution time | — | — |
+| Documentation currency for assigned integrations | — | — |
+| Escalation rate (trend: decreasing as skills develop) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -149,7 +149,7 @@ The Integration Product Owner owns the integration platform product backlog — 
 | Time-to-integrate: median onboarding time for new application teams to the integration platform reduced by ≥20% year-on-year | ≥20% | — |
 | Point-to-point integration reduction: ≥15% of legacy point-to-point integrations decommissioned per year as governed platform patterns expand | ≥15% | — |
 | API developer portal adoption: number of internal and external API consumers growing ≥10% quarter-on-quarter | ≥10% | — |
-| Integration-related incident rate: trend declining, with platform-attributable root causes addressed within agreed SLA response windows | — | — |
+| Integration-related incident rate: trend declining, with platform-attributable root causes addressed within agreed SLA response windows | ≥95% (proposed) | Monthly |
 | API governance compliance: ≥90% of APIs published to the developer portal meeting integration architecture standards | ≥90% | — |
 
 ## Remote Work Considerations

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -142,13 +142,15 @@ The Integration Product Owner owns the integration platform product backlog — 
 
 ## Key Performance Indicators
 
-- Integration platform availability: API gateway and message broker meeting defined SLA targets (e.g., ≥99.9% monthly uptime)
-- Backlog delivery rate: ≥85% of committed sprint items delivered each sprint
-- Time-to-integrate: median onboarding time for new application teams to the integration platform reduced by ≥20% year-on-year
-- Point-to-point integration reduction: ≥15% of legacy point-to-point integrations decommissioned per year as governed platform patterns expand
-- API developer portal adoption: number of internal and external API consumers growing ≥10% quarter-on-quarter
-- Integration-related incident rate: trend declining, with platform-attributable root causes addressed within agreed SLA response windows
-- API governance compliance: ≥90% of APIs published to the developer portal meeting integration architecture standards
+| Metric | Target | Frequency |
+|---|---|---|
+| Integration platform availability: API gateway and message broker meeting defined SLA targets (e.g., ≥99.9% monthly uptime) | ≥99.9% | Monthly |
+| Backlog delivery rate: ≥85% of committed sprint items delivered each sprint | ≥85% | — |
+| Time-to-integrate: median onboarding time for new application teams to the integration platform reduced by ≥20% year-on-year | ≥20% | — |
+| Point-to-point integration reduction: ≥15% of legacy point-to-point integrations decommissioned per year as governed platform patterns expand | ≥15% | — |
+| API developer portal adoption: number of internal and external API consumers growing ≥10% quarter-on-quarter | ≥10% | — |
+| Integration-related incident rate: trend declining, with platform-attributable root causes addressed within agreed SLA response windows | — | — |
+| API governance compliance: ≥90% of APIs published to the developer portal meeting integration architecture standards | ≥90% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -138,7 +138,7 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Integration flow availability and SLA compliance | — | — |
+| Integration flow availability and SLA compliance | ≥95% (proposed) | Monthly |
 | Error rate on critical integration flows (trend: decreasing) | — | — |
 | API response time compliance | — | — |
 | Code review coverage within the integration team | — | — |

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -136,12 +136,14 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 
 ## Key Performance Indicators
 
-- Integration flow availability and SLA compliance
-- Error rate on critical integration flows (trend: decreasing)
-- API response time compliance
-- Code review coverage within the integration team
-- Integration incident resolution time
-- Documentation currency for owned integrations
+| Metric | Target | Frequency |
+|---|---|---|
+| Integration flow availability and SLA compliance | — | — |
+| Error rate on critical integration flows (trend: decreasing) | — | — |
+| API response time compliance | — | — |
+| Code review coverage within the integration team | — | — |
+| Integration incident resolution time | — | — |
+| Documentation currency for owned integrations | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -129,16 +129,18 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of configuration designs with business requirements
-- Configuration management reliability and scalability
-- Security posture of configuration systems
-- Adoption of configuration reference architectures
-- Reduction in configuration-related incidents
-- Configuration automation maturity improvement
-- Innovation in configuration management approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of configuration designs with business requirements | — | — |
+| Configuration management reliability and scalability | — | — |
+| Security posture of configuration systems | — | — |
+| Adoption of configuration reference architectures | — | — |
+| Reduction in configuration-related incidents | — | — |
+| Configuration automation maturity improvement | — | — |
+| Innovation in configuration management approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -130,16 +130,18 @@ The Application Configuration Management Engineer implements and maintains confi
 
 ## Key Performance Indicators
 
-- Configuration accuracy and consistency
-- Configuration deployment success rate
-- Configuration-related incident reduction
-- Time to resolve configuration issues
-- Documentation quality and completeness
-- Configuration compliance percentage
-- Configuration management automation level
-- Environment configuration consistency
-- User satisfaction with configuration services
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Configuration accuracy and consistency | — | — |
+| Configuration deployment success rate | — | — |
+| Configuration-related incident reduction | — | — |
+| Time to resolve configuration issues | — | — |
+| Documentation quality and completeness | — | — |
+| Configuration compliance percentage | — | — |
+| Configuration management automation level | — | — |
+| Environment configuration consistency | — | — |
+| User satisfaction with configuration services | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -140,7 +140,7 @@ The Application Configuration Management Engineer implements and maintains confi
 | Configuration compliance percentage | — | — |
 | Configuration management automation level | — | — |
 | Environment configuration consistency | — | — |
-| User satisfaction with configuration services | — | — |
+| User satisfaction with configuration services | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -141,7 +141,7 @@ The Application Configuration Management Senior Engineer leads the implementatio
 | Standardization level of configuration practices | — | — |
 | Innovation in configuration management approaches | — | — |
 | Security compliance of configuration processes | — | — |
-| Stakeholder satisfaction with configuration services | — | — |
+| Stakeholder satisfaction with configuration services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -130,16 +130,18 @@ The Application Configuration Management Senior Engineer leads the implementatio
 
 ## Key Performance Indicators
 
-- Configuration management reliability metrics
-- Automation coverage for configuration processes
-- Configuration deployment success rate
-- Implementation quality of configuration solutions
-- Resolution time for configuration incidents
-- Knowledge transfer effectiveness to engineers
-- Standardization level of configuration practices
-- Innovation in configuration management approaches
-- Security compliance of configuration processes
-- Stakeholder satisfaction with configuration services
+| Metric | Target | Frequency |
+|---|---|---|
+| Configuration management reliability metrics | — | — |
+| Automation coverage for configuration processes | — | — |
+| Configuration deployment success rate | — | — |
+| Implementation quality of configuration solutions | — | — |
+| Resolution time for configuration incidents | — | — |
+| Knowledge transfer effectiveness to engineers | — | — |
+| Standardization level of configuration practices | — | — |
+| Innovation in configuration management approaches | — | — |
+| Security compliance of configuration processes | — | — |
+| Stakeholder satisfaction with configuration services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -133,10 +133,10 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 | Metric | Target | Frequency |
 |---|---|---|
 | Backlog velocity and sprint delivery predictability | — | — |
-| ITSM platform user satisfaction score (CSAT) | — | — |
+| ITSM platform user satisfaction score (CSAT) | ≥85% (proposed) | Quarterly |
 | CMDB CI accuracy rate (target: >95% for in-scope CI classes) | >95% | — |
 | Service request self-service adoption rate (trend: increasing) | — | — |
-| Incident, Change, and Problem SLA compliance rates (platform impact contribution) | — | — |
+| Incident, Change, and Problem SLA compliance rates (platform impact contribution) | ≥95% (proposed) | Monthly |
 | Roadmap milestone delivery against plan | — | — |
 
 ## Remote Work Considerations

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -130,12 +130,14 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 
 ## Key Performance Indicators
 
-- Backlog velocity and sprint delivery predictability
-- ITSM platform user satisfaction score (CSAT)
-- CMDB CI accuracy rate (target: >95% for in-scope CI classes)
-- Service request self-service adoption rate (trend: increasing)
-- Incident, Change, and Problem SLA compliance rates (platform impact contribution)
-- Roadmap milestone delivery against plan
+| Metric | Target | Frequency |
+|---|---|---|
+| Backlog velocity and sprint delivery predictability | — | — |
+| ITSM platform user satisfaction score (CSAT) | — | — |
+| CMDB CI accuracy rate (target: >95% for in-scope CI classes) | >95% | — |
+| Service request self-service adoption rate (trend: increasing) | — | — |
+| Incident, Change, and Problem SLA compliance rates (platform impact contribution) | — | — |
+| Roadmap milestone delivery against plan | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -169,13 +169,15 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 
 ## Key Performance Indicators
 
-- Successful implementation of Kubernetes platform strategies
-- Adoption rate of containerized applications
-- Platform reliability and availability metrics
-- Documentation quality and completeness
-- Effective knowledge transfer to engineering teams
-- Alignment of Kubernetes platforms with business requirements
-- Number of CNCF technologies formally evaluated and adopted into the platform per year; operator maturity level (basic / managed / full lifecycle)
+| Metric | Target | Frequency |
+|---|---|---|
+| Successful implementation of Kubernetes platform strategies | — | — |
+| Adoption rate of containerized applications | — | — |
+| Platform reliability and availability metrics | — | — |
+| Documentation quality and completeness | — | — |
+| Effective knowledge transfer to engineering teams | — | — |
+| Alignment of Kubernetes platforms with business requirements | — | — |
+| Number of CNCF technologies formally evaluated and adopted into the platform per year; operator maturity level (basic / managed / full lifecycle) | — | — |
 
 ## Recommended Certifications & Learning Paths
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -173,7 +173,7 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 |---|---|---|
 | Successful implementation of Kubernetes platform strategies | — | — |
 | Adoption rate of containerized applications | — | — |
-| Platform reliability and availability metrics | — | — |
+| Platform reliability and availability metrics | ≥99.9% (proposed) | Monthly |
 | Documentation quality and completeness | — | — |
 | Effective knowledge transfer to engineering teams | — | — |
 | Alignment of Kubernetes platforms with business requirements | — | — |

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -130,16 +130,18 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 
 ## Key Performance Indicators
 
-- Kubernetes cluster uptime and reliability
-- Container deployment success rate
-- Time to resolve Kubernetes incidents
-- Security compliance in Kubernetes environments
-- Documentation quality and completeness
-- Implementation quality of standard patterns
-- Knowledge sharing and collaboration
-- Kubernetes automation implementation
-- User satisfaction with container platform
-- Cluster resource utilization efficiency
+| Metric | Target | Frequency |
+|---|---|---|
+| Kubernetes cluster uptime and reliability | — | — |
+| Container deployment success rate | — | — |
+| Time to resolve Kubernetes incidents | — | — |
+| Security compliance in Kubernetes environments | — | — |
+| Documentation quality and completeness | — | — |
+| Implementation quality of standard patterns | — | — |
+| Knowledge sharing and collaboration | — | — |
+| Kubernetes automation implementation | — | — |
+| User satisfaction with container platform | — | — |
+| Cluster resource utilization efficiency | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -132,7 +132,7 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Kubernetes cluster uptime and reliability | — | — |
+| Kubernetes cluster uptime and reliability | ≥99.9% (proposed) | Monthly |
 | Container deployment success rate | — | — |
 | Time to resolve Kubernetes incidents | — | — |
 | Security compliance in Kubernetes environments | — | — |
@@ -140,7 +140,7 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 | Implementation quality of standard patterns | — | — |
 | Knowledge sharing and collaboration | — | — |
 | Kubernetes automation implementation | — | — |
-| User satisfaction with container platform | — | — |
+| User satisfaction with container platform | ≥85% (proposed) | Quarterly |
 | Cluster resource utilization efficiency | — | — |
 
 ## Remote Work Considerations

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -111,7 +111,7 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 |---|---|---|
 | Platform adoption rates across application teams | — | — |
 | Successful delivery of roadmap initiatives | — | — |
-| Stakeholder satisfaction with Kubernetes services | — | — |
+| Stakeholder satisfaction with Kubernetes services | ≥85% (proposed) | Quarterly |
 | Quality of backlog management and prioritization | — | — |
 | Measurable improvement in application deployment velocity | — | — |
 | Effective communication of platform capabilities and value | — | — |

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -107,12 +107,14 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 
 ## Key Performance Indicators
 
-- Platform adoption rates across application teams
-- Successful delivery of roadmap initiatives
-- Stakeholder satisfaction with Kubernetes services
-- Quality of backlog management and prioritization
-- Measurable improvement in application deployment velocity
-- Effective communication of platform capabilities and value
+| Metric | Target | Frequency |
+|---|---|---|
+| Platform adoption rates across application teams | — | — |
+| Successful delivery of roadmap initiatives | — | — |
+| Stakeholder satisfaction with Kubernetes services | — | — |
+| Quality of backlog management and prioritization | — | — |
+| Measurable improvement in application deployment velocity | — | — |
+| Effective communication of platform capabilities and value | — | — |
 
 ## Key Technologies
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -109,16 +109,18 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 
 ## Key Performance Indicators
 
-- Successful implementation rate of complex Kubernetes solutions
-- Platform reliability metrics (uptime, stability)
-- Mean time to recovery for platform incidents
-- Deployment automation effectiveness
-- Knowledge transfer metrics for mentored engineers
-- Kubernetes platform security posture scores
-- Resource utilization efficiency metrics
-- Contribution to platform standards adoption
-- Implementation of innovative container solutions
-- Reduced operational overhead through automation
+| Metric | Target | Frequency |
+|---|---|---|
+| Successful implementation rate of complex Kubernetes solutions | — | — |
+| Platform reliability metrics (uptime, stability) | — | — |
+| Mean time to recovery for platform incidents | — | — |
+| Deployment automation effectiveness | — | — |
+| Knowledge transfer metrics for mentored engineers | — | — |
+| Kubernetes platform security posture scores | — | — |
+| Resource utilization efficiency metrics | — | — |
+| Contribution to platform standards adoption | — | — |
+| Implementation of innovative container solutions | — | — |
+| Reduced operational overhead through automation | — | — |
 
 ## Key Technologies
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -112,7 +112,7 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 | Metric | Target | Frequency |
 |---|---|---|
 | Successful implementation rate of complex Kubernetes solutions | — | — |
-| Platform reliability metrics (uptime, stability) | — | — |
+| Platform reliability metrics (uptime, stability) | ≥99.9% (proposed) | Monthly |
 | Mean time to recovery for platform incidents | — | — |
 | Deployment automation effectiveness | — | — |
 | Knowledge transfer metrics for mentored engineers | — | — |

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -147,14 +147,14 @@ The CISO sits above the PAL and TAL in the technology leadership hierarchy on ma
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Security incident frequency, severity, and mean time to detect and respond | — | — |
+| Security incident frequency, severity, and mean time to detect and respond | ≤24 hours (proposed) | Monthly |
 | Regulatory audit outcomes: findings severity, remediation speed, and repeat finding rate | — | — |
 | Compliance posture across applicable frameworks (ISO 27001, GDPR, NIS2, DORA, SOC 2) | — | — |
 | Third-party security risk exposure trend and high-risk vendor remediation rate | — | — |
 | Security investment efficiency: capability maturity growth per unit of investment | — | — |
 | Board and executive confidence in security governance (survey or qualitative assessment) | — | — |
 | Employee security awareness score and phishing simulation performance trend | — | — |
-| Vulnerability mean time to remediate (MTTR) across critical and high severity findings | — | — |
+| Vulnerability mean time to remediate (MTTR) across critical and high severity findings | ≤4 hours (proposed) | Monthly |
 | Security architecture adoption rate across technology programmes | — | — |
 | Security team retention and capability development progression | — | — |
 

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -145,16 +145,18 @@ The CISO sits above the PAL and TAL in the technology leadership hierarchy on ma
 
 ## Key Performance Indicators
 
-- Security incident frequency, severity, and mean time to detect and respond
-- Regulatory audit outcomes: findings severity, remediation speed, and repeat finding rate
-- Compliance posture across applicable frameworks (ISO 27001, GDPR, NIS2, DORA, SOC 2)
-- Third-party security risk exposure trend and high-risk vendor remediation rate
-- Security investment efficiency: capability maturity growth per unit of investment
-- Board and executive confidence in security governance (survey or qualitative assessment)
-- Employee security awareness score and phishing simulation performance trend
-- Vulnerability mean time to remediate (MTTR) across critical and high severity findings
-- Security architecture adoption rate across technology programmes
-- Security team retention and capability development progression
+| Metric | Target | Frequency |
+|---|---|---|
+| Security incident frequency, severity, and mean time to detect and respond | — | — |
+| Regulatory audit outcomes: findings severity, remediation speed, and repeat finding rate | — | — |
+| Compliance posture across applicable frameworks (ISO 27001, GDPR, NIS2, DORA, SOC 2) | — | — |
+| Third-party security risk exposure trend and high-risk vendor remediation rate | — | — |
+| Security investment efficiency: capability maturity growth per unit of investment | — | — |
+| Board and executive confidence in security governance (survey or qualitative assessment) | — | — |
+| Employee security awareness score and phishing simulation performance trend | — | — |
+| Vulnerability mean time to remediate (MTTR) across critical and high severity findings | — | — |
+| Security architecture adoption rate across technology programmes | — | — |
+| Security team retention and capability development progression | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -143,7 +143,7 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | Hiring velocity and quality for infrastructure architect and senior engineer roles (90-day retention of new hires) | — | — |
-| Chapter satisfaction score (internal survey results for the infrastructure chapter) | — | — |
+| Chapter satisfaction score (internal survey results for the infrastructure chapter) | ≥85% (proposed) | Quarterly |
 | Infrastructure architecture standards adoption rate across all eleven domains | — | — |
 | Cloud cost optimisation savings attributed to FinOps domain activity within the chapter | — | — |
 | Platform consolidation progress against chapter roadmap milestones | — | — |

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -139,17 +139,19 @@ The Cloud, Platform & Infrastructure Chapter Lead is the most senior technical m
 
 ## Key Performance Indicators
 
-- Chapter practitioner retention rate and voluntary attrition trend
-- Hiring velocity and quality for infrastructure architect and senior engineer roles (90-day retention of new hires)
-- Chapter satisfaction score (internal survey results for the infrastructure chapter)
-- Infrastructure architecture standards adoption rate across all eleven domains
-- Cloud cost optimisation savings attributed to FinOps domain activity within the chapter
-- Platform consolidation progress against chapter roadmap milestones
-- Cloud vs. on-premises placement decision quality and consistency (measured via architecture review outcomes)
-- Hardware refresh cycle adherence rate
-- Architecture debt reduction trend across the infrastructure estate
-- Cross-domain dependency resolution speed
-- Chapter architecture review board throughput and decision quality
+| Metric | Target | Frequency |
+|---|---|---|
+| Chapter practitioner retention rate and voluntary attrition trend | — | — |
+| Hiring velocity and quality for infrastructure architect and senior engineer roles (90-day retention of new hires) | — | — |
+| Chapter satisfaction score (internal survey results for the infrastructure chapter) | — | — |
+| Infrastructure architecture standards adoption rate across all eleven domains | — | — |
+| Cloud cost optimisation savings attributed to FinOps domain activity within the chapter | — | — |
+| Platform consolidation progress against chapter roadmap milestones | — | — |
+| Cloud vs. on-premises placement decision quality and consistency (measured via architecture review outcomes) | — | — |
+| Hardware refresh cycle adherence rate | — | — |
+| Architecture debt reduction trend across the infrastructure estate | — | — |
+| Cross-domain dependency resolution speed | — | — |
+| Chapter architecture review board throughput and decision quality | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -141,7 +141,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
-| Chapter satisfaction score (internal survey results for the Data & AI chapter) | — | — |
+| Chapter satisfaction score (internal survey results for the Data & AI chapter) | ≥85% (proposed) | Quarterly |
 | Data platform adoption and coverage across the organisation's data domains | — | — |
 | Data quality scores for critical business data domains | — | — |
 | AI/ML model governance compliance rate — percentage of models with approved governance artefacts | — | — |

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -137,16 +137,18 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 
 ## Key Performance Indicators
 
-- Chapter practitioner retention rate and voluntary attrition trend
-- Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires)
-- Chapter satisfaction score (internal survey results for the Data & AI chapter)
-- Data platform adoption and coverage across the organisation's data domains
-- Data quality scores for critical business data domains
-- AI/ML model governance compliance rate — percentage of models with approved governance artefacts
-- Data governance policy adherence rate across data-producing teams
-- Time-to-access trusted data products for analytics and AI consumers
-- Architecture debt reduction trend across data and AI platforms
-- AI ethics and compliance review throughput and issue resolution rate
+| Metric | Target | Frequency |
+|---|---|---|
+| Chapter practitioner retention rate and voluntary attrition trend | — | — |
+| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| Chapter satisfaction score (internal survey results for the Data & AI chapter) | — | — |
+| Data platform adoption and coverage across the organisation's data domains | — | — |
+| Data quality scores for critical business data domains | — | — |
+| AI/ML model governance compliance rate — percentage of models with approved governance artefacts | — | — |
+| Data governance policy adherence rate across data-producing teams | — | — |
+| Time-to-access trusted data products for analytics and AI consumers | — | — |
+| Architecture debt reduction trend across data and AI platforms | — | — |
+| AI ethics and compliance review throughput and issue resolution rate | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -136,15 +136,17 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 
 ## Key Performance Indicators
 
-- Chapter practitioner retention rate and voluntary attrition trend
-- Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires)
-- Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter)
-- DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR)
-- IDP adoption rate across development teams
-- Pipeline standardisation coverage across the organisation
-- API governance compliance rate
-- Integration platform consolidation progress against chapter roadmap milestones
-- Architecture debt reduction trend across delivery and integration domains
+| Metric | Target | Frequency |
+|---|---|---|
+| Chapter practitioner retention rate and voluntary attrition trend | — | — |
+| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter) | — | — |
+| DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | — | — |
+| IDP adoption rate across development teams | — | — |
+| Pipeline standardisation coverage across the organisation | — | — |
+| API governance compliance rate | — | — |
+| Integration platform consolidation progress against chapter roadmap milestones | — | — |
+| Architecture debt reduction trend across delivery and integration domains | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -140,8 +140,8 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
-| Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter) | — | — |
-| DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | — | — |
+| Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter) | ≥85% (proposed) | Quarterly |
+| DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | ≤15% (proposed) | Monthly |
 | IDP adoption rate across development teams | — | — |
 | Pipeline standardisation coverage across the organisation | — | — |
 | API governance compliance rate | — | — |

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -142,7 +142,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
-| Chapter satisfaction score (internal survey results for the End User & Workplace chapter) | — | — |
+| Chapter satisfaction score (internal survey results for the End User & Workplace chapter) | ≥85% (proposed) | Quarterly |
 | Device management coverage and compliance rate across all managed endpoints | — | — |
 | Microsoft 365 governance compliance rate — adherence to tenant standards and Teams governance policies | — | — |
 | Digital employee experience (DEX) score trend | — | — |

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -138,16 +138,18 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 
 ## Key Performance Indicators
 
-- Chapter practitioner retention rate and voluntary attrition trend
-- Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires)
-- Chapter satisfaction score (internal survey results for the End User & Workplace chapter)
-- Device management coverage and compliance rate across all managed endpoints
-- Microsoft 365 governance compliance rate — adherence to tenant standards and Teams governance policies
-- Digital employee experience (DEX) score trend
-- Endpoint security posture alignment score with Security chapter standards
-- Modern workplace roadmap delivery milestone completion rate
-- M365 feature adoption rate for strategic platform capabilities
-- Device refresh cycle adherence and end-of-life device reduction rate
+| Metric | Target | Frequency |
+|---|---|---|
+| Chapter practitioner retention rate and voluntary attrition trend | — | — |
+| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| Chapter satisfaction score (internal survey results for the End User & Workplace chapter) | — | — |
+| Device management coverage and compliance rate across all managed endpoints | — | — |
+| Microsoft 365 governance compliance rate — adherence to tenant standards and Teams governance policies | — | — |
+| Digital employee experience (DEX) score trend | — | — |
+| Endpoint security posture alignment score with Security chapter standards | — | — |
+| Modern workplace roadmap delivery milestone completion rate | — | — |
+| M365 feature adoption rate for strategic platform capabilities | — | — |
+| Device refresh cycle adherence and end-of-life device reduction rate | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -134,14 +134,16 @@ The Engineering Practices Champion is a senior individual contributor and intern
 
 ## Key Performance Indicators
 
-- DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement
-- Code quality gate adoption rate across delivery teams (percentage of active pipelines with configured and enforced quality gates)
-- Number of distinct teams coached per quarter, with a defined engagement scope and measurable outcome
-- Engineering practice maturity score delta — improvement in structured maturity assessment scores across coached teams
-- Test coverage trend across teams using shared pipeline templates with quality gate enforcement
-- Definition of Done completeness rate — percentage of teams with formally documented and tool-embedded DoD criteria
-- Practitioner feedback score from post-coaching engagement surveys — measuring coaching quality and perceived impact
-- Golden path template adoption rate in Backstage — percentage of new projects starting from a quality-configured template
+| Metric | Target | Frequency |
+|---|---|---|
+| DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement | — | — |
+| Code quality gate adoption rate across delivery teams (percentage of active pipelines with configured and enforced quality gates) | — | — |
+| Number of distinct teams coached per quarter, with a defined engagement scope and measurable outcome | — | — |
+| Engineering practice maturity score delta — improvement in structured maturity assessment scores across coached teams | — | — |
+| Test coverage trend across teams using shared pipeline templates with quality gate enforcement | — | — |
+| Definition of Done completeness rate — percentage of teams with formally documented and tool-embedded DoD criteria | — | — |
+| Practitioner feedback score from post-coaching engagement surveys — measuring coaching quality and perceived impact | — | — |
+| Golden path template adoption rate in Backstage — percentage of new projects starting from a quality-configured template | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -136,11 +136,11 @@ The Engineering Practices Champion is a senior individual contributor and intern
 
 | Metric | Target | Frequency |
 |---|---|---|
-| DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement | — | — |
+| DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement | ≤15% (proposed) | Monthly |
 | Code quality gate adoption rate across delivery teams (percentage of active pipelines with configured and enforced quality gates) | — | — |
 | Number of distinct teams coached per quarter, with a defined engagement scope and measurable outcome | — | — |
 | Engineering practice maturity score delta — improvement in structured maturity assessment scores across coached teams | — | — |
-| Test coverage trend across teams using shared pipeline templates with quality gate enforcement | — | — |
+| Test coverage trend across teams using shared pipeline templates with quality gate enforcement | ≥80% (proposed) | Monthly |
 | Definition of Done completeness rate — percentage of teams with formally documented and tool-embedded DoD criteria | — | — |
 | Practitioner feedback score from post-coaching engagement surveys — measuring coaching quality and perceived impact | — | — |
 | Golden path template adoption rate in Backstage — percentage of new projects starting from a quality-configured template | — | — |

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -136,16 +136,18 @@ The Product Area Lead (PAL) is a senior IT management role responsible for the e
 
 ## Key Performance Indicators
 
-- Service availability and SLA compliance across the product area
-- Delivery predictability (percentage of committed roadmap items delivered on time)
-- Budget adherence (actual spend vs. plan)
-- Employee engagement and retention scores within the area
-- Time-to-hire for open positions in the area
-- Stakeholder satisfaction scores (business and internal)
-- Risk and compliance posture of services within the area
-- Vendor performance against contracted SLAs
-- Team capability growth (certifications, competency progression)
-- Cross-area dependency resolution speed
+| Metric | Target | Frequency |
+|---|---|---|
+| Service availability and SLA compliance across the product area | — | — |
+| Delivery predictability (percentage of committed roadmap items delivered on time) | — | — |
+| Budget adherence (actual spend vs. plan) | — | — |
+| Employee engagement and retention scores within the area | — | — |
+| Time-to-hire for open positions in the area | — | — |
+| Stakeholder satisfaction scores (business and internal) | — | — |
+| Risk and compliance posture of services within the area | — | — |
+| Vendor performance against contracted SLAs | — | — |
+| Team capability growth (certifications, competency progression) | — | — |
+| Cross-area dependency resolution speed | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -138,12 +138,12 @@ The Product Area Lead (PAL) is a senior IT management role responsible for the e
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Service availability and SLA compliance across the product area | — | — |
+| Service availability and SLA compliance across the product area | ≥95% (proposed) | Monthly |
 | Delivery predictability (percentage of committed roadmap items delivered on time) | — | — |
 | Budget adherence (actual spend vs. plan) | — | — |
 | Employee engagement and retention scores within the area | — | — |
 | Time-to-hire for open positions in the area | — | — |
-| Stakeholder satisfaction scores (business and internal) | — | — |
+| Stakeholder satisfaction scores (business and internal) | ≥85% (proposed) | Quarterly |
 | Risk and compliance posture of services within the area | — | — |
 | Vendor performance against contracted SLAs | — | — |
 | Team capability growth (certifications, competency progression) | — | — |

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -138,16 +138,18 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 
 ## Key Performance Indicators
 
-- Chapter practitioner retention rate and voluntary attrition trend
-- Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires)
-- Chapter satisfaction score (internal survey results for the Security & Identity chapter)
-- Security architecture standards adoption rate across all technology domains
-- Zero trust roadmap milestone completion rate against agreed programme timeline
-- Identity governance coverage — percentage of identities under IGA and PAM control
-- Data protection policy compliance rate across data-handling platforms
-- Security toolchain rationalisation progress — coverage gaps and duplicate tool reduction
-- Threat modelling adoption rate in architecture review processes across chapters
-- Mean time to remediate critical and high architecture-level security findings
+| Metric | Target | Frequency |
+|---|---|---|
+| Chapter practitioner retention rate and voluntary attrition trend | — | — |
+| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| Chapter satisfaction score (internal survey results for the Security & Identity chapter) | — | — |
+| Security architecture standards adoption rate across all technology domains | — | — |
+| Zero trust roadmap milestone completion rate against agreed programme timeline | — | — |
+| Identity governance coverage — percentage of identities under IGA and PAM control | — | — |
+| Data protection policy compliance rate across data-handling platforms | — | — |
+| Security toolchain rationalisation progress — coverage gaps and duplicate tool reduction | — | — |
+| Threat modelling adoption rate in architecture review processes across chapters | — | — |
+| Mean time to remediate critical and high architecture-level security findings | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -142,7 +142,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
-| Chapter satisfaction score (internal survey results for the Security & Identity chapter) | — | — |
+| Chapter satisfaction score (internal survey results for the Security & Identity chapter) | ≥85% (proposed) | Quarterly |
 | Security architecture standards adoption rate across all technology domains | — | — |
 | Zero trust roadmap milestone completion rate against agreed programme timeline | — | — |
 | Identity governance coverage — percentage of identities under IGA and PAM control | — | — |

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -137,16 +137,18 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 
 ## Key Performance Indicators
 
-- Chapter practitioner retention rate and voluntary attrition trend
-- Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires)
-- Chapter satisfaction score (internal survey results for the Service & Governance chapter)
-- ITSM process maturity level across all ITIL 4 processes (measured against ITIL 4 maturity model)
-- CMDB accuracy and completeness rate for critical configuration item classes
-- EA governance board throughput — submission-to-decision cycle time and architecture compliance rate
-- Service catalogue coverage — percentage of IT services with accurate, maintained catalogue entries
-- Infrastructure onboarding playbook adherence rate across chapters
-- IT compliance reporting accuracy and on-time delivery rate
-- Change management success rate and change-related incident trend
+| Metric | Target | Frequency |
+|---|---|---|
+| Chapter practitioner retention rate and voluntary attrition trend | — | — |
+| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| Chapter satisfaction score (internal survey results for the Service & Governance chapter) | — | — |
+| ITSM process maturity level across all ITIL 4 processes (measured against ITIL 4 maturity model) | — | — |
+| CMDB accuracy and completeness rate for critical configuration item classes | — | — |
+| EA governance board throughput — submission-to-decision cycle time and architecture compliance rate | — | — |
+| Service catalogue coverage — percentage of IT services with accurate, maintained catalogue entries | — | — |
+| Infrastructure onboarding playbook adherence rate across chapters | — | — |
+| IT compliance reporting accuracy and on-time delivery rate | — | — |
+| Change management success rate and change-related incident trend | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -141,7 +141,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
-| Chapter satisfaction score (internal survey results for the Service & Governance chapter) | — | — |
+| Chapter satisfaction score (internal survey results for the Service & Governance chapter) | ≥85% (proposed) | Quarterly |
 | ITSM process maturity level across all ITIL 4 processes (measured against ITIL 4 maturity model) | — | — |
 | CMDB accuracy and completeness rate for critical configuration item classes | — | — |
 | EA governance board throughput — submission-to-decision cycle time and architecture compliance rate | — | — |

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -153,7 +153,7 @@ The SVP of Technology sits above the Product Area Lead (PAL) and Technical Area 
 | Enterprise technology risk posture (board-level risk rating trend) | — | — |
 | IT spend as a percentage of revenue and against peer benchmarks | — | — |
 | Technology function employee engagement and senior leadership retention | — | — |
-| Board and executive satisfaction with technology governance and reporting | — | — |
+| Board and executive satisfaction with technology governance and reporting | ≥85% (proposed) | Quarterly |
 | Strategic vendor and partner performance against enterprise agreements | — | — |
 | Technology capability maturity progression (measured against defined target state) | — | — |
 | Time-to-value for major technology platform and product investments | — | — |

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -146,16 +146,18 @@ The SVP of Technology sits above the Product Area Lead (PAL) and Technical Area 
 
 ## Key Performance Indicators
 
-- Technology ROI and value realisation from major technology investments
-- Digital transformation programme delivery against strategic milestones
-- Enterprise technology risk posture (board-level risk rating trend)
-- IT spend as a percentage of revenue and against peer benchmarks
-- Technology function employee engagement and senior leadership retention
-- Board and executive satisfaction with technology governance and reporting
-- Strategic vendor and partner performance against enterprise agreements
-- Technology capability maturity progression (measured against defined target state)
-- Time-to-value for major technology platform and product investments
-- Regulatory compliance posture across all technology-governed domains
+| Metric | Target | Frequency |
+|---|---|---|
+| Technology ROI and value realisation from major technology investments | — | — |
+| Digital transformation programme delivery against strategic milestones | — | — |
+| Enterprise technology risk posture (board-level risk rating trend) | — | — |
+| IT spend as a percentage of revenue and against peer benchmarks | — | — |
+| Technology function employee engagement and senior leadership retention | — | — |
+| Board and executive satisfaction with technology governance and reporting | — | — |
+| Strategic vendor and partner performance against enterprise agreements | — | — |
+| Technology capability maturity progression (measured against defined target state) | — | — |
+| Time-to-value for major technology platform and product investments | — | — |
+| Regulatory compliance posture across all technology-governed domains | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -133,16 +133,18 @@ The Technical Area Lead (TAL) is the senior technical authority for a defined IT
 
 ## Key Performance Indicators
 
-- Architecture standards adoption rate across area domains
-- Technical debt trend (age, volume, and resolution velocity)
-- Platform availability and reliability metrics for area-owned services
-- Engineering hiring quality (90-day retention, performance of TAL-approved hires)
-- Innovation adoption rate (new technologies successfully adopted and operationalized)
-- Technical risk resolution rate and time-to-remediate critical risks
-- Engineer and architect satisfaction with technical leadership and direction
-- Architecture review cycle time and decision quality
-- Cross-area technical dependency resolution speed
-- Senior engineer and architect promotion and retention rate
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture standards adoption rate across area domains | — | — |
+| Technical debt trend (age, volume, and resolution velocity) | — | — |
+| Platform availability and reliability metrics for area-owned services | — | — |
+| Engineering hiring quality (90-day retention, performance of TAL-approved hires) | — | — |
+| Innovation adoption rate (new technologies successfully adopted and operationalized) | — | — |
+| Technical risk resolution rate and time-to-remediate critical risks | — | — |
+| Engineer and architect satisfaction with technical leadership and direction | — | — |
+| Architecture review cycle time and decision quality | — | — |
+| Cross-area technical dependency resolution speed | — | — |
+| Senior engineer and architect promotion and retention rate | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -137,11 +137,11 @@ The Technical Area Lead (TAL) is the senior technical authority for a defined IT
 |---|---|---|
 | Architecture standards adoption rate across area domains | — | — |
 | Technical debt trend (age, volume, and resolution velocity) | — | — |
-| Platform availability and reliability metrics for area-owned services | — | — |
+| Platform availability and reliability metrics for area-owned services | ≥99.9% (proposed) | Monthly |
 | Engineering hiring quality (90-day retention, performance of TAL-approved hires) | — | — |
 | Innovation adoption rate (new technologies successfully adopted and operationalized) | — | — |
 | Technical risk resolution rate and time-to-remediate critical risks | — | — |
-| Engineer and architect satisfaction with technical leadership and direction | — | — |
+| Engineer and architect satisfaction with technical leadership and direction | ≥85% (proposed) | Quarterly |
 | Architecture review cycle time and decision quality | — | — |
 | Cross-area technical dependency resolution speed | — | — |
 | Senior engineer and architect promotion and retention rate | — | — |

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -136,7 +136,7 @@ The Technical Community Leader is a senior individual contributor responsible fo
 | CoP session attendance rate and active participation trend (contributors, not just attendees) | — | — |
 | Number of cross-domain knowledge transfer events facilitated per quarter | — | — |
 | Volume and currency of internal technical content published (articles, guides, radar updates, standards) | — | — |
-| Practitioner satisfaction score from periodic community engagement surveys | — | — |
+| Practitioner satisfaction score from periodic community engagement surveys | ≥85% (proposed) | Quarterly |
 | Adoption rate of shared standards and patterns across engineering teams | — | — |
 | Time from standard proposal to published and communicated adoption guidance | — | — |
 | Hackathon and knowledge share event participation across domain boundaries | — | — |

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -131,14 +131,16 @@ The Technical Community Leader is a senior individual contributor responsible fo
 
 ## Key Performance Indicators
 
-- CoP session attendance rate and active participation trend (contributors, not just attendees)
-- Number of cross-domain knowledge transfer events facilitated per quarter
-- Volume and currency of internal technical content published (articles, guides, radar updates, standards)
-- Practitioner satisfaction score from periodic community engagement surveys
-- Adoption rate of shared standards and patterns across engineering teams
-- Time from standard proposal to published and communicated adoption guidance
-- Hackathon and knowledge share event participation across domain boundaries
-- HR/L&D alignment coverage — proportion of community learning activities mapped to career framework competencies
+| Metric | Target | Frequency |
+|---|---|---|
+| CoP session attendance rate and active participation trend (contributors, not just attendees) | — | — |
+| Number of cross-domain knowledge transfer events facilitated per quarter | — | — |
+| Volume and currency of internal technical content published (articles, guides, radar updates, standards) | — | — |
+| Practitioner satisfaction score from periodic community engagement surveys | — | — |
+| Adoption rate of shared standards and patterns across engineering teams | — | — |
+| Time from standard proposal to published and communicated adoption guidance | — | — |
+| Hackathon and knowledge share event participation across domain boundaries | — | — |
+| HR/L&D alignment coverage — proportion of community learning activities mapped to career framework competencies | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -143,12 +143,14 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 
 ## Key Performance Indicators
 
-- Number of chaos experiments executed per quarter
-- Resilience weaknesses discovered and remediated
-- Game day exercises conducted per year (target: per major service domain)
-- Services with automated pre-production chaos gates in CI/CD
-- MTTD validation accuracy (alerts triggered within target window during experiments)
-- Stakeholder participation rate in game days
+| Metric | Target | Frequency |
+|---|---|---|
+| Number of chaos experiments executed per quarter | — | — |
+| Resilience weaknesses discovered and remediated | — | — |
+| Game day exercises conducted per year (target: per major service domain) | — | — |
+| Services with automated pre-production chaos gates in CI/CD | — | — |
+| MTTD validation accuracy (alerts triggered within target window during experiments) | — | — |
+| Stakeholder participation rate in game days | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -149,7 +149,7 @@ The Chaos Engineer designs, implements, and executes controlled failure experime
 | Resilience weaknesses discovered and remediated | — | — |
 | Game day exercises conducted per year (target: per major service domain) | — | — |
 | Services with automated pre-production chaos gates in CI/CD | — | — |
-| MTTD validation accuracy (alerts triggered within target window during experiments) | — | — |
+| MTTD validation accuracy (alerts triggered within target window during experiments) | ≤24 hours (proposed) | Monthly |
 | Stakeholder participation rate in game days | — | — |
 
 ## Remote Work Considerations

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -128,7 +128,7 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 
 | Metric | Target | Frequency |
 |---|---|---|
-| AI platform availability and reliability for model serving workloads | — | — |
+| AI platform availability and reliability for model serving workloads | ≥99.9% (proposed) | Monthly |
 | Time-to-production for new AI/LLM applications using the platform | — | — |
 | AI cost per unit of value delivered (token cost efficiency, GPU utilization) | — | — |
 | Coverage of AI security and governance controls across deployments | — | — |
@@ -139,7 +139,7 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 | Responsible AI compliance rate across AI deployments | — | — |
 | Knowledge transfer and enablement effectiveness | — | — |
 | Edge AI model deployment coverage: ≥80% of approved edge AI workloads served via standardised edge inference patterns | ≥80% | — |
-| Edge inference latency: p95 inference latency within agreed SLA for latency-sensitive edge AI applications | — | — |
+| Edge inference latency: p95 inference latency within agreed SLA for latency-sensitive edge AI applications | ≥95% (proposed) | Monthly |
 
 ## Role Scope & Boundaries
 

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -126,18 +126,20 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 
 ## Key Performance Indicators
 
-- AI platform availability and reliability for model serving workloads
-- Time-to-production for new AI/LLM applications using the platform
-- AI cost per unit of value delivered (token cost efficiency, GPU utilization)
-- Coverage of AI security and governance controls across deployments
-- Developer adoption of AI platform golden paths and reference architectures
-- Model evaluation score improvements through platform tooling
-- Reduction in AI-related security incidents and prompt injection attempts
-- AI platform scalability under demand spikes
-- Responsible AI compliance rate across AI deployments
-- Knowledge transfer and enablement effectiveness
-- Edge AI model deployment coverage: ≥80% of approved edge AI workloads served via standardised edge inference patterns
-- Edge inference latency: p95 inference latency within agreed SLA for latency-sensitive edge AI applications
+| Metric | Target | Frequency |
+|---|---|---|
+| AI platform availability and reliability for model serving workloads | — | — |
+| Time-to-production for new AI/LLM applications using the platform | — | — |
+| AI cost per unit of value delivered (token cost efficiency, GPU utilization) | — | — |
+| Coverage of AI security and governance controls across deployments | — | — |
+| Developer adoption of AI platform golden paths and reference architectures | — | — |
+| Model evaluation score improvements through platform tooling | — | — |
+| Reduction in AI-related security incidents and prompt injection attempts | — | — |
+| AI platform scalability under demand spikes | — | — |
+| Responsible AI compliance rate across AI deployments | — | — |
+| Knowledge transfer and enablement effectiveness | — | — |
+| Edge AI model deployment coverage: ≥80% of approved edge AI workloads served via standardised edge inference patterns | ≥80% | — |
+| Edge inference latency: p95 inference latency within agreed SLA for latency-sensitive edge AI applications | — | — |
 
 ## Role Scope & Boundaries
 

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -141,12 +141,12 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 
 | Metric | Target | Frequency |
 |---|---|---|
-| LLM serving reliability and latency SLA compliance | — | — |
+| LLM serving reliability and latency SLA compliance | ≥95% (proposed) | Monthly |
 | RAG pipeline retrieval accuracy and end-to-end quality scores | — | — |
 | AI platform cost per request / token cost efficiency | — | — |
 | Time to onboard new teams onto AI platform capabilities | — | — |
 | AI security control effectiveness (blocked prompt injection attempts) | — | — |
-| Mean time to restore for AI platform incidents | — | — |
+| Mean time to restore for AI platform incidents | ≤4 hours (proposed) | Monthly |
 | Coverage of AI workloads under observability and evaluation monitoring | — | — |
 | Deployment automation coverage and frequency | — | — |
 | Quality and completeness of platform documentation | — | — |

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -139,15 +139,17 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 
 ## Key Performance Indicators
 
-- LLM serving reliability and latency SLA compliance
-- RAG pipeline retrieval accuracy and end-to-end quality scores
-- AI platform cost per request / token cost efficiency
-- Time to onboard new teams onto AI platform capabilities
-- AI security control effectiveness (blocked prompt injection attempts)
-- Mean time to restore for AI platform incidents
-- Coverage of AI workloads under observability and evaluation monitoring
-- Deployment automation coverage and frequency
-- Quality and completeness of platform documentation
+| Metric | Target | Frequency |
+|---|---|---|
+| LLM serving reliability and latency SLA compliance | — | — |
+| RAG pipeline retrieval accuracy and end-to-end quality scores | — | — |
+| AI platform cost per request / token cost efficiency | — | — |
+| Time to onboard new teams onto AI platform capabilities | — | — |
+| AI security control effectiveness (blocked prompt injection attempts) | — | — |
+| Mean time to restore for AI platform incidents | — | — |
+| Coverage of AI workloads under observability and evaluation monitoring | — | — |
+| Deployment automation coverage and frequency | — | — |
+| Quality and completeness of platform documentation | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/infrastructure_automation_architect.md
+++ b/Roles/modern_infrastructure/infrastructure_automation_architect.md
@@ -147,15 +147,17 @@ The Infrastructure Automation Architect designs and governs the organisation's e
 
 ## Key Performance Indicators
 
-- IaC coverage rate: ≥90% of cloud infrastructure managed as code and tracked in version control within 12 months of standard publication
-- Reusable module adoption: ≥75% of new infrastructure provisioning using modules from the approved internal IaC module library
-- Compliance-as-code pass rate: ≥95% of IaC pipeline runs passing all mandatory compliance-as-code gates without manual overrides
-- Infrastructure drift detection rate: 100% of IaC-managed infrastructure enrolled in drift detection, with critical drift remediated within 24 hours
-- IaC provisioning lead time: median time to provision a standard cloud environment reduced to ≤4 hours via automation
-- Runbook automation coverage: ≥60% of Tier 1 operational runbooks automated or partially automated within 12 months
-- Automation-related incident rate: fewer than 3 production incidents per quarter attributable to automation errors or unchecked drift
-- Infracost integration coverage: ≥80% of IaC pipelines generating cost estimates before infrastructure approval
-- Edge node provisioning automation coverage: ≥80% of edge nodes provisioned via automated IaC pipelines within 12 months of edge automation standard publication
+| Metric | Target | Frequency |
+|---|---|---|
+| IaC coverage rate: ≥90% of cloud infrastructure managed as code and tracked in version control within 12 months of standard publication | ≥90% | — |
+| Reusable module adoption: ≥75% of new infrastructure provisioning using modules from the approved internal IaC module library | ≥75% | — |
+| Compliance-as-code pass rate: ≥95% of IaC pipeline runs passing all mandatory compliance-as-code gates without manual overrides | ≥95% | — |
+| Infrastructure drift detection rate: 100% of IaC-managed infrastructure enrolled in drift detection, with critical drift remediated within 24 hours | 100% | — |
+| IaC provisioning lead time: median time to provision a standard cloud environment reduced to ≤4 hours via automation | ≤4 hours | — |
+| Runbook automation coverage: ≥60% of Tier 1 operational runbooks automated or partially automated within 12 months | ≥60% | — |
+| Automation-related incident rate: fewer than 3 production incidents per quarter attributable to automation errors or unchecked drift | — | — |
+| Infracost integration coverage: ≥80% of IaC pipelines generating cost estimates before infrastructure approval | ≥80% | — |
+| Edge node provisioning automation coverage: ≥80% of edge nodes provisioned via automated IaC pipelines within 12 months of edge automation standard publication | ≥80% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -145,9 +145,9 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 |---|---|---|
 | ML model deployment time and reliability | — | — |
 | Pipeline automation coverage | — | — |
-| Model serving availability and performance | — | — |
-| Time to detect and resolve model issues | — | — |
-| Model deployment frequency | — | — |
+| Model serving availability and performance | ≥99.9% (proposed) | Monthly |
+| Time to detect and resolve model issues | ≤24 hours (proposed) | Monthly |
+| Model deployment frequency | Weekly or better (proposed) | Monthly |
 | Infrastructure cost optimization for ML workloads | — | — |
 | Reproducibility of ML workflows | — | — |
 | Model monitoring coverage | — | — |

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -141,18 +141,20 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 ## Key Performance Indicators
 
-- ML model deployment time and reliability
-- Pipeline automation coverage
-- Model serving availability and performance
-- Time to detect and resolve model issues
-- Model deployment frequency
-- Infrastructure cost optimization for ML workloads
-- Reproducibility of ML workflows
-- Model monitoring coverage
-- Feature engineering automation level
-- Knowledge sharing and documentation quality
-- Edge model deployment automation coverage: ≥80% of edge model updates delivered via automated pipelines
-- Edge model drift detection rate: ≥90% of edge-deployed models under active performance monitoring
+| Metric | Target | Frequency |
+|---|---|---|
+| ML model deployment time and reliability | — | — |
+| Pipeline automation coverage | — | — |
+| Model serving availability and performance | — | — |
+| Time to detect and resolve model issues | — | — |
+| Model deployment frequency | — | — |
+| Infrastructure cost optimization for ML workloads | — | — |
+| Reproducibility of ML workflows | — | — |
+| Model monitoring coverage | — | — |
+| Feature engineering automation level | — | — |
+| Knowledge sharing and documentation quality | — | — |
+| Edge model deployment automation coverage: ≥80% of edge model updates delivered via automated pipelines | ≥80% | — |
+| Edge model drift detection rate: ≥90% of edge-deployed models under active performance monitoring | ≥90% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -150,14 +150,16 @@ The Observability Architect designs and governs the organisation's full-stack ob
 
 ## Key Performance Indicators
 
-- Mean time to detect (MTTD) for P1/P2 incidents: target reduction of ≥20% year-on-year
-- SLO achievement rate across critical services: ≥95% of defined SLOs met per quarter
-- Observability coverage: ≥90% of production services emitting metrics, logs, and traces conforming to standards
-- Alert signal-to-noise ratio: false positive alert rate below 15% of total actionable alerts triggered
-- Telemetry pipeline cost per observed service: tracked and within agreed FinOps budget envelope each quarter
-- Time-to-instrument new services: median instrumentation to production observability within 5 business days
-- OpenTelemetry standard adoption: ≥80% of new services instrumented using org standards within 6 months of standard publication
-- Edge observability coverage: ≥80% of edge nodes emitting conformant metrics, logs, and traces within 3 months of edge platform deployment
+| Metric | Target | Frequency |
+|---|---|---|
+| Mean time to detect (MTTD) for P1/P2 incidents: target reduction of ≥20% year-on-year | ≥20% | — |
+| SLO achievement rate across critical services: ≥95% of defined SLOs met per quarter | ≥95% | — |
+| Observability coverage: ≥90% of production services emitting metrics, logs, and traces conforming to standards | ≥90% | — |
+| Alert signal-to-noise ratio: false positive alert rate below 15% of total actionable alerts triggered | 15% | — |
+| Telemetry pipeline cost per observed service: tracked and within agreed FinOps budget envelope each quarter | — | — |
+| Time-to-instrument new services: median instrumentation to production observability within 5 business days | — | — |
+| OpenTelemetry standard adoption: ≥80% of new services instrumented using org standards within 6 months of standard publication | ≥80% | — |
+| Edge observability coverage: ≥80% of edge nodes emitting conformant metrics, logs, and traces within 3 months of edge platform deployment | ≥80% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -123,12 +123,14 @@ The Observability Engineer implements and maintains monitoring, logging, and tra
 
 ## Key Performance Indicators
 
-- Reliability and performance of observability platforms
-- Coverage of monitoring across critical systems
-- Quality and usefulness of dashboards and visualizations
-- Effectiveness of alerting in detecting actual issues
-- Timeliness of resolving observability platform issues
-- Comprehensiveness of monitoring documentation
+| Metric | Target | Frequency |
+|---|---|---|
+| Reliability and performance of observability platforms | — | — |
+| Coverage of monitoring across critical systems | — | — |
+| Quality and usefulness of dashboards and visualizations | — | — |
+| Effectiveness of alerting in detecting actual issues | — | — |
+| Timeliness of resolving observability platform issues | — | — |
+| Comprehensiveness of monitoring documentation | — | — |
 
 ## Typical Day-to-Day Activities
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -114,7 +114,7 @@ The Observability Product Owner manages the observability platform portfolio, de
 | Metric | Target | Frequency |
 |---|---|---|
 | Platform adoption rates across teams | — | — |
-| Stakeholder satisfaction with observability services | — | — |
+| Stakeholder satisfaction with observability services | ≥85% (proposed) | Quarterly |
 | Successful delivery of roadmap initiatives | — | — |
 | Quality of backlog management and prioritization | — | — |
 | Effectiveness of observability in improving system reliability | — | — |

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -111,12 +111,14 @@ The Observability Product Owner manages the observability platform portfolio, de
 
 ## Key Performance Indicators
 
-- Platform adoption rates across teams
-- Stakeholder satisfaction with observability services
-- Successful delivery of roadmap initiatives
-- Quality of backlog management and prioritization
-- Effectiveness of observability in improving system reliability
-- Clear demonstration of platform value to the business
+| Metric | Target | Frequency |
+|---|---|---|
+| Platform adoption rates across teams | — | — |
+| Stakeholder satisfaction with observability services | — | — |
+| Successful delivery of roadmap initiatives | — | — |
+| Quality of backlog management and prioritization | — | — |
+| Effectiveness of observability in improving system reliability | — | — |
+| Clear demonstration of platform value to the business | — | — |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -112,12 +112,14 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 
 ## Key Performance Indicators
 
-- Successful implementation of complex observability solutions
-- Effectiveness of advanced alerting and detection mechanisms
-- Platform scalability and performance improvements
-- Quality of technical leadership and mentorship
-- Contribution to observability standards and patterns
-- Implementation of innovative monitoring approaches
+| Metric | Target | Frequency |
+|---|---|---|
+| Successful implementation of complex observability solutions | — | — |
+| Effectiveness of advanced alerting and detection mechanisms | — | — |
+| Platform scalability and performance improvements | — | — |
+| Quality of technical leadership and mentorship | — | — |
+| Contribution to observability standards and patterns | — | — |
+| Implementation of innovative monitoring approaches | — | — |
 
 ## Key Technologies
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -151,7 +151,7 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 | Technical leadership effectiveness | — | — |
 | Knowledge transfer to engineering teams | — | — |
 | Edge workload onboarding time: time from request to production-ready edge deployment | — | — |
-| Edge platform availability: uptime SLA for IDP golden paths and self-service tooling at edge locations | — | — |
+| Edge platform availability: uptime SLA for IDP golden paths and self-service tooling at edge locations | ≥95% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -138,18 +138,20 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of platform design with developer needs
-- Platform architecture scalability and flexibility
-- Developer experience improvement through architecture
-- Platform reliability and performance through design
-- Adoption of reference architectures and golden paths
-- Reduction in architectural complexity
-- Innovation in platform approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
-- Edge workload onboarding time: time from request to production-ready edge deployment
-- Edge platform availability: uptime SLA for IDP golden paths and self-service tooling at edge locations
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of platform design with developer needs | — | — |
+| Platform architecture scalability and flexibility | — | — |
+| Developer experience improvement through architecture | — | — |
+| Platform reliability and performance through design | — | — |
+| Adoption of reference architectures and golden paths | — | — |
+| Reduction in architectural complexity | — | — |
+| Innovation in platform approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
+| Edge workload onboarding time: time from request to production-ready edge deployment | — | — |
+| Edge platform availability: uptime SLA for IDP golden paths and self-service tooling at edge locations | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -135,7 +135,7 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Platform component reliability and uptime | — | — |
+| Platform component reliability and uptime | ≥99.9% (proposed) | Monthly |
 | Implementation quality of platform features | — | — |
 | Documentation quality and completeness | — | — |
 | Developer onboarding efficiency | — | — |

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -133,16 +133,18 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 ## Key Performance Indicators
 
-- Platform component reliability and uptime
-- Implementation quality of platform features
-- Documentation quality and completeness
-- Developer onboarding efficiency
-- Platform issue resolution time
-- Self-service capability effectiveness
-- Template and golden path usage rates
-- Developer support responsiveness
-- Platform deployment automation success rate
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Platform component reliability and uptime | — | — |
+| Implementation quality of platform features | — | — |
+| Documentation quality and completeness | — | — |
+| Developer onboarding efficiency | — | — |
+| Platform issue resolution time | — | — |
+| Self-service capability effectiveness | — | — |
+| Template and golden path usage rates | — | — |
+| Developer support responsiveness | — | — |
+| Platform deployment automation success rate | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -134,7 +134,7 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Developer satisfaction with platform experience | — | — |
+| Developer satisfaction with platform experience | ≥85% (proposed) | Quarterly |
 | Platform adoption rates across development teams | — | — |
 | Time-to-production for new applications | — | — |
 | Developer self-service capability utilization | — | — |

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -132,16 +132,18 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 ## Key Performance Indicators
 
-- Developer satisfaction with platform experience
-- Platform adoption rates across development teams
-- Time-to-production for new applications
-- Developer self-service capability utilization
-- Reduction in developer toil through automation
-- Platform reliability and performance metrics
-- Successful delivery of platform roadmap items
-- Business value delivery through platform capabilities
-- Return on investment for platform initiatives
-- Innovation in developer experience
+| Metric | Target | Frequency |
+|---|---|---|
+| Developer satisfaction with platform experience | — | — |
+| Platform adoption rates across development teams | — | — |
+| Time-to-production for new applications | — | — |
+| Developer self-service capability utilization | — | — |
+| Reduction in developer toil through automation | — | — |
+| Platform reliability and performance metrics | — | — |
+| Successful delivery of platform roadmap items | — | — |
+| Business value delivery through platform capabilities | — | — |
+| Return on investment for platform initiatives | — | — |
+| Innovation in developer experience | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -140,7 +140,7 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 | Developer adoption of platform services | — | — |
 | Implementation quality of platform solutions | — | — |
 | Time to resolution for platform incidents | — | — |
-| Developer experience satisfaction scores | — | — |
+| Developer experience satisfaction scores | ≥85% (proposed) | Quarterly |
 | Reduction in toil through platform automation | — | — |
 | Knowledge transfer effectiveness to platform engineers | — | — |
 | Time-to-deployment improvement through platform | — | — |

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -134,16 +134,18 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 
 ## Key Performance Indicators
 
-- Platform stability and reliability metrics
-- Developer adoption of platform services
-- Implementation quality of platform solutions
-- Time to resolution for platform incidents
-- Developer experience satisfaction scores
-- Reduction in toil through platform automation
-- Knowledge transfer effectiveness to platform engineers
-- Time-to-deployment improvement through platform
-- Platform service catalog expansion
-- Innovation in platform capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| Platform stability and reliability metrics | — | — |
+| Developer adoption of platform services | — | — |
+| Implementation quality of platform solutions | — | — |
+| Time to resolution for platform incidents | — | — |
+| Developer experience satisfaction scores | — | — |
+| Reduction in toil through platform automation | — | — |
+| Knowledge transfer effectiveness to platform engineers | — | — |
+| Time-to-deployment improvement through platform | — | — |
+| Platform service catalog expansion | — | — |
+| Innovation in platform capabilities | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -135,10 +135,10 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| System availability and reliability metrics | — | — |
-| Mean time to detection (MTTD) for incidents | — | — |
-| Mean time to recovery (MTTR) from failures | — | — |
-| SLO/SLA achievement percentages | — | — |
+| System availability and reliability metrics | ≥99.9% (proposed) | Monthly |
+| Mean time to detection (MTTD) for incidents | ≤24 hours (proposed) | Monthly |
+| Mean time to recovery (MTTR) from failures | ≤4 hours (proposed) | Monthly |
+| SLO/SLA achievement percentages | ≥95% (proposed) | Monthly |
 | Percentage of incidents resolved by automated remediation | — | — |
 | Reduction in toil through automation | — | — |
 | Accuracy of capacity planning | — | — |

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -133,16 +133,18 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 ## Key Performance Indicators
 
-- System availability and reliability metrics
-- Mean time to detection (MTTD) for incidents
-- Mean time to recovery (MTTR) from failures
-- SLO/SLA achievement percentages
-- Percentage of incidents resolved by automated remediation
-- Reduction in toil through automation
-- Accuracy of capacity planning
-- Effectiveness of observability solutions
-- Quality of postmortem analysis and improvements
-- Knowledge sharing and documentation quality
+| Metric | Target | Frequency |
+|---|---|---|
+| System availability and reliability metrics | — | — |
+| Mean time to detection (MTTD) for incidents | — | — |
+| Mean time to recovery (MTTR) from failures | — | — |
+| SLO/SLA achievement percentages | — | — |
+| Percentage of incidents resolved by automated remediation | — | — |
+| Reduction in toil through automation | — | — |
+| Accuracy of capacity planning | — | — |
+| Effectiveness of observability solutions | — | — |
+| Quality of postmortem analysis and improvements | — | — |
+| Knowledge sharing and documentation quality | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -145,13 +145,15 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 
 ## Key Performance Indicators
 
-- SLO target achievement rate per service
-- Error budget consumption trends (healthy burn rate)
-- Mean time to detect (MTTD) for P1/P2 incidents
-- Mean time to recover (MTTR) for P1/P2 incidents
-- Toil hours per week (trend: decreasing)
-- Post-mortem completion rate and action item close rate
-- Chaos experiment coverage across critical service tier
+| Metric | Target | Frequency |
+|---|---|---|
+| SLO target achievement rate per service | — | — |
+| Error budget consumption trends (healthy burn rate) | — | — |
+| Mean time to detect (MTTD) for P1/P2 incidents | — | — |
+| Mean time to recover (MTTR) for P1/P2 incidents | — | — |
+| Toil hours per week (trend: decreasing) | — | — |
+| Post-mortem completion rate and action item close rate | — | — |
+| Chaos experiment coverage across critical service tier | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -149,8 +149,8 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 |---|---|---|
 | SLO target achievement rate per service | — | — |
 | Error budget consumption trends (healthy burn rate) | — | — |
-| Mean time to detect (MTTD) for P1/P2 incidents | — | — |
-| Mean time to recover (MTTR) for P1/P2 incidents | — | — |
+| Mean time to detect (MTTD) for P1/P2 incidents | ≤24 hours (proposed) | Monthly |
+| Mean time to recover (MTTR) for P1/P2 incidents | ≤4 hours (proposed) | Monthly |
 | Toil hours per week (trend: decreasing) | — | — |
 | Post-mortem completion rate and action item close rate | — | — |
 | Chaos experiment coverage across critical service tier | — | — |

--- a/Roles/modern_workplace/modern_workplace_architect.md
+++ b/Roles/modern_workplace/modern_workplace_architect.md
@@ -145,12 +145,12 @@ The Modern Workplace Architect is responsible for designing, governing, and evol
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Microsoft 365 service availability (Exchange, Teams, SharePoint) | — | — |
+| Microsoft 365 service availability (Exchange, Teams, SharePoint) | ≥99.9% (proposed) | Monthly |
 | Microsoft Secure Score target achievement | — | — |
 | M365 Copilot adoption rate (active users / licensed users) | — | — |
 | DLP policy match and block accuracy rate | — | — |
-| eDiscovery case turnaround time (Legal SLA compliance) | — | — |
-| User satisfaction with collaboration tools (annual survey) | — | Annual |
+| eDiscovery case turnaround time (Legal SLA compliance) | ≥95% (proposed) | Monthly |
+| User satisfaction with collaboration tools (annual survey) | ≥85% (proposed) | Annual |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_workplace/modern_workplace_architect.md
+++ b/Roles/modern_workplace/modern_workplace_architect.md
@@ -143,12 +143,14 @@ The Modern Workplace Architect is responsible for designing, governing, and evol
 
 ## Key Performance Indicators
 
-- Microsoft 365 service availability (Exchange, Teams, SharePoint)
-- Microsoft Secure Score target achievement
-- M365 Copilot adoption rate (active users / licensed users)
-- DLP policy match and block accuracy rate
-- eDiscovery case turnaround time (Legal SLA compliance)
-- User satisfaction with collaboration tools (annual survey)
+| Metric | Target | Frequency |
+|---|---|---|
+| Microsoft 365 service availability (Exchange, Teams, SharePoint) | — | — |
+| Microsoft Secure Score target achievement | — | — |
+| M365 Copilot adoption rate (active users / licensed users) | — | — |
+| DLP policy match and block accuracy rate | — | — |
+| eDiscovery case turnaround time (Legal SLA compliance) | — | — |
+| User satisfaction with collaboration tools (annual survey) | — | Annual |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -130,11 +130,13 @@ The Modern Workplace Engineer administers and supports the organisation's Micros
 
 ## Key Performance Indicators
 
-- Mailbox and Teams provisioning SLA compliance
-- Help desk escalation resolution time
-- M365 user lifecycle task completion accuracy
-- Compliance task turnaround (eDiscovery, holds) within SLA
-- Knowledge base article currency and completeness
+| Metric | Target | Frequency |
+|---|---|---|
+| Mailbox and Teams provisioning SLA compliance | — | — |
+| Help desk escalation resolution time | — | — |
+| M365 user lifecycle task completion accuracy | — | — |
+| Compliance task turnaround (eDiscovery, holds) within SLA | — | — |
+| Knowledge base article currency and completeness | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -132,10 +132,10 @@ The Modern Workplace Engineer administers and supports the organisation's Micros
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Mailbox and Teams provisioning SLA compliance | — | — |
+| Mailbox and Teams provisioning SLA compliance | ≥95% (proposed) | Monthly |
 | Help desk escalation resolution time | — | — |
 | M365 user lifecycle task completion accuracy | — | — |
-| Compliance task turnaround (eDiscovery, holds) within SLA | — | — |
+| Compliance task turnaround (eDiscovery, holds) within SLA | ≥95% (proposed) | Monthly |
 | Knowledge base article currency and completeness | — | — |
 
 ## Remote Work Considerations

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -131,12 +131,14 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 
 ## Key Performance Indicators
 
-- M365 workload adoption rates (monthly active users by product)
-- Microsoft 365 Copilot adoption (active users / licensed)
-- Licensing utilisation efficiency (active use / licensed seats)
-- Employee satisfaction with digital workplace tools (annual survey)
-- Backlog velocity and sprint delivery predictability
-- Roadmap milestones delivered against plan
+| Metric | Target | Frequency |
+|---|---|---|
+| M365 workload adoption rates (monthly active users by product) | — | Monthly |
+| Microsoft 365 Copilot adoption (active users / licensed) | — | — |
+| Licensing utilisation efficiency (active use / licensed seats) | — | — |
+| Employee satisfaction with digital workplace tools (annual survey) | — | Annual |
+| Backlog velocity and sprint delivery predictability | — | — |
+| Roadmap milestones delivered against plan | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -136,7 +136,7 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 | M365 workload adoption rates (monthly active users by product) | — | Monthly |
 | Microsoft 365 Copilot adoption (active users / licensed) | — | — |
 | Licensing utilisation efficiency (active use / licensed seats) | — | — |
-| Employee satisfaction with digital workplace tools (annual survey) | — | Annual |
+| Employee satisfaction with digital workplace tools (annual survey) | ≥85% (proposed) | Annual |
 | Backlog velocity and sprint delivery predictability | — | — |
 | Roadmap milestones delivered against plan | — | — |
 

--- a/Roles/modern_workplace/modern_workplace_senior_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_senior_engineer.md
@@ -134,12 +134,14 @@ The Modern Workplace Senior Engineer implements, manages, and optimises the orga
 
 ## Key Performance Indicators
 
-- Exchange Online mail flow availability and delivery SLA
-- Teams call quality (P.MOS score, call reliability %)
-- Purview compliance policy coverage across tenant
-- Secure Score trend (improving quarter-over-quarter)
-- Help desk escalation response and resolution time
-- Automation scripts deployed (increasing coverage)
+| Metric | Target | Frequency |
+|---|---|---|
+| Exchange Online mail flow availability and delivery SLA | — | — |
+| Teams call quality (P.MOS score, call reliability %) | — | — |
+| Purview compliance policy coverage across tenant | — | — |
+| Secure Score trend (improving quarter-over-quarter) | — | — |
+| Help desk escalation response and resolution time | — | — |
+| Automation scripts deployed (increasing coverage) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_workplace/modern_workplace_senior_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_senior_engineer.md
@@ -136,9 +136,9 @@ The Modern Workplace Senior Engineer implements, manages, and optimises the orga
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Exchange Online mail flow availability and delivery SLA | — | — |
+| Exchange Online mail flow availability and delivery SLA | ≥95% (proposed) | Monthly |
 | Teams call quality (P.MOS score, call reliability %) | — | — |
-| Purview compliance policy coverage across tenant | — | — |
+| Purview compliance policy coverage across tenant | ≥95% (proposed) | Monthly |
 | Secure Score trend (improving quarter-over-quarter) | — | — |
 | Help desk escalation response and resolution time | — | — |
 | Automation scripts deployed (increasing coverage) | — | — |

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -133,19 +133,21 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of network designs with business requirements
-- Network architecture scalability and flexibility
-- Security posture improvement through network design
-- Adoption of network reference architectures
-- Reduction in network-related incidents
-- Network simplification and standardization
-- Innovation in network architectural approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
-- AIOps prediction accuracy for capacity forecasting and incident detection (target: >85% precision)
-- Edge network availability: ≥99.9% connectivity SLA for business-critical edge PoPs and industrial edge sites
-- Edge site deployment time: network provisioning lead time for new edge PoPs reduced via SD-WAN ZTP automation
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of network designs with business requirements | — | — |
+| Network architecture scalability and flexibility | — | — |
+| Security posture improvement through network design | — | — |
+| Adoption of network reference architectures | — | — |
+| Reduction in network-related incidents | — | — |
+| Network simplification and standardization | — | — |
+| Innovation in network architectural approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
+| AIOps prediction accuracy for capacity forecasting and incident detection (target: >85% precision) | >85% | — |
+| Edge network availability: ≥99.9% connectivity SLA for business-critical edge PoPs and industrial edge sites | ≥99.9% | — |
+| Edge site deployment time: network provisioning lead time for new edge PoPs reduced via SD-WAN ZTP automation | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_automation_architect.md
+++ b/Roles/network/network_automation_architect.md
@@ -150,7 +150,7 @@ The Network Automation Architect designs and governs the strategy, tooling, and 
 | Network change cycle time (automated vs. manual benchmark) | — | — |
 | Network compliance check pass rate (automated validation) | — | — |
 | Mean time to remediate network misconfigurations | — | — |
-| Network automation pipeline code coverage and test pass rate | — | — |
+| Network automation pipeline code coverage and test pass rate | ≥80% (proposed) | Monthly |
 | Edge site provisioning automation coverage: ≥80% of new edge PoPs and branch sites provisioned via automated ZTP pipelines | ≥80% | — |
 | Edge network configuration drift rate: near-zero target applied consistently across the edge and branch network estate | — | — |
 

--- a/Roles/network/network_automation_architect.md
+++ b/Roles/network/network_automation_architect.md
@@ -143,14 +143,16 @@ The Network Automation Architect designs and governs the strategy, tooling, and 
 
 ## Key Performance Indicators
 
-- Percentage of network changes deployed via automated pipelines (coverage)
-- Network configuration drift rate (target: near-zero with continuous reconciliation)
-- Network change cycle time (automated vs. manual benchmark)
-- Network compliance check pass rate (automated validation)
-- Mean time to remediate network misconfigurations
-- Network automation pipeline code coverage and test pass rate
-- Edge site provisioning automation coverage: ≥80% of new edge PoPs and branch sites provisioned via automated ZTP pipelines
-- Edge network configuration drift rate: near-zero target applied consistently across the edge and branch network estate
+| Metric | Target | Frequency |
+|---|---|---|
+| Percentage of network changes deployed via automated pipelines (coverage) | — | — |
+| Network configuration drift rate (target: near-zero with continuous reconciliation) | — | — |
+| Network change cycle time (automated vs. manual benchmark) | — | — |
+| Network compliance check pass rate (automated validation) | — | — |
+| Mean time to remediate network misconfigurations | — | — |
+| Network automation pipeline code coverage and test pass rate | — | — |
+| Edge site provisioning automation coverage: ≥80% of new edge PoPs and branch sites provisioned via automated ZTP pipelines | ≥80% | — |
+| Edge network configuration drift rate: near-zero target applied consistently across the edge and branch network estate | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -131,16 +131,18 @@ The Network Automation Engineer specializes in developing and implementing autom
 
 ## Key Performance Indicators
 
-- Percentage of network operations automated
-- Time savings from automated processes
-- Error reduction through automation
-- Network change success rate improvement
-- Code quality and reusability metrics
-- Documentation quality and completeness
-- Testing coverage for network automation
-- Pipeline reliability and performance
-- Innovation in automation approaches
-- Knowledge sharing and enablement
+| Metric | Target | Frequency |
+|---|---|---|
+| Percentage of network operations automated | — | — |
+| Time savings from automated processes | — | — |
+| Error reduction through automation | — | — |
+| Network change success rate improvement | — | — |
+| Code quality and reusability metrics | — | — |
+| Documentation quality and completeness | — | — |
+| Testing coverage for network automation | — | — |
+| Pipeline reliability and performance | — | — |
+| Innovation in automation approaches | — | — |
+| Knowledge sharing and enablement | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -131,16 +131,18 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 
 ## Key Performance Indicators
 
-- Network uptime and availability metrics
-- Mean time to resolution for network incidents
-- Change implementation success rate
-- Documentation quality and completeness
-- Network security policy compliance
-- Network monitoring coverage
-- Response time to service requests
-- Knowledge sharing and collaboration
-- Successful implementation of standard designs
-- Customer satisfaction with network services
+| Metric | Target | Frequency |
+|---|---|---|
+| Network uptime and availability metrics | — | — |
+| Mean time to resolution for network incidents | — | — |
+| Change implementation success rate | — | — |
+| Documentation quality and completeness | — | — |
+| Network security policy compliance | — | — |
+| Network monitoring coverage | — | — |
+| Response time to service requests | — | — |
+| Knowledge sharing and collaboration | — | — |
+| Successful implementation of standard designs | — | — |
+| Customer satisfaction with network services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -133,7 +133,7 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Network uptime and availability metrics | — | — |
+| Network uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for network incidents | — | — |
 | Change implementation success rate | — | — |
 | Documentation quality and completeness | — | — |
@@ -142,7 +142,7 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 | Response time to service requests | — | — |
 | Knowledge sharing and collaboration | — | — |
 | Successful implementation of standard designs | — | — |
-| Customer satisfaction with network services | — | — |
+| Customer satisfaction with network services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -132,9 +132,9 @@ The Network Product Owner manages the development and lifecycle of the organizat
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Network service availability and reliability | — | — |
+| Network service availability and reliability | ≥99.9% (proposed) | Monthly |
 | Time-to-delivery for network services | — | — |
-| Stakeholder satisfaction with network capabilities | — | — |
+| Stakeholder satisfaction with network capabilities | ≥85% (proposed) | Quarterly |
 | Network security posture improvement | — | — |
 | Cost optimization achievements | — | — |
 | Successful delivery of network roadmap items | — | — |

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -130,16 +130,18 @@ The Network Product Owner manages the development and lifecycle of the organizat
 
 ## Key Performance Indicators
 
-- Network service availability and reliability
-- Time-to-delivery for network services
-- Stakeholder satisfaction with network capabilities
-- Network security posture improvement
-- Cost optimization achievements
-- Successful delivery of network roadmap items
-- Network service request fulfillment time
-- Backlog health and prioritization effectiveness
-- Network capacity management accuracy
-- Innovation in network service delivery
+| Metric | Target | Frequency |
+|---|---|---|
+| Network service availability and reliability | — | — |
+| Time-to-delivery for network services | — | — |
+| Stakeholder satisfaction with network capabilities | — | — |
+| Network security posture improvement | — | — |
+| Cost optimization achievements | — | — |
+| Successful delivery of network roadmap items | — | — |
+| Network service request fulfillment time | — | — |
+| Backlog health and prioritization effectiveness | — | — |
+| Network capacity management accuracy | — | — |
+| Innovation in network service delivery | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -131,16 +131,18 @@ The Network Senior Engineer leads the implementation and optimization of complex
 
 ## Key Performance Indicators
 
-- Network availability and reliability metrics
-- Mean time to resolution for complex network issues
-- Implementation quality of network solutions
-- Network security posture improvement
-- Knowledge transfer effectiveness to network engineers
-- Network automation coverage and efficiency
-- Success rate of network migrations and changes
-- Network performance optimization results
-- Customer satisfaction with network services
-- Innovation in network implementation approaches
+| Metric | Target | Frequency |
+|---|---|---|
+| Network availability and reliability metrics | — | — |
+| Mean time to resolution for complex network issues | — | — |
+| Implementation quality of network solutions | — | — |
+| Network security posture improvement | — | — |
+| Knowledge transfer effectiveness to network engineers | — | — |
+| Network automation coverage and efficiency | — | — |
+| Success rate of network migrations and changes | — | — |
+| Network performance optimization results | — | — |
+| Customer satisfaction with network services | — | — |
+| Innovation in network implementation approaches | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -133,7 +133,7 @@ The Network Senior Engineer leads the implementation and optimization of complex
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Network availability and reliability metrics | — | — |
+| Network availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for complex network issues | — | — |
 | Implementation quality of network solutions | — | — |
 | Network security posture improvement | — | — |
@@ -141,7 +141,7 @@ The Network Senior Engineer leads the implementation and optimization of complex
 | Network automation coverage and efficiency | — | — |
 | Success rate of network migrations and changes | — | — |
 | Network performance optimization results | — | — |
-| Customer satisfaction with network services | — | — |
+| Customer satisfaction with network services | ≥85% (proposed) | Quarterly |
 | Innovation in network implementation approaches | — | — |
 
 ## Remote Work Considerations

--- a/Roles/security/devsecops_architect.md
+++ b/Roles/security/devsecops_architect.md
@@ -139,12 +139,14 @@ The DevSecOps Architect is responsible for designing and governing the strategy,
 
 ## Key Performance Indicators
 
-- Percentage of CI/CD pipelines with SAST/SCA gates enforced
-- Mean time to remediate critical and high severity code vulnerabilities
-- Security defect escape rate (defects found in production vs. pipeline)
-- Developer security training completion rate
-- SBOM generation coverage across software portfolio
-- Critical CVE identification to remediation cycle time
+| Metric | Target | Frequency |
+|---|---|---|
+| Percentage of CI/CD pipelines with SAST/SCA gates enforced | — | — |
+| Mean time to remediate critical and high severity code vulnerabilities | — | — |
+| Security defect escape rate (defects found in production vs. pipeline) | — | — |
+| Developer security training completion rate | — | — |
+| SBOM generation coverage across software portfolio | — | — |
+| Critical CVE identification to remediation cycle time | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -139,7 +139,7 @@ The DevSecOps Engineer implements and maintains the security tooling, automation
 | Pipeline SAST/SCA gate coverage percentage | — | — |
 | False positive rate from automated scanning tools (minimised via tuning) | — | — |
 | Mean time to triage and assign vulnerability findings | — | — |
-| Developer satisfaction score with DevSecOps tooling | — | — |
+| Developer satisfaction score with DevSecOps tooling | ≥85% (proposed) | Quarterly |
 | Secret rotation compliance rate | — | — |
 | SBOM generation coverage | — | — |
 

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -134,12 +134,14 @@ The DevSecOps Engineer implements and maintains the security tooling, automation
 
 ## Key Performance Indicators
 
-- Pipeline SAST/SCA gate coverage percentage
-- False positive rate from automated scanning tools (minimised via tuning)
-- Mean time to triage and assign vulnerability findings
-- Developer satisfaction score with DevSecOps tooling
-- Secret rotation compliance rate
-- SBOM generation coverage
+| Metric | Target | Frequency |
+|---|---|---|
+| Pipeline SAST/SCA gate coverage percentage | — | — |
+| False positive rate from automated scanning tools (minimised via tuning) | — | — |
+| Mean time to triage and assign vulnerability findings | — | — |
+| Developer satisfaction score with DevSecOps tooling | — | — |
+| Secret rotation compliance rate | — | — |
+| SBOM generation coverage | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -127,7 +127,7 @@ The Security Architect designs and implements security systems and frameworks th
 | Effectiveness of security controls implementation | — | — |
 | Security standards adoption across the organization | — | — |
 | Quality of security architecture documentation | — | — |
-| Stakeholder satisfaction with security guidance | — | — |
+| Stakeholder satisfaction with security guidance | ≥85% (proposed) | Quarterly |
 | Time to address critical security vulnerabilities | — | — |
 | Security maturity score improvement | — | — |
 | Knowledge sharing and mentoring effectiveness | — | — |

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -119,17 +119,19 @@ The Security Architect designs and implements security systems and frameworks th
 
 ## Key Performance Indicators
 
-- Security architecture compliance rate
-- Reduction in security vulnerabilities and incidents
-- Timely completion of security architecture deliverables
-- Effectiveness of security controls implementation
-- Security standards adoption across the organization
-- Quality of security architecture documentation
-- Stakeholder satisfaction with security guidance
-- Time to address critical security vulnerabilities
-- Security maturity score improvement
-- Knowledge sharing and mentoring effectiveness
-- Number of security engineers advanced to Architect level through mentorship; security training completion rate across engineering teams (%)
+| Metric | Target | Frequency |
+|---|---|---|
+| Security architecture compliance rate | — | — |
+| Reduction in security vulnerabilities and incidents | — | — |
+| Timely completion of security architecture deliverables | — | — |
+| Effectiveness of security controls implementation | — | — |
+| Security standards adoption across the organization | — | — |
+| Quality of security architecture documentation | — | — |
+| Stakeholder satisfaction with security guidance | — | — |
+| Time to address critical security vulnerabilities | — | — |
+| Security maturity score improvement | — | — |
+| Knowledge sharing and mentoring effectiveness | — | — |
+| Number of security engineers advanced to Architect level through mentorship; security training completion rate across engineering teams (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -129,16 +129,18 @@ The Security Engineer implements and maintains security controls and technologie
 
 ## Key Performance Indicators
 
-- Security control implementation quality
-- Vulnerability remediation effectiveness
-- Security incident response time
-- Documentation quality and completeness
-- Security monitoring coverage
-- Compliance with security standards
-- Resolution time for security issues
-- Implementation of security best practices
-- Collaboration with other teams
-- Security knowledge sharing
+| Metric | Target | Frequency |
+|---|---|---|
+| Security control implementation quality | — | — |
+| Vulnerability remediation effectiveness | — | — |
+| Security incident response time | — | — |
+| Documentation quality and completeness | — | — |
+| Security monitoring coverage | — | — |
+| Compliance with security standards | — | — |
+| Resolution time for security issues | — | — |
+| Implementation of security best practices | — | — |
+| Collaboration with other teams | — | — |
+| Security knowledge sharing | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -132,7 +132,7 @@ The Security Engineer implements and maintains security controls and technologie
 | Metric | Target | Frequency |
 |---|---|---|
 | Security control implementation quality | — | — |
-| Vulnerability remediation effectiveness | — | — |
+| Vulnerability remediation effectiveness | ≤30 days (critical) (proposed) | Monthly |
 | Security incident response time | — | — |
 | Documentation quality and completeness | — | — |
 | Security monitoring coverage | — | — |

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -143,16 +143,18 @@ The Security Product Owner manages the development and lifecycle of the organiza
 
 ## Key Performance Indicators
 
-- Security risk reduction effectiveness
-- Time-to-delivery for security capabilities
-- Stakeholder satisfaction with security services
-- Security incident reduction trends
-- Compliance achievement percentage
-- Successful delivery of security roadmap items
-- Security awareness and adoption metrics
-- Backlog health and prioritization effectiveness
-- Return on security investment metrics
-- Security maturity improvement
+| Metric | Target | Frequency |
+|---|---|---|
+| Security risk reduction effectiveness | — | — |
+| Time-to-delivery for security capabilities | — | — |
+| Stakeholder satisfaction with security services | — | — |
+| Security incident reduction trends | — | — |
+| Compliance achievement percentage | — | — |
+| Successful delivery of security roadmap items | — | — |
+| Security awareness and adoption metrics | — | — |
+| Backlog health and prioritization effectiveness | — | — |
+| Return on security investment metrics | — | — |
+| Security maturity improvement | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -147,7 +147,7 @@ The Security Product Owner manages the development and lifecycle of the organiza
 |---|---|---|
 | Security risk reduction effectiveness | — | — |
 | Time-to-delivery for security capabilities | — | — |
-| Stakeholder satisfaction with security services | — | — |
+| Stakeholder satisfaction with security services | ≥85% (proposed) | Quarterly |
 | Security incident reduction trends | — | — |
 | Compliance achievement percentage | — | — |
 | Successful delivery of security roadmap items | — | — |

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -140,7 +140,7 @@ The Security Senior Engineer leads the implementation and optimization of comple
 | Security posture improvement metrics | — | — |
 | Reduction in security vulnerabilities | — | — |
 | Innovation in security approaches | — | — |
-| Customer satisfaction with security services | — | — |
+| Customer satisfaction with security services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -129,16 +129,18 @@ The Security Senior Engineer leads the implementation and optimization of comple
 
 ## Key Performance Indicators
 
-- Security solution implementation quality
-- Security incident detection and response metrics
-- Implementation quality of security standards
-- Time to resolve complex security issues
-- Security automation coverage and effectiveness
-- Knowledge transfer effectiveness to security engineers
-- Security posture improvement metrics
-- Reduction in security vulnerabilities
-- Innovation in security approaches
-- Customer satisfaction with security services
+| Metric | Target | Frequency |
+|---|---|---|
+| Security solution implementation quality | — | — |
+| Security incident detection and response metrics | — | — |
+| Implementation quality of security standards | — | — |
+| Time to resolve complex security issues | — | — |
+| Security automation coverage and effectiveness | — | — |
+| Knowledge transfer effectiveness to security engineers | — | — |
+| Security posture improvement metrics | — | — |
+| Reduction in security vulnerabilities | — | — |
+| Innovation in security approaches | — | — |
+| Customer satisfaction with security services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -148,7 +148,7 @@ The Cloud Security Posture Manager implements and operates Cloud Security Postur
 | CIS Benchmark compliance score: maintain ≥80% pass rate across CIS Azure, AWS, and GCP Benchmarks per quarter | ≥80% | — |
 | CSPM finding recurrence rate: fewer than 10% of remediated findings reoccurring within 60 days | 10% | — |
 | Mean time to remediate (MTTR) critical findings: target ≤3 business days from identification to verified remediation | ≤3 business days | — |
-| Compliance posture trend: quarter-on-quarter improvement in overall benchmark compliance score across all three cloud platforms | — | — |
+| Compliance posture trend: quarter-on-quarter improvement in overall benchmark compliance score across all three cloud platforms | ≥95% (proposed) | Monthly |
 | CSPM false positive rate: suppressed findings representing ≤15% of total active findings, with all suppressions documented and reviewed quarterly | ≤15% | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -140,14 +140,16 @@ The Cloud Security Posture Manager implements and operates Cloud Security Postur
 
 ## Key Performance Indicators
 
-- Critical misconfiguration SLA compliance: ≥95% of critical-severity CSPM findings remediated or formally risk-accepted within 5 business days
-- High-severity misconfiguration SLA compliance: ≥90% of high-severity findings remediated within 15 business days
-- CSPM coverage rate: ≥95% of cloud subscriptions/accounts/projects enrolled in CSPM monitoring within 3 months of account creation
-- CIS Benchmark compliance score: maintain ≥80% pass rate across CIS Azure, AWS, and GCP Benchmarks per quarter
-- CSPM finding recurrence rate: fewer than 10% of remediated findings reoccurring within 60 days
-- Mean time to remediate (MTTR) critical findings: target ≤3 business days from identification to verified remediation
-- Compliance posture trend: quarter-on-quarter improvement in overall benchmark compliance score across all three cloud platforms
-- CSPM false positive rate: suppressed findings representing ≤15% of total active findings, with all suppressions documented and reviewed quarterly
+| Metric | Target | Frequency |
+|---|---|---|
+| Critical misconfiguration SLA compliance: ≥95% of critical-severity CSPM findings remediated or formally risk-accepted within 5 business days | ≥95% | — |
+| High-severity misconfiguration SLA compliance: ≥90% of high-severity findings remediated within 15 business days | ≥90% | — |
+| CSPM coverage rate: ≥95% of cloud subscriptions/accounts/projects enrolled in CSPM monitoring within 3 months of account creation | ≥95% | — |
+| CIS Benchmark compliance score: maintain ≥80% pass rate across CIS Azure, AWS, and GCP Benchmarks per quarter | ≥80% | — |
+| CSPM finding recurrence rate: fewer than 10% of remediated findings reoccurring within 60 days | 10% | — |
+| Mean time to remediate (MTTR) critical findings: target ≤3 business days from identification to verified remediation | ≤3 business days | — |
+| Compliance posture trend: quarter-on-quarter improvement in overall benchmark compliance score across all three cloud platforms | — | — |
+| CSPM false positive rate: suppressed findings representing ≤15% of total active findings, with all suppressions documented and reviewed quarterly | ≤15% | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -151,14 +151,16 @@ The Security Automation Engineer builds and maintains the automated security too
 
 ## Key Performance Indicators
 
-- SAST/DAST/SCA pipeline coverage: ≥95% of active repositories instrumented with at least one automated security scan integrated into the CI/CD pipeline
-- Mean time to detect (MTTD) critical vulnerabilities: ≤24 hours from code commit or image push to security alert generation for critical-severity findings
-- Automated remediation rate: ≥30% of low-to-medium severity findings resolved through automated PR suggestions, dependency auto-updates, or SOAR-driven remediation actions
-- Security gate false positive rate: ≤10% of security gate failures representing validated false positives, tracked per scanner and reviewed monthly
-- Compliance evidence automation coverage: ≥80% of required audit control evidence items satisfied by automated collection pipelines, reducing manual evidence-gathering effort
-- Policy-as-code admission control coverage: 100% of production Kubernetes clusters protected by OPA/Kyverno admission controllers enforcing organisation security policies
-- SOAR playbook mean time to respond (MTTR): automated playbook-driven response actions initiated within ≤5 minutes of qualifying alert for defined high-priority threat scenarios
-- Security scanning tooling availability: ≥99% pipeline security scan job success rate across all instrumented repositories, with failures alerted and resolved within 1 business day
+| Metric | Target | Frequency |
+|---|---|---|
+| SAST/DAST/SCA pipeline coverage: ≥95% of active repositories instrumented with at least one automated security scan integrated into the CI/CD pipeline | ≥95% | — |
+| Mean time to detect (MTTD) critical vulnerabilities: ≤24 hours from code commit or image push to security alert generation for critical-severity findings | ≤24 hours | — |
+| Automated remediation rate: ≥30% of low-to-medium severity findings resolved through automated PR suggestions, dependency auto-updates, or SOAR-driven remediation actions | ≥30% | — |
+| Security gate false positive rate: ≤10% of security gate failures representing validated false positives, tracked per scanner and reviewed monthly | ≤10% | Monthly |
+| Compliance evidence automation coverage: ≥80% of required audit control evidence items satisfied by automated collection pipelines, reducing manual evidence-gathering effort | ≥80% | — |
+| Policy-as-code admission control coverage: 100% of production Kubernetes clusters protected by OPA/Kyverno admission controllers enforcing organisation security policies | 100% | — |
+| SOAR playbook mean time to respond (MTTR): automated playbook-driven response actions initiated within ≤5 minutes of qualifying alert for defined high-priority threat scenarios | ≤5 minutes | — |
+| Security scanning tooling availability: ≥99% pipeline security scan job success rate across all instrumented repositories, with failures alerted and resolved within 1 business day | ≥99% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_cross_platform/security_cross_platform_architect.md
+++ b/Roles/security_cross_platform/security_cross_platform_architect.md
@@ -135,11 +135,13 @@ The Security Cross-Platform Architect designs and develops comprehensive securit
 
 ## Key Performance Indicators
 
-- Implementation of consistent security controls across all technology domains
-- Reduction in security vulnerabilities through standardized approaches
-- Improved security posture across diverse technology platforms
-- Faster security implementation through reusable patterns and frameworks
-- Increased automation of security controls across multiple domains
+| Metric | Target | Frequency |
+|---|---|---|
+| Implementation of consistent security controls across all technology domains | — | — |
+| Reduction in security vulnerabilities through standardized approaches | — | — |
+| Improved security posture across diverse technology platforms | — | — |
+| Faster security implementation through reusable patterns and frameworks | — | — |
+| Increased automation of security controls across multiple domains | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -135,16 +135,18 @@ The Security Cross-Platform Engineer implements and maintains security controls 
 
 ## Key Performance Indicators
 
-- Number of security controls successfully implemented
-- Reduction in security vulnerabilities across platforms
-- Time to resolve security configuration issues
-- Coverage of security monitoring across environments
-- Documentation quality and completeness
-- Compliance with security standards in implementations
-- Time to implement critical security patches
-- Success rate of security control testing
-- Collaboration effectiveness with domain teams
-- Security posture improvement metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Number of security controls successfully implemented | — | — |
+| Reduction in security vulnerabilities across platforms | — | — |
+| Time to resolve security configuration issues | — | — |
+| Coverage of security monitoring across environments | — | — |
+| Documentation quality and completeness | — | — |
+| Compliance with security standards in implementations | — | — |
+| Time to implement critical security patches | — | — |
+| Success rate of security control testing | — | — |
+| Collaboration effectiveness with domain teams | — | — |
+| Security posture improvement metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -138,7 +138,7 @@ The Security Cross-Platform Product Owner manages the portfolio of security serv
 |---|---|---|
 | On-time delivery of cross-platform security capabilities | — | — |
 | Consistent implementation of security features across various technology domains | — | — |
-| Stakeholder satisfaction with security services that span multiple platforms | — | — |
+| Stakeholder satisfaction with security services that span multiple platforms | ≥85% (proposed) | Quarterly |
 | Measurable improvement in security posture across domains | — | — |
 | Effective prioritization of security initiatives based on risk and business impact | — | — |
 | Reduced time-to-market for security controls through coordinated implementation | — | — |

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -134,12 +134,14 @@ The Security Cross-Platform Product Owner manages the portfolio of security serv
 
 ## Key Performance Indicators
 
-- On-time delivery of cross-platform security capabilities
-- Consistent implementation of security features across various technology domains
-- Stakeholder satisfaction with security services that span multiple platforms
-- Measurable improvement in security posture across domains
-- Effective prioritization of security initiatives based on risk and business impact
-- Reduced time-to-market for security controls through coordinated implementation
+| Metric | Target | Frequency |
+|---|---|---|
+| On-time delivery of cross-platform security capabilities | — | — |
+| Consistent implementation of security features across various technology domains | — | — |
+| Stakeholder satisfaction with security services that span multiple platforms | — | — |
+| Measurable improvement in security posture across domains | — | — |
+| Effective prioritization of security initiatives based on risk and business impact | — | — |
+| Reduced time-to-market for security controls through coordinated implementation | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
@@ -135,12 +135,14 @@ The Security Cross-Platform Senior Engineer leads the technical implementation o
 
 ## Key Performance Indicators
 
-- Successful implementation of security controls that work consistently across all platforms
-- Development of reusable security components that can be leveraged across domains
-- Increased automation of security processes spanning multiple technology areas
-- Reduction in security incidents through proactive cross-platform controls
-- Improved detection and response capabilities through integrated monitoring
-- Knowledge transfer to domain-specific teams on security best practices
+| Metric | Target | Frequency |
+|---|---|---|
+| Successful implementation of security controls that work consistently across all platforms | — | — |
+| Development of reusable security components that can be leveraged across domains | — | — |
+| Increased automation of security processes spanning multiple technology areas | — | — |
+| Reduction in security incidents through proactive cross-platform controls | — | — |
+| Improved detection and response capabilities through integrated monitoring | — | — |
+| Knowledge transfer to domain-specific teams on security best practices | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -141,7 +141,7 @@ The Access Management Architect designs and oversees the organization's access m
 | Reduction in access-related security incidents | — | — |
 | Improvement in access governance metrics | — | — |
 | Timely delivery of access architecture artifacts | — | — |
-| Stakeholder satisfaction with access solutions | — | — |
+| Stakeholder satisfaction with access solutions | ≥85% (proposed) | Quarterly |
 | Innovation in access management approaches | — | — |
 | Alignment with security and compliance requirements | — | — |
 | Successful adoption of access architecture patterns | — | — |

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -135,16 +135,18 @@ The Access Management Architect designs and oversees the organization's access m
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Reduction in access-related security incidents
-- Improvement in access governance metrics
-- Timely delivery of access architecture artifacts
-- Stakeholder satisfaction with access solutions
-- Innovation in access management approaches
-- Alignment with security and compliance requirements
-- Successful adoption of access architecture patterns
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Reduction in access-related security incidents | — | — |
+| Improvement in access governance metrics | — | — |
+| Timely delivery of access architecture artifacts | — | — |
+| Stakeholder satisfaction with access solutions | — | — |
+| Innovation in access management approaches | — | — |
+| Alignment with security and compliance requirements | — | — |
+| Successful adoption of access architecture patterns | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -130,16 +130,18 @@ The Access Management Engineer implements and maintains access management system
 
 ## Key Performance Indicators
 
-- Access management system uptime and reliability
-- Access request fulfillment time
-- Access certification campaign completion rates
-- Time to revoke inappropriate access
-- Access-related incident resolution time
-- Documentation quality and completeness
-- User satisfaction with access processes
-- Implementation quality of access solutions
-- Self-service adoption for access requests
-- Reduction in access-related security issues
+| Metric | Target | Frequency |
+|---|---|---|
+| Access management system uptime and reliability | — | — |
+| Access request fulfillment time | — | — |
+| Access certification campaign completion rates | — | — |
+| Time to revoke inappropriate access | — | — |
+| Access-related incident resolution time | — | — |
+| Documentation quality and completeness | — | — |
+| User satisfaction with access processes | — | — |
+| Implementation quality of access solutions | — | — |
+| Self-service adoption for access requests | — | — |
+| Reduction in access-related security issues | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -132,13 +132,13 @@ The Access Management Engineer implements and maintains access management system
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Access management system uptime and reliability | — | — |
+| Access management system uptime and reliability | ≥99.9% (proposed) | Monthly |
 | Access request fulfillment time | — | — |
 | Access certification campaign completion rates | — | — |
 | Time to revoke inappropriate access | — | — |
 | Access-related incident resolution time | — | — |
 | Documentation quality and completeness | — | — |
-| User satisfaction with access processes | — | — |
+| User satisfaction with access processes | ≥85% (proposed) | Quarterly |
 | Implementation quality of access solutions | — | — |
 | Self-service adoption for access requests | — | — |
 | Reduction in access-related security issues | — | — |

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -163,13 +163,13 @@ The Access Management Product Owner manages the development and lifecycle of the
 | Access management system reliability | — | — |
 | Access request fulfillment time | — | — |
 | Access review campaign completion rates | — | — |
-| Stakeholder satisfaction with access processes | — | — |
+| Stakeholder satisfaction with access processes | ≥85% (proposed) | Quarterly |
 | Privileged access security metrics | — | — |
 | Reduction in access-related security incidents | — | — |
 | Successful delivery of access roadmap items | — | — |
 | Self-service access request adoption | — | — |
 | Access governance compliance scores | — | — |
-| User satisfaction with access processes | — | — |
+| User satisfaction with access processes | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -158,16 +158,18 @@ The Access Management Product Owner manages the development and lifecycle of the
 
 ## Key Performance Indicators
 
-- Access management system reliability
-- Access request fulfillment time
-- Access review campaign completion rates
-- Stakeholder satisfaction with access processes
-- Privileged access security metrics
-- Reduction in access-related security incidents
-- Successful delivery of access roadmap items
-- Self-service access request adoption
-- Access governance compliance scores
-- User satisfaction with access processes
+| Metric | Target | Frequency |
+|---|---|---|
+| Access management system reliability | — | — |
+| Access request fulfillment time | — | — |
+| Access review campaign completion rates | — | — |
+| Stakeholder satisfaction with access processes | — | — |
+| Privileged access security metrics | — | — |
+| Reduction in access-related security incidents | — | — |
+| Successful delivery of access roadmap items | — | — |
+| Self-service access request adoption | — | — |
+| Access governance compliance scores | — | — |
+| User satisfaction with access processes | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -133,7 +133,7 @@ The Access Management Senior Engineer leads the implementation and optimization 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Access management system availability | — | — |
+| Access management system availability | ≥99.9% (proposed) | Monthly |
 | Privileged access security effectiveness | — | — |
 | Implementation quality of access solutions | — | — |
 | Time to resolve complex access incidents | — | — |

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -131,16 +131,18 @@ The Access Management Senior Engineer leads the implementation and optimization 
 
 ## Key Performance Indicators
 
-- Access management system availability
-- Privileged access security effectiveness
-- Implementation quality of access solutions
-- Time to resolve complex access incidents
-- Access certification campaign completion rates
-- Automation level of access processes
-- Knowledge transfer to junior engineers
-- Reduction in inappropriate access events
-- Compliance with access governance frameworks
-- Innovation in access management approaches
+| Metric | Target | Frequency |
+|---|---|---|
+| Access management system availability | — | — |
+| Privileged access security effectiveness | — | — |
+| Implementation quality of access solutions | — | — |
+| Time to resolve complex access incidents | — | — |
+| Access certification campaign completion rates | — | — |
+| Automation level of access processes | — | — |
+| Knowledge transfer to junior engineers | — | — |
+| Reduction in inappropriate access events | — | — |
+| Compliance with access governance frameworks | — | — |
+| Innovation in access management approaches | — | — |
 
 ## Key Performance Indicators
 

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -148,13 +148,15 @@ The Identity and Access Governance Specialist owns the Identity Governance and A
 
 ## Key Performance Indicators
 
-- Access certification campaign completion rate: ≥95% of scheduled certification reviews completed by the campaign deadline, with 100% of revocation decisions actioned within 5 business days of campaign close
-- Orphaned account elimination rate: ≥98% of identified orphaned accounts revoked or formally risk-accepted within 10 business days of detection
-- SoD violation remediation time: ≥90% of SoD violations remediated or compensating controls documented within 15 business days of detection
-- JML process automation percentage: ≥90% of Joiner, Mover, and Leaver events processed via automated IGA workflows without manual intervention, measured monthly
-- Over-privileged account reduction: quarter-on-quarter reduction in the number of accounts holding entitlements beyond their role-defined access baseline, tracked via role mining and certification outcomes
-- IGA provisioning accuracy: ≤1% error rate on automated provisioning and deprovisioning events, measured as failed or incorrectly processed JML workflow events per total events
-- Audit finding rate: zero repeat identity governance audit findings across consecutive annual audit cycles; fewer than two new findings per assessment cycle attributable to IGA process or tooling gaps
+| Metric | Target | Frequency |
+|---|---|---|
+| Access certification campaign completion rate: ≥95% of scheduled certification reviews completed by the campaign deadline, with 100% of revocation decisions actioned within 5 business days of campaign close | ≥95% | — |
+| Orphaned account elimination rate: ≥98% of identified orphaned accounts revoked or formally risk-accepted within 10 business days of detection | ≥98% | — |
+| SoD violation remediation time: ≥90% of SoD violations remediated or compensating controls documented within 15 business days of detection | ≥90% | — |
+| JML process automation percentage: ≥90% of Joiner, Mover, and Leaver events processed via automated IGA workflows without manual intervention, measured monthly | ≥90% | Monthly |
+| Over-privileged account reduction: quarter-on-quarter reduction in the number of accounts holding entitlements beyond their role-defined access baseline, tracked via role mining and certification outcomes | — | — |
+| IGA provisioning accuracy: ≤1% error rate on automated provisioning and deprovisioning events, measured as failed or incorrectly processed JML workflow events per total events | ≤1% | — |
+| Audit finding rate: zero repeat identity governance audit findings across consecutive annual audit cycles; fewer than two new findings per assessment cycle attributable to IGA process or tooling gaps | — | Annual |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -130,16 +130,18 @@ The Identity Management Architect designs and oversees the organization's identi
 
 ## Key Performance Indicators
 
-- Identity architecture quality and effectiveness
-- Alignment of solutions with security and business requirements
-- Identity system reliability and scalability
-- User experience improvements through architecture
-- Security posture improvement via identity controls
-- Adoption of identity standards and patterns
-- Reduction in identity-related security incidents
-- Innovation in identity management approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Identity architecture quality and effectiveness | — | — |
+| Alignment of solutions with security and business requirements | — | — |
+| Identity system reliability and scalability | — | — |
+| User experience improvements through architecture | — | — |
+| Security posture improvement via identity controls | — | — |
+| Adoption of identity standards and patterns | — | — |
+| Reduction in identity-related security incidents | — | — |
+| Innovation in identity management approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -132,7 +132,7 @@ The Identity Management Engineer implements and maintains identity management sy
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Identity system uptime and reliability | — | — |
+| Identity system uptime and reliability | ≥99.9% (proposed) | Monthly |
 | User provisioning and deprovisioning accuracy | — | — |
 | Authentication system performance | — | — |
 | Identity-related incident resolution time | — | — |

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -130,16 +130,18 @@ The Identity Management Engineer implements and maintains identity management sy
 
 ## Key Performance Indicators
 
-- Identity system uptime and reliability
-- User provisioning and deprovisioning accuracy
-- Authentication system performance
-- Identity-related incident resolution time
-- Implementation quality of identity solutions
-- Documentation quality and completeness
-- Federation service reliability
-- Password reset success rate
-- Directory service synchronization accuracy
-- Security compliance of identity implementations
+| Metric | Target | Frequency |
+|---|---|---|
+| Identity system uptime and reliability | — | — |
+| User provisioning and deprovisioning accuracy | — | — |
+| Authentication system performance | — | — |
+| Identity-related incident resolution time | — | — |
+| Implementation quality of identity solutions | — | — |
+| Documentation quality and completeness | — | — |
+| Federation service reliability | — | — |
+| Password reset success rate | — | — |
+| Directory service synchronization accuracy | — | — |
+| Security compliance of identity implementations | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -163,15 +163,15 @@ The Identity Management Product Owner manages the development and lifecycle of t
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Identity system availability and reliability | — | — |
+| Identity system availability and reliability | ≥99.9% (proposed) | Monthly |
 | User provisioning time efficiency | — | — |
 | Identity-related incident reduction | — | — |
-| Authentication process user satisfaction | — | — |
+| Authentication process user satisfaction | ≥85% (proposed) | Quarterly |
 | Self-service adoption rates | — | — |
 | Identity governance compliance scores | — | — |
 | Successful delivery of identity roadmap items | — | — |
 | Cost effectiveness of identity solutions | — | — |
-| Stakeholder satisfaction with identity services | — | — |
+| Stakeholder satisfaction with identity services | ≥85% (proposed) | Quarterly |
 | Directory data quality metrics | — | — |
 
 ## Remote Work Considerations

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -161,16 +161,18 @@ The Identity Management Product Owner manages the development and lifecycle of t
 
 ## Key Performance Indicators
 
-- Identity system availability and reliability
-- User provisioning time efficiency
-- Identity-related incident reduction
-- Authentication process user satisfaction
-- Self-service adoption rates
-- Identity governance compliance scores
-- Successful delivery of identity roadmap items
-- Cost effectiveness of identity solutions
-- Stakeholder satisfaction with identity services
-- Directory data quality metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Identity system availability and reliability | — | — |
+| User provisioning time efficiency | — | — |
+| Identity-related incident reduction | — | — |
+| Authentication process user satisfaction | — | — |
+| Self-service adoption rates | — | — |
+| Identity governance compliance scores | — | — |
+| Successful delivery of identity roadmap items | — | — |
+| Cost effectiveness of identity solutions | — | — |
+| Stakeholder satisfaction with identity services | — | — |
+| Directory data quality metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -133,7 +133,7 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Identity system availability and reliability metrics | — | — |
+| Identity system availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Authentication service response times | — | — |
 | Implementation quality of identity solutions | — | — |
 | Time to resolution for complex identity incidents | — | — |
@@ -142,7 +142,7 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 | Knowledge transfer effectiveness to junior engineers | — | — |
 | Reduction in identity-related security incidents | — | — |
 | Successful implementation of identity standards | — | — |
-| User satisfaction with authentication experience | — | — |
+| User satisfaction with authentication experience | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -131,16 +131,18 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 
 ## Key Performance Indicators
 
-- Identity system availability and reliability metrics
-- Authentication service response times
-- Implementation quality of identity solutions
-- Time to resolution for complex identity incidents
-- Automation level achieved for identity operations
-- Security posture improvement in identity systems
-- Knowledge transfer effectiveness to junior engineers
-- Reduction in identity-related security incidents
-- Successful implementation of identity standards
-- User satisfaction with authentication experience
+| Metric | Target | Frequency |
+|---|---|---|
+| Identity system availability and reliability metrics | — | — |
+| Authentication service response times | — | — |
+| Implementation quality of identity solutions | — | — |
+| Time to resolution for complex identity incidents | — | — |
+| Automation level achieved for identity operations | — | — |
+| Security posture improvement in identity systems | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Reduction in identity-related security incidents | — | — |
+| Successful implementation of identity standards | — | — |
+| User satisfaction with authentication experience | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/privileged_access_management_architect.md
+++ b/Roles/security_identity/privileged_access_management_architect.md
@@ -137,12 +137,14 @@ The Privileged Access Management (PAM) Architect designs, governs, and evolves t
 
 ## Key Performance Indicators
 
-- Percentage of privileged accounts vaulted in PAM (target: 100% of in-scope accounts)
-- Standing privileged access reduction (trend to zero standing admin accounts)
-- Privileged session audit coverage (target: 100% of production privileged access)
-- JIT access adoption rate across administrative populations
-- PAM platform availability (target: 99.9%+)
-- Time to on-board newly discovered privileged accounts
+| Metric | Target | Frequency |
+|---|---|---|
+| Percentage of privileged accounts vaulted in PAM (target: 100% of in-scope accounts) | 100% | — |
+| Standing privileged access reduction (trend to zero standing admin accounts) | — | — |
+| Privileged session audit coverage (target: 100% of production privileged access) | 100% | — |
+| JIT access adoption rate across administrative populations | — | — |
+| PAM platform availability (target: 99.9%+) | 99.9% | — |
+| Time to on-board newly discovered privileged accounts | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/privileged_access_management_engineer.md
+++ b/Roles/security_identity/privileged_access_management_engineer.md
@@ -132,12 +132,14 @@ The Privileged Access Management (PAM) Engineer implements, operates, and mainta
 
 ## Key Performance Indicators
 
-- Privileged account on-boarding rate (accounts added per sprint/month)
-- Credential rotation success rate (target: >99%)
-- PAM platform availability (target: 99.9%+)
-- Open privileged account discovery findings (trend: decreasing)
-- Compliance audit findings related to PAM (target: zero)
-- Session recording completeness rate
+| Metric | Target | Frequency |
+|---|---|---|
+| Privileged account on-boarding rate (accounts added per sprint/month) | — | Per sprint |
+| Credential rotation success rate (target: >99%) | >99% | — |
+| PAM platform availability (target: 99.9%+) | 99.9% | — |
+| Open privileged account discovery findings (trend: decreasing) | — | — |
+| Compliance audit findings related to PAM (target: zero) | — | — |
+| Session recording completeness rate | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -129,16 +129,18 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of hardware designs with business requirements
-- Server infrastructure performance and reliability
-- Power efficiency and sustainability metrics
-- Cost effectiveness of hardware architectures
-- Adoption of reference architectures and standards
-- Hardware lifecycle optimization metrics
-- Innovation in server infrastructure approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of hardware designs with business requirements | — | — |
+| Server infrastructure performance and reliability | — | — |
+| Power efficiency and sustainability metrics | — | — |
+| Cost effectiveness of hardware architectures | — | — |
+| Adoption of reference architectures and standards | — | — |
+| Hardware lifecycle optimization metrics | — | — |
+| Innovation in server infrastructure approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -146,7 +146,7 @@ The Server Hardware Engineer implements and maintains the physical server infras
 | Hardware inventory accuracy | — | — |
 | Successful hardware maintenance completions | — | — |
 | Standard build implementation quality | — | — |
-| User satisfaction with hardware support | — | — |
+| User satisfaction with hardware support | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -136,16 +136,18 @@ The Server Hardware Engineer implements and maintains the physical server infras
 
 ## Key Performance Indicators
 
-- Server deployment time efficiency
-- Hardware-related incident resolution time
-- Hardware configuration accuracy
-- Documentation quality and completeness
-- Firmware compliance percentage
-- Hardware inventory accuracy
-- Successful hardware maintenance completions
-- Standard build implementation quality
-- User satisfaction with hardware support
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Server deployment time efficiency | — | — |
+| Hardware-related incident resolution time | — | — |
+| Hardware configuration accuracy | — | — |
+| Documentation quality and completeness | — | — |
+| Firmware compliance percentage | — | — |
+| Hardware inventory accuracy | — | — |
+| Successful hardware maintenance completions | — | — |
+| Standard build implementation quality | — | — |
+| User satisfaction with hardware support | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -153,7 +153,7 @@ The Server Hardware Product Owner manages the lifecycle of physical server infra
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Server hardware availability and reliability metrics | — | — |
+| Server hardware availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Hardware procurement cycle efficiency | — | — |
 | Server provisioning time metrics | — | — |
 | Hardware costs versus performance benchmarks | — | — |
@@ -162,7 +162,7 @@ The Server Hardware Product Owner manages the lifecycle of physical server infra
 | Asset lifecycle management effectiveness | — | — |
 | Successful delivery of hardware roadmap items | — | — |
 | Hardware incident reduction trends | — | — |
-| Stakeholder satisfaction with server infrastructure | — | — |
+| Stakeholder satisfaction with server infrastructure | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -151,16 +151,18 @@ The Server Hardware Product Owner manages the lifecycle of physical server infra
 
 ## Key Performance Indicators
 
-- Server hardware availability and reliability metrics
-- Hardware procurement cycle efficiency
-- Server provisioning time metrics
-- Hardware costs versus performance benchmarks
-- Energy efficiency metrics (PUE, DCiE)
-- Hardware standardization percentage
-- Asset lifecycle management effectiveness
-- Successful delivery of hardware roadmap items
-- Hardware incident reduction trends
-- Stakeholder satisfaction with server infrastructure
+| Metric | Target | Frequency |
+|---|---|---|
+| Server hardware availability and reliability metrics | — | — |
+| Hardware procurement cycle efficiency | — | — |
+| Server provisioning time metrics | — | — |
+| Hardware costs versus performance benchmarks | — | — |
+| Energy efficiency metrics (PUE, DCiE) | — | — |
+| Hardware standardization percentage | — | — |
+| Asset lifecycle management effectiveness | — | — |
+| Successful delivery of hardware roadmap items | — | — |
+| Hardware incident reduction trends | — | — |
+| Stakeholder satisfaction with server infrastructure | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -139,7 +139,7 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Server hardware availability and reliability metrics | — | — |
+| Server hardware availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Implementation quality of hardware solutions | — | — |
 | Time to resolution for critical hardware issues | — | — |
 | Hardware deployment automation effectiveness | — | — |
@@ -148,7 +148,7 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 | Hardware standardization implementation success | — | — |
 | Success rate of hardware upgrades and refreshes | — | — |
 | Innovation in server infrastructure approaches | — | — |
-| Stakeholder satisfaction with infrastructure services | — | — |
+| Stakeholder satisfaction with infrastructure services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -137,16 +137,18 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 
 ## Key Performance Indicators
 
-- Server hardware availability and reliability metrics
-- Implementation quality of hardware solutions
-- Time to resolution for critical hardware issues
-- Hardware deployment automation effectiveness
-- Power and cooling efficiency improvements
-- Knowledge transfer effectiveness to junior engineers
-- Hardware standardization implementation success
-- Success rate of hardware upgrades and refreshes
-- Innovation in server infrastructure approaches
-- Stakeholder satisfaction with infrastructure services
+| Metric | Target | Frequency |
+|---|---|---|
+| Server hardware availability and reliability metrics | — | — |
+| Implementation quality of hardware solutions | — | — |
+| Time to resolution for critical hardware issues | — | — |
+| Hardware deployment automation effectiveness | — | — |
+| Power and cooling efficiency improvements | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Hardware standardization implementation success | — | — |
+| Success rate of hardware upgrades and refreshes | — | — |
+| Innovation in server infrastructure approaches | — | — |
+| Stakeholder satisfaction with infrastructure services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -135,16 +135,18 @@ The HPE Server Hardware Architect designs and oversees the organization's server
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of hardware designs with business requirements
-- Server infrastructure performance and reliability
-- Power efficiency and sustainability metrics
-- Cost effectiveness of hardware architectures
-- Adoption of reference architectures and standards
-- Hardware lifecycle optimization metrics
-- Innovation in server infrastructure approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of hardware designs with business requirements | — | — |
+| Server infrastructure performance and reliability | — | — |
+| Power efficiency and sustainability metrics | — | — |
+| Cost effectiveness of hardware architectures | — | — |
+| Adoption of reference architectures and standards | — | — |
+| Hardware lifecycle optimization metrics | — | — |
+| Innovation in server infrastructure approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -160,16 +160,18 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 
 ## Key Performance Indicators
 
-- Server deployment time efficiency
-- Hardware-related incident resolution time
-- Hardware configuration accuracy
-- Documentation quality and completeness
-- Firmware compliance percentage
-- Hardware inventory accuracy
-- Successful hardware maintenance completions
-- Standard build implementation quality
-- User satisfaction with hardware support
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Server deployment time efficiency | — | — |
+| Hardware-related incident resolution time | — | — |
+| Hardware configuration accuracy | — | — |
+| Documentation quality and completeness | — | — |
+| Firmware compliance percentage | — | — |
+| Hardware inventory accuracy | — | — |
+| Successful hardware maintenance completions | — | — |
+| Standard build implementation quality | — | — |
+| User satisfaction with hardware support | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -170,7 +170,7 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 | Hardware inventory accuracy | — | — |
 | Successful hardware maintenance completions | — | — |
 | Standard build implementation quality | — | — |
-| User satisfaction with hardware support | — | — |
+| User satisfaction with hardware support | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -125,16 +125,18 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 
 ## Key Performance Indicators
 
-- Server infrastructure availability and reliability metrics
-- On-time delivery of hardware initiatives and projects
-- Stakeholder satisfaction ratings
-- Budget management and cost optimization
-- Hardware standardization percentage
-- Time to provision new server infrastructure
-- Server capacity utilization efficiency
-- Successful technology adoption rate
-- Documentation quality and completeness
-- Team velocity and productivity metrics
+| Metric | Target | Frequency |
+|---|---|---|
+| Server infrastructure availability and reliability metrics | — | — |
+| On-time delivery of hardware initiatives and projects | — | — |
+| Stakeholder satisfaction ratings | — | — |
+| Budget management and cost optimization | — | — |
+| Hardware standardization percentage | — | — |
+| Time to provision new server infrastructure | — | — |
+| Server capacity utilization efficiency | — | — |
+| Successful technology adoption rate | — | — |
+| Documentation quality and completeness | — | — |
+| Team velocity and productivity metrics | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -127,9 +127,9 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Server infrastructure availability and reliability metrics | — | — |
+| Server infrastructure availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | On-time delivery of hardware initiatives and projects | — | — |
-| Stakeholder satisfaction ratings | — | — |
+| Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Budget management and cost optimization | — | — |
 | Hardware standardization percentage | — | — |
 | Time to provision new server infrastructure | — | — |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -115,18 +115,20 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 
 ## Key Performance Indicators
 
-- Server deployment accuracy and quality
-- Implementation time for server infrastructure projects
-- Server hardware incident resolution time
-- Documentation quality and completeness
-- Knowledge sharing effectiveness
-- Automation implementation success rate
-- Server performance optimization metrics
-- Hardware standardization compliance
-- Team technical capability development
-- Server capacity utilization metrics
-- Reduction in recurring hardware issues
-- Successful technology adoptions
+| Metric | Target | Frequency |
+|---|---|---|
+| Server deployment accuracy and quality | — | — |
+| Implementation time for server infrastructure projects | — | — |
+| Server hardware incident resolution time | — | — |
+| Documentation quality and completeness | — | — |
+| Knowledge sharing effectiveness | — | — |
+| Automation implementation success rate | — | — |
+| Server performance optimization metrics | — | — |
+| Hardware standardization compliance | — | — |
+| Team technical capability development | — | — |
+| Server capacity utilization metrics | — | — |
+| Reduction in recurring hardware issues | — | — |
+| Successful technology adoptions | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -134,7 +134,7 @@ The Linux Server Architect designs and defines the strategic direction for the o
 |---|---|---|
 | Architectural standards adoption rate across Linux deployments | — | — |
 | Reduction in Linux infrastructure incidents due to architectural improvements | — | — |
-| Linux environment availability and performance metrics | — | — |
+| Linux environment availability and performance metrics | ≥99.9% (proposed) | Monthly |
 | Successful implementation of architectural recommendations | — | — |
 | Cost optimization of Linux infrastructure | — | — |
 | Quality and completeness of architecture documentation | — | — |

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -130,16 +130,18 @@ The Linux Server Architect designs and defines the strategic direction for the o
 
 ## Key Performance Indicators
 
-- Architectural standards adoption rate across Linux deployments
-- Reduction in Linux infrastructure incidents due to architectural improvements
-- Linux environment availability and performance metrics
-- Successful implementation of architectural recommendations
-- Cost optimization of Linux infrastructure
-- Quality and completeness of architecture documentation
-- Technical debt reduction in Linux environments
-- Time-to-delivery for new Linux capabilities and services
-- Linux security posture improvement
-- Knowledge transfer effectiveness to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architectural standards adoption rate across Linux deployments | — | — |
+| Reduction in Linux infrastructure incidents due to architectural improvements | — | — |
+| Linux environment availability and performance metrics | — | — |
+| Successful implementation of architectural recommendations | — | — |
+| Cost optimization of Linux infrastructure | — | — |
+| Quality and completeness of architecture documentation | — | — |
+| Technical debt reduction in Linux environments | — | — |
+| Time-to-delivery for new Linux capabilities and services | — | — |
+| Linux security posture improvement | — | — |
+| Knowledge transfer effectiveness to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -139,14 +139,14 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Linux server availability metrics | — | — |
+| Linux server availability metrics | ≥99.9% (proposed) | Monthly |
 | Time to resolve Linux-related incidents | — | — |
-| Patch compliance percentage | — | — |
+| Patch compliance percentage | ≥95% (proposed) | Monthly |
 | Documentation quality and completeness | — | — |
 | Security compliance scores | — | — |
 | Successful implementation of automation tasks | — | — |
-| Backup success rates and recovery capabilities | — | — |
-| User satisfaction with Linux support | — | — |
+| Backup success rates and recovery capabilities | ≥99% (proposed) | Monthly |
+| User satisfaction with Linux support | ≥85% (proposed) | Quarterly |
 | Adherence to Linux standards and procedures | — | — |
 | Knowledge sharing and collaboration | — | — |
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -137,16 +137,18 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 
 ## Key Performance Indicators
 
-- Linux server availability metrics
-- Time to resolve Linux-related incidents
-- Patch compliance percentage
-- Documentation quality and completeness
-- Security compliance scores
-- Successful implementation of automation tasks
-- Backup success rates and recovery capabilities
-- User satisfaction with Linux support
-- Adherence to Linux standards and procedures
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Linux server availability metrics | — | — |
+| Time to resolve Linux-related incidents | — | — |
+| Patch compliance percentage | — | — |
+| Documentation quality and completeness | — | — |
+| Security compliance scores | — | — |
+| Successful implementation of automation tasks | — | — |
+| Backup success rates and recovery capabilities | — | — |
+| User satisfaction with Linux support | — | — |
+| Adherence to Linux standards and procedures | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -150,10 +150,10 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Linux platform availability and reliability metrics | — | — |
+| Linux platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Time to provision new Linux servers | — | — |
 | Linux patching compliance percentages | — | — |
-| Stakeholder satisfaction with Linux services | — | — |
+| Stakeholder satisfaction with Linux services | ≥85% (proposed) | Quarterly |
 | Linux-related incident reduction | — | — |
 | Successful delivery of Linux roadmap items | — | — |
 | Self-service adoption for Linux provisioning | — | — |

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -148,16 +148,18 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 
 ## Key Performance Indicators
 
-- Linux platform availability and reliability metrics
-- Time to provision new Linux servers
-- Linux patching compliance percentages
-- Stakeholder satisfaction with Linux services
-- Linux-related incident reduction
-- Successful delivery of Linux roadmap items
-- Self-service adoption for Linux provisioning
-- Linux automation coverage percentage
-- Linux security compliance scores
-- Cost efficiency of Linux platform
+| Metric | Target | Frequency |
+|---|---|---|
+| Linux platform availability and reliability metrics | — | — |
+| Time to provision new Linux servers | — | — |
+| Linux patching compliance percentages | — | — |
+| Stakeholder satisfaction with Linux services | — | — |
+| Linux-related incident reduction | — | — |
+| Successful delivery of Linux roadmap items | — | — |
+| Self-service adoption for Linux provisioning | — | — |
+| Linux automation coverage percentage | — | — |
+| Linux security compliance scores | — | — |
+| Cost efficiency of Linux platform | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -137,7 +137,7 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Linux system availability and reliability metrics | — | — |
+| Linux system availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Implementation quality of Linux solutions | — | — |
 | Time to resolution for critical Linux incidents | — | — |
 | Automation coverage for Linux administration tasks | — | — |

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -135,16 +135,18 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 
 ## Key Performance Indicators
 
-- Linux system availability and reliability metrics
-- Implementation quality of Linux solutions
-- Time to resolution for critical Linux incidents
-- Automation coverage for Linux administration tasks
-- Security compliance scores for Linux environments
-- Knowledge transfer effectiveness to junior engineers
-- Successful implementation of Linux standards
-- Innovation in Linux platform enhancements
-- Resource optimization achievements
-- Project delivery timeframes and quality
+| Metric | Target | Frequency |
+|---|---|---|
+| Linux system availability and reliability metrics | — | — |
+| Implementation quality of Linux solutions | — | — |
+| Time to resolution for critical Linux incidents | — | — |
+| Automation coverage for Linux administration tasks | — | — |
+| Security compliance scores for Linux environments | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Successful implementation of Linux standards | — | — |
+| Innovation in Linux platform enhancements | — | — |
+| Resource optimization achievements | — | — |
+| Project delivery timeframes and quality | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -133,7 +133,7 @@ The Windows Server Architect designs and defines the strategic direction for the
 |---|---|---|
 | Architectural standards adoption rate across Windows deployments | — | — |
 | Reduction in Windows infrastructure incidents due to architectural improvements | — | — |
-| Windows environment availability and performance metrics | — | — |
+| Windows environment availability and performance metrics | ≥99.9% (proposed) | Monthly |
 | Successful implementation of architectural recommendations | — | — |
 | Cost optimization of Windows licensing and infrastructure | — | — |
 | Quality and completeness of architecture documentation | — | — |

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -129,16 +129,18 @@ The Windows Server Architect designs and defines the strategic direction for the
 
 ## Key Performance Indicators
 
-- Architectural standards adoption rate across Windows deployments
-- Reduction in Windows infrastructure incidents due to architectural improvements
-- Windows environment availability and performance metrics
-- Successful implementation of architectural recommendations
-- Cost optimization of Windows licensing and infrastructure
-- Quality and completeness of architecture documentation
-- Technical debt reduction in Windows environments
-- Time-to-delivery for new Windows capabilities and services
-- Windows security posture improvement
-- Knowledge transfer effectiveness to engineering teams
+| Metric | Target | Frequency |
+|---|---|---|
+| Architectural standards adoption rate across Windows deployments | — | — |
+| Reduction in Windows infrastructure incidents due to architectural improvements | — | — |
+| Windows environment availability and performance metrics | — | — |
+| Successful implementation of architectural recommendations | — | — |
+| Cost optimization of Windows licensing and infrastructure | — | — |
+| Quality and completeness of architecture documentation | — | — |
+| Technical debt reduction in Windows environments | — | — |
+| Time-to-delivery for new Windows capabilities and services | — | — |
+| Windows security posture improvement | — | — |
+| Knowledge transfer effectiveness to engineering teams | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -140,16 +140,16 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Windows Server availability and reliability metrics | — | — |
-| Patch compliance percentages | — | — |
+| Windows Server availability and reliability metrics | ≥99.9% (proposed) | Monthly |
+| Patch compliance percentages | ≥95% (proposed) | Monthly |
 | Time to implement standard server configurations | — | — |
 | Service request resolution time | — | — |
 | Documentation quality and completeness | — | — |
 | Group Policy implementation accuracy | — | — |
-| Backup success rate and recovery effectiveness | — | — |
+| Backup success rate and recovery effectiveness | ≥99% (proposed) | Monthly |
 | Change implementation success rate | — | — |
 | Adherence to security standards and best practices | — | — |
-| User satisfaction with server services | — | — |
+| User satisfaction with server services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -138,16 +138,18 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 
 ## Key Performance Indicators
 
-- Windows Server availability and reliability metrics
-- Patch compliance percentages
-- Time to implement standard server configurations
-- Service request resolution time
-- Documentation quality and completeness
-- Group Policy implementation accuracy
-- Backup success rate and recovery effectiveness
-- Change implementation success rate
-- Adherence to security standards and best practices
-- User satisfaction with server services
+| Metric | Target | Frequency |
+|---|---|---|
+| Windows Server availability and reliability metrics | — | — |
+| Patch compliance percentages | — | — |
+| Time to implement standard server configurations | — | — |
+| Service request resolution time | — | — |
+| Documentation quality and completeness | — | — |
+| Group Policy implementation accuracy | — | — |
+| Backup success rate and recovery effectiveness | — | — |
+| Change implementation success rate | — | — |
+| Adherence to security standards and best practices | — | — |
+| User satisfaction with server services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -150,11 +150,11 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Windows Server availability and reliability metrics | — | — |
+| Windows Server availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for platform incidents | — | — |
-| Patch compliance percentages | — | — |
+| Patch compliance percentages | ≥95% (proposed) | Monthly |
 | Cost efficiency of Windows infrastructure | — | — |
-| Stakeholder satisfaction with server services | — | — |
+| Stakeholder satisfaction with server services | ≥85% (proposed) | Quarterly |
 | Windows Server automation efficiency | — | — |
 | Successful delivery of roadmap initiatives | — | — |
 | Security compliance scores for server environment | — | — |

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -148,16 +148,18 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 
 ## Key Performance Indicators
 
-- Windows Server availability and reliability metrics
-- Mean time to resolution for platform incidents
-- Patch compliance percentages
-- Cost efficiency of Windows infrastructure
-- Stakeholder satisfaction with server services
-- Windows Server automation efficiency
-- Successful delivery of roadmap initiatives
-- Security compliance scores for server environment
-- Backlog health and prioritization effectiveness
-- Service level objective achievement
+| Metric | Target | Frequency |
+|---|---|---|
+| Windows Server availability and reliability metrics | — | — |
+| Mean time to resolution for platform incidents | — | — |
+| Patch compliance percentages | — | — |
+| Cost efficiency of Windows infrastructure | — | — |
+| Stakeholder satisfaction with server services | — | — |
+| Windows Server automation efficiency | — | — |
+| Successful delivery of roadmap initiatives | — | — |
+| Security compliance scores for server environment | — | — |
+| Backlog health and prioritization effectiveness | — | — |
+| Service level objective achievement | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -142,7 +142,7 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Windows environment availability and reliability metrics | — | — |
+| Windows environment availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Implementation quality of Windows solutions | — | — |
 | Time to resolve critical Windows incidents | — | — |
 | Automation coverage for Windows administration | — | — |

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -140,16 +140,18 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 
 ## Key Performance Indicators
 
-- Windows environment availability and reliability metrics
-- Implementation quality of Windows solutions
-- Time to resolve critical Windows incidents
-- Automation coverage for Windows administration
-- Security compliance scores for Windows servers
-- Knowledge transfer effectiveness to junior engineers
-- Successful implementation of Windows standards
-- Server performance optimization metrics
-- Project delivery timeliness and quality
-- Innovation in Windows platform capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| Windows environment availability and reliability metrics | — | — |
+| Implementation quality of Windows solutions | — | — |
+| Time to resolve critical Windows incidents | — | — |
+| Automation coverage for Windows administration | — | — |
+| Security compliance scores for Windows servers | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Successful implementation of Windows standards | — | — |
+| Server performance optimization metrics | — | — |
+| Project delivery timeliness and quality | — | — |
+| Innovation in Windows platform capabilities | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -129,16 +129,18 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 ## Key Performance Indicators
 
-- Architecture design quality and effectiveness
-- Alignment of ITSM designs with business requirements
-- Process efficiency and effectiveness metrics
-- Service integration reliability
-- Adoption of ITSM reference architectures
-- Reduction in service-related incidents
-- Innovation in service management approaches
-- Technical leadership effectiveness
-- Knowledge transfer to engineering teams
-- Service management maturity improvement
+| Metric | Target | Frequency |
+|---|---|---|
+| Architecture design quality and effectiveness | — | — |
+| Alignment of ITSM designs with business requirements | — | — |
+| Process efficiency and effectiveness metrics | — | — |
+| Service integration reliability | — | — |
+| Adoption of ITSM reference architectures | — | — |
+| Reduction in service-related incidents | — | — |
+| Innovation in service management approaches | — | — |
+| Technical leadership effectiveness | — | — |
+| Knowledge transfer to engineering teams | — | — |
+| Service management maturity improvement | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -137,7 +137,7 @@ The Service Management Engineer implements and maintains IT service management p
 | Service catalog effectiveness | — | — |
 | Workflow automation success rate | — | — |
 | Documentation quality and completeness | — | — |
-| User satisfaction with ITSM tools | — | — |
+| User satisfaction with ITSM tools | ≥85% (proposed) | Quarterly |
 | Reporting and dashboard utility | — | — |
 | Resolution time for ITSM platform issues | — | — |
 | Knowledge sharing and collaboration | — | — |

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -130,16 +130,18 @@ The Service Management Engineer implements and maintains IT service management p
 
 ## Key Performance Indicators
 
-- ITSM configuration implementation quality
-- Time to complete service management requests
-- Service catalog effectiveness
-- Workflow automation success rate
-- Documentation quality and completeness
-- User satisfaction with ITSM tools
-- Reporting and dashboard utility
-- Resolution time for ITSM platform issues
-- Knowledge sharing and collaboration
-- Process automation efficiency
+| Metric | Target | Frequency |
+|---|---|---|
+| ITSM configuration implementation quality | — | — |
+| Time to complete service management requests | — | — |
+| Service catalog effectiveness | — | — |
+| Workflow automation success rate | — | — |
+| Documentation quality and completeness | — | — |
+| User satisfaction with ITSM tools | — | — |
+| Reporting and dashboard utility | — | — |
+| Resolution time for ITSM platform issues | — | — |
+| Knowledge sharing and collaboration | — | — |
+| Process automation efficiency | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -131,9 +131,9 @@ The Service Management Product Owner manages the development and lifecycle of th
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Service availability and reliability metrics | — | — |
+| Service availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Time-to-resolution for incidents and service requests | — | — |
-| Customer satisfaction with IT services | — | — |
+| Customer satisfaction with IT services | ≥85% (proposed) | Quarterly |
 | Self-service adoption rates | — | — |
 | Successful implementation of ITIL processes | — | — |
 | Service catalog maturity and adoption | — | — |

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -129,16 +129,18 @@ The Service Management Product Owner manages the development and lifecycle of th
 
 ## Key Performance Indicators
 
-- Service availability and reliability metrics
-- Time-to-resolution for incidents and service requests
-- Customer satisfaction with IT services
-- Self-service adoption rates
-- Successful implementation of ITIL processes
-- Service catalog maturity and adoption
-- ITSM platform enhancement delivery
-- Process automation effectiveness
-- Knowledge base utilization and quality
-- Return on investment for ITSM initiatives
+| Metric | Target | Frequency |
+|---|---|---|
+| Service availability and reliability metrics | — | — |
+| Time-to-resolution for incidents and service requests | — | — |
+| Customer satisfaction with IT services | — | — |
+| Self-service adoption rates | — | — |
+| Successful implementation of ITIL processes | — | — |
+| Service catalog maturity and adoption | — | — |
+| ITSM platform enhancement delivery | — | — |
+| Process automation effectiveness | — | — |
+| Knowledge base utilization and quality | — | — |
+| Return on investment for ITSM initiatives | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -129,16 +129,18 @@ The Service Management Senior Engineer leads the implementation and optimization
 
 ## Key Performance Indicators
 
-- ITSM platform availability and performance
-- Workflow automation effectiveness
-- Implementation quality of ITSM solutions
-- Time to resolution for complex platform issues
-- Knowledge transfer effectiveness to junior engineers
-- ITSM platform security and compliance
-- Successful implementation of ITSM standards
-- Innovation in service management solutions
-- Integration reliability with enterprise systems
-- User satisfaction with ITSM platform
+| Metric | Target | Frequency |
+|---|---|---|
+| ITSM platform availability and performance | — | — |
+| Workflow automation effectiveness | — | — |
+| Implementation quality of ITSM solutions | — | — |
+| Time to resolution for complex platform issues | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| ITSM platform security and compliance | — | — |
+| Successful implementation of ITSM standards | — | — |
+| Innovation in service management solutions | — | — |
+| Integration reliability with enterprise systems | — | — |
+| User satisfaction with ITSM platform | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -131,7 +131,7 @@ The Service Management Senior Engineer leads the implementation and optimization
 
 | Metric | Target | Frequency |
 |---|---|---|
-| ITSM platform availability and performance | — | — |
+| ITSM platform availability and performance | ≥99.9% (proposed) | Monthly |
 | Workflow automation effectiveness | — | — |
 | Implementation quality of ITSM solutions | — | — |
 | Time to resolution for complex platform issues | — | — |
@@ -140,7 +140,7 @@ The Service Management Senior Engineer leads the implementation and optimization
 | Successful implementation of ITSM standards | — | — |
 | Innovation in service management solutions | — | — |
 | Integration reliability with enterprise systems | — | — |
-| User satisfaction with ITSM platform | — | — |
+| User satisfaction with ITSM platform | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/specialized_computing/hpc_architect.md
+++ b/Roles/specialized_computing/hpc_architect.md
@@ -156,7 +156,7 @@ The High-Performance Computing (HPC) Architect leads the design, implementation,
 | Time-to-solution improvements for computational workloads | — | — |
 | Security and compliance adherence in HPC environments | — | — |
 | Knowledge transfer effectiveness and documentation quality | — | — |
-| Stakeholder satisfaction with HPC capabilities | — | — |
+| Stakeholder satisfaction with HPC capabilities | ≥85% (proposed) | Quarterly |
 | Innovation in HPC solutions and approaches | — | — |
 | Sustainability improvements in HPC operations | — | — |
 | Edge-to-cloud latency SLA adherence: ≥99% of edge inference workloads meeting defined end-to-end latency SLAs | ≥99% | — |

--- a/Roles/specialized_computing/hpc_architect.md
+++ b/Roles/specialized_computing/hpc_architect.md
@@ -147,17 +147,19 @@ The High-Performance Computing (HPC) Architect leads the design, implementation,
 
 ## Key Performance Indicators
 
-- Architectural design quality and alignment with business needs
-- System performance benchmarks against industry standards
-- Cost efficiency and resource optimization achievements
-- Successful implementation of new technologies and approaches
-- Time-to-solution improvements for computational workloads
-- Security and compliance adherence in HPC environments
-- Knowledge transfer effectiveness and documentation quality
-- Stakeholder satisfaction with HPC capabilities
-- Innovation in HPC solutions and approaches
-- Sustainability improvements in HPC operations
-- Edge-to-cloud latency SLA adherence: ≥99% of edge inference workloads meeting defined end-to-end latency SLAs
+| Metric | Target | Frequency |
+|---|---|---|
+| Architectural design quality and alignment with business needs | — | — |
+| System performance benchmarks against industry standards | — | — |
+| Cost efficiency and resource optimization achievements | — | — |
+| Successful implementation of new technologies and approaches | — | — |
+| Time-to-solution improvements for computational workloads | — | — |
+| Security and compliance adherence in HPC environments | — | — |
+| Knowledge transfer effectiveness and documentation quality | — | — |
+| Stakeholder satisfaction with HPC capabilities | — | — |
+| Innovation in HPC solutions and approaches | — | — |
+| Sustainability improvements in HPC operations | — | — |
+| Edge-to-cloud latency SLA adherence: ≥99% of edge inference workloads meeting defined end-to-end latency SLAs | ≥99% | — |
 
 ## Remote Work Considerations
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -149,15 +149,17 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 
 ## Key Performance Indicators
 
-- Cluster uptime, availability, and security metrics
-- Job scheduling and resource utilization efficiency
-- Automation coverage and reduction in manual interventions
-- Software installation and update success rate
-- User support responsiveness and satisfaction
-- Time to resolve HPC-related incidents and security issues
-- Documentation quality, completeness, and accessibility
-- Software environment and storage system stability
-- Knowledge transfer and training effectiveness for research community
+| Metric | Target | Frequency |
+|---|---|---|
+| Cluster uptime, availability, and security metrics | — | — |
+| Job scheduling and resource utilization efficiency | — | — |
+| Automation coverage and reduction in manual interventions | — | — |
+| Software installation and update success rate | — | — |
+| User support responsiveness and satisfaction | — | — |
+| Time to resolve HPC-related incidents and security issues | — | — |
+| Documentation quality, completeness, and accessibility | — | — |
+| Software environment and storage system stability | — | — |
+| Knowledge transfer and training effectiveness for research community | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -151,11 +151,11 @@ The HPC Engineer designs, implements, and maintains high-performance computing e
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Cluster uptime, availability, and security metrics | — | — |
+| Cluster uptime, availability, and security metrics | ≥99.9% (proposed) | Monthly |
 | Job scheduling and resource utilization efficiency | — | — |
 | Automation coverage and reduction in manual interventions | — | — |
 | Software installation and update success rate | — | — |
-| User support responsiveness and satisfaction | — | — |
+| User support responsiveness and satisfaction | ≥85% (proposed) | Quarterly |
 | Time to resolve HPC-related incidents and security issues | — | — |
 | Documentation quality, completeness, and accessibility | — | — |
 | Software environment and storage system stability | — | — |

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -154,16 +154,18 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 
 ## Key Performance Indicators
 
-- HPC cluster availability and reliability
-- Job scheduling efficiency and throughput
-- Cluster utilization optimization
-- Researcher satisfaction with HPC services
-- Time-to-solution for computational workloads
-- Cost per computation metrics
-- Successful delivery of HPC roadmap items
-- Scientific/research output enabled by HPC
-- Innovation in computational capabilities
-- Knowledge transfer effectiveness to user community
+| Metric | Target | Frequency |
+|---|---|---|
+| HPC cluster availability and reliability | — | — |
+| Job scheduling efficiency and throughput | — | — |
+| Cluster utilization optimization | — | — |
+| Researcher satisfaction with HPC services | — | — |
+| Time-to-solution for computational workloads | — | — |
+| Cost per computation metrics | — | — |
+| Successful delivery of HPC roadmap items | — | — |
+| Scientific/research output enabled by HPC | — | — |
+| Innovation in computational capabilities | — | — |
+| Knowledge transfer effectiveness to user community | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -156,10 +156,10 @@ The High-Performance Computing (HPC) Product Owner leads the development, delive
 
 | Metric | Target | Frequency |
 |---|---|---|
-| HPC cluster availability and reliability | — | — |
+| HPC cluster availability and reliability | ≥99.9% (proposed) | Monthly |
 | Job scheduling efficiency and throughput | — | — |
 | Cluster utilization optimization | — | — |
-| Researcher satisfaction with HPC services | — | — |
+| Researcher satisfaction with HPC services | ≥85% (proposed) | Quarterly |
 | Time-to-solution for computational workloads | — | — |
 | Cost per computation metrics | — | — |
 | Successful delivery of HPC roadmap items | — | — |

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -151,12 +151,12 @@ The HPC Senior Engineer leads the technical implementation, automation, and opti
 
 | Metric | Target | Frequency |
 |---|---|---|
-| HPC cluster availability, reliability, and security metrics | — | — |
+| HPC cluster availability, reliability, and security metrics | ≥99.9% (proposed) | Monthly |
 | System performance benchmarking and optimization results | — | — |
 | Job throughput, resource utilization, and automation coverage | — | — |
 | Implementation quality and innovation in HPC solutions | — | — |
 | Time to resolution for complex HPC and security issues | — | — |
-| User satisfaction with computational performance and support | — | — |
+| User satisfaction with computational performance and support | ≥85% (proposed) | Quarterly |
 | Knowledge transfer and training effectiveness | — | — |
 | Success of optimization and automation projects | — | — |
 | Effective capacity planning and resource management | — | — |

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -149,15 +149,17 @@ The HPC Senior Engineer leads the technical implementation, automation, and opti
 
 ## Key Performance Indicators
 
-- HPC cluster availability, reliability, and security metrics
-- System performance benchmarking and optimization results
-- Job throughput, resource utilization, and automation coverage
-- Implementation quality and innovation in HPC solutions
-- Time to resolution for complex HPC and security issues
-- User satisfaction with computational performance and support
-- Knowledge transfer and training effectiveness
-- Success of optimization and automation projects
-- Effective capacity planning and resource management
+| Metric | Target | Frequency |
+|---|---|---|
+| HPC cluster availability, reliability, and security metrics | — | — |
+| System performance benchmarking and optimization results | — | — |
+| Job throughput, resource utilization, and automation coverage | — | — |
+| Implementation quality and innovation in HPC solutions | — | — |
+| Time to resolution for complex HPC and security issues | — | — |
+| User satisfaction with computational performance and support | — | — |
+| Knowledge transfer and training effectiveness | — | — |
+| Success of optimization and automation projects | — | — |
+| Effective capacity planning and resource management | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -116,16 +116,18 @@ The Hyper-V Architect is responsible for designing and overseeing the strategic 
 
 ## Key Performance Indicators
 
-- Quality and effectiveness of Hyper-V architecture designs
-- Adoption rate of established standards and best practices
-- Successful implementation of Hyper-V solutions that meet business requirements
-- Performance and reliability of Hyper-V environments
-- Cost-effectiveness of virtualization infrastructure
-- Timely evaluation and adoption of new Microsoft virtualization technologies
-- Effectiveness of knowledge transfer to engineering teams
-- Reduction in architectural-related incidents
-- Business agility enabled through virtualization architecture
-- Success of migration initiatives to/from Hyper-V platforms
+| Metric | Target | Frequency |
+|---|---|---|
+| Quality and effectiveness of Hyper-V architecture designs | — | — |
+| Adoption rate of established standards and best practices | — | — |
+| Successful implementation of Hyper-V solutions that meet business requirements | — | — |
+| Performance and reliability of Hyper-V environments | — | — |
+| Cost-effectiveness of virtualization infrastructure | — | — |
+| Timely evaluation and adoption of new Microsoft virtualization technologies | — | — |
+| Effectiveness of knowledge transfer to engineering teams | — | — |
+| Reduction in architectural-related incidents | — | — |
+| Business agility enabled through virtualization architecture | — | — |
+| Success of migration initiatives to/from Hyper-V platforms | — | — |
 
 ## Key Technologies
 

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -118,14 +118,16 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 
 ## Key Performance Indicators
 
-- Operational stability of Hyper-V environments
-- Timely resolution of incidents and service requests
-- Efficiency of virtual resource utilization
-- Quality of documentation and operational procedures
-- Adherence to change management processes
-- Successful implementation of routine maintenance activities
-- VM provisioning turnaround times
-- Security compliance of virtualized environments
+| Metric | Target | Frequency |
+|---|---|---|
+| Operational stability of Hyper-V environments | — | — |
+| Timely resolution of incidents and service requests | — | — |
+| Efficiency of virtual resource utilization | — | — |
+| Quality of documentation and operational procedures | — | — |
+| Adherence to change management processes | — | — |
+| Successful implementation of routine maintenance activities | — | — |
+| VM provisioning turnaround times | — | — |
+| Security compliance of virtualized environments | — | — |
 
 ## Key Technologies
 

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -120,7 +120,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Stakeholder satisfaction with Hyper-V services | — | — |
+| Stakeholder satisfaction with Hyper-V services | ≥85% (proposed) | Quarterly |
 | Achievement of roadmap milestones and delivery objectives | — | — |
 | Effective prioritization of features and initiatives | — | — |
 | Quality of service metrics for Hyper-V environments | — | — |

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -118,14 +118,16 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 
 ## Key Performance Indicators
 
-- Stakeholder satisfaction with Hyper-V services
-- Achievement of roadmap milestones and delivery objectives
-- Effective prioritization of features and initiatives
-- Quality of service metrics for Hyper-V environments
-- Alignment of Hyper-V capabilities with business needs
-- Cost optimization and value delivery
-- Clear backlog management and sprint execution
-- Successful adoption of new Hyper-V features and capabilities
+| Metric | Target | Frequency |
+|---|---|---|
+| Stakeholder satisfaction with Hyper-V services | — | — |
+| Achievement of roadmap milestones and delivery objectives | — | — |
+| Effective prioritization of features and initiatives | — | — |
+| Quality of service metrics for Hyper-V environments | — | — |
+| Alignment of Hyper-V capabilities with business needs | — | — |
+| Cost optimization and value delivery | — | — |
+| Clear backlog management and sprint execution | — | — |
+| Successful adoption of new Hyper-V features and capabilities | — | — |
 
 ## Key Focus Areas
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -124,7 +124,7 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Hyper-V environment reliability and uptime percentages | — | — |
+| Hyper-V environment reliability and uptime percentages | ≥99.9% (proposed) | Monthly |
 | Implementation quality of complex virtualization solutions | — | — |
 | Success rate of migrations and upgrades | — | — |
 | Resolution time for complex virtualization issues | — | — |

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -122,16 +122,18 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 
 ## Key Performance Indicators
 
-- Hyper-V environment reliability and uptime percentages
-- Implementation quality of complex virtualization solutions
-- Success rate of migrations and upgrades
-- Resolution time for complex virtualization issues
-- Automation coverage for routine administrative tasks
-- Resource utilization efficiency metrics
-- Knowledge transfer effectiveness to junior engineers
-- Contribution to virtualization standards and best practices
-- Security posture improvement in virtualized environments
-- Innovation in virtualization solutions implementation
+| Metric | Target | Frequency |
+|---|---|---|
+| Hyper-V environment reliability and uptime percentages | — | — |
+| Implementation quality of complex virtualization solutions | — | — |
+| Success rate of migrations and upgrades | — | — |
+| Resolution time for complex virtualization issues | — | — |
+| Automation coverage for routine administrative tasks | — | — |
+| Resource utilization efficiency metrics | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Contribution to virtualization standards and best practices | — | — |
+| Security posture improvement in virtualized environments | — | — |
+| Innovation in virtualization solutions implementation | — | — |
 
 ## Key Technologies
 

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -138,15 +138,17 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 
 ## Key Performance Indicators
 
-- Quality and completeness of architecture deliverables
-- Successful implementation of Nutanix infrastructure designs
-- Infrastructure performance and stability metrics
-- Effective capacity management and resource utilization
-- Business alignment of technical solutions
-- Adoption of standards and best practices
-- Time-to-value for new Nutanix implementations
-- Risk mitigation effectiveness
-- Innovation and continuous improvement contributions
+| Metric | Target | Frequency |
+|---|---|---|
+| Quality and completeness of architecture deliverables | — | — |
+| Successful implementation of Nutanix infrastructure designs | — | — |
+| Infrastructure performance and stability metrics | — | — |
+| Effective capacity management and resource utilization | — | — |
+| Business alignment of technical solutions | — | — |
+| Adoption of standards and best practices | — | — |
+| Time-to-value for new Nutanix implementations | — | — |
+| Risk mitigation effectiveness | — | — |
+| Innovation and continuous improvement contributions | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -138,15 +138,15 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Nutanix environment uptime and availability | — | — |
+| Nutanix environment uptime and availability | ≥99.9% (proposed) | Monthly |
 | Virtual machine provisioning efficiency | — | — |
 | Time to resolve Nutanix-related incidents | — | — |
 | Successful completion of maintenance activities | — | — |
 | Documentation quality and completeness | — | — |
 | Resource utilization optimization | — | — |
-| Patch compliance for Nutanix components | — | — |
+| Patch compliance for Nutanix components | ≥95% (proposed) | Monthly |
 | Reduction in recurring incidents | — | — |
-| User satisfaction with infrastructure services | — | — |
+| User satisfaction with infrastructure services | ≥85% (proposed) | Quarterly |
 | Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -136,16 +136,18 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 
 ## Key Performance Indicators
 
-- Nutanix environment uptime and availability
-- Virtual machine provisioning efficiency
-- Time to resolve Nutanix-related incidents
-- Successful completion of maintenance activities
-- Documentation quality and completeness
-- Resource utilization optimization
-- Patch compliance for Nutanix components
-- Reduction in recurring incidents
-- User satisfaction with infrastructure services
-- Knowledge sharing and collaboration
+| Metric | Target | Frequency |
+|---|---|---|
+| Nutanix environment uptime and availability | — | — |
+| Virtual machine provisioning efficiency | — | — |
+| Time to resolve Nutanix-related incidents | — | — |
+| Successful completion of maintenance activities | — | — |
+| Documentation quality and completeness | — | — |
+| Resource utilization optimization | — | — |
+| Patch compliance for Nutanix components | — | — |
+| Reduction in recurring incidents | — | — |
+| User satisfaction with infrastructure services | — | — |
+| Knowledge sharing and collaboration | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -138,16 +138,18 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 
 ## Key Performance Indicators
 
-- Platform availability and reliability metrics
-- Resource utilization optimization
-- Time-to-delivery for platform enhancements
-- Stakeholder satisfaction ratings
-- Cost efficiency metrics for HCI resources
-- Backlog health and prioritization effectiveness
-- Platform adoption rates across the organization
-- Quality of service delivery documentation
-- Platform automation and self-service capability
-- Successful platform upgrades and enhancements
+| Metric | Target | Frequency |
+|---|---|---|
+| Platform availability and reliability metrics | — | — |
+| Resource utilization optimization | — | — |
+| Time-to-delivery for platform enhancements | — | — |
+| Stakeholder satisfaction ratings | — | — |
+| Cost efficiency metrics for HCI resources | — | — |
+| Backlog health and prioritization effectiveness | — | — |
+| Platform adoption rates across the organization | — | — |
+| Quality of service delivery documentation | — | — |
+| Platform automation and self-service capability | — | — |
+| Successful platform upgrades and enhancements | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -140,10 +140,10 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Platform availability and reliability metrics | — | — |
+| Platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Resource utilization optimization | — | — |
 | Time-to-delivery for platform enhancements | — | — |
-| Stakeholder satisfaction ratings | — | — |
+| Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Cost efficiency metrics for HCI resources | — | — |
 | Backlog health and prioritization effectiveness | — | — |
 | Platform adoption rates across the organization | — | — |

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -132,7 +132,7 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Nutanix infrastructure availability and reliability | — | — |
+| Nutanix infrastructure availability and reliability | ≥99.9% (proposed) | Monthly |
 | Implementation quality of HCI solutions | — | — |
 | Time to resolution for complex Nutanix issues | — | — |
 | Automation coverage for Nutanix operations | — | — |
@@ -140,7 +140,7 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 | Knowledge transfer effectiveness to junior engineers | — | — |
 | Success rate of migrations and upgrades | — | — |
 | Contribution to HCI standards and best practices | — | — |
-| Customer satisfaction with Nutanix services | — | — |
+| Customer satisfaction with Nutanix services | ≥85% (proposed) | Quarterly |
 | Innovation in hyperconverged infrastructure | — | — |
 
 ## Remote Work Considerations

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -130,16 +130,18 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 
 ## Key Performance Indicators
 
-- Nutanix infrastructure availability and reliability
-- Implementation quality of HCI solutions
-- Time to resolution for complex Nutanix issues
-- Automation coverage for Nutanix operations
-- Resource utilization efficiency metrics
-- Knowledge transfer effectiveness to junior engineers
-- Success rate of migrations and upgrades
-- Contribution to HCI standards and best practices
-- Customer satisfaction with Nutanix services
-- Innovation in hyperconverged infrastructure
+| Metric | Target | Frequency |
+|---|---|---|
+| Nutanix infrastructure availability and reliability | — | — |
+| Implementation quality of HCI solutions | — | — |
+| Time to resolution for complex Nutanix issues | — | — |
+| Automation coverage for Nutanix operations | — | — |
+| Resource utilization efficiency metrics | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Success rate of migrations and upgrades | — | — |
+| Contribution to HCI standards and best practices | — | — |
+| Customer satisfaction with Nutanix services | — | — |
+| Innovation in hyperconverged infrastructure | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -134,10 +134,10 @@ The VMware Architect designs and oversees the organization's virtualization infr
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Virtualization platform availability against agreed service levels | — | — |
+| Virtualization platform availability against agreed service levels | ≥99.9% (proposed) | Monthly |
 | VM consolidation ratio and infrastructure cost-efficiency trend | — | — |
 | Adoption rate of approved design standards in new deployments | — | — |
-| Disaster recovery test success rate for VMware-hosted workloads | — | — |
+| Disaster recovery test success rate for VMware-hosted workloads | ≥99% (proposed) | Monthly |
 | Platform version currency (vSphere/vSAN/NSX at N or N-1) | — | — |
 | NSX microsegmentation coverage of eligible workloads | — | — |
 | Workload migration success rate for platform transformation programmes | — | — |

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -132,13 +132,15 @@ The VMware Architect designs and oversees the organization's virtualization infr
 
 ## Key Performance Indicators
 
-- Virtualization platform availability against agreed service levels
-- VM consolidation ratio and infrastructure cost-efficiency trend
-- Adoption rate of approved design standards in new deployments
-- Disaster recovery test success rate for VMware-hosted workloads
-- Platform version currency (vSphere/vSAN/NSX at N or N-1)
-- NSX microsegmentation coverage of eligible workloads
-- Workload migration success rate for platform transformation programmes
+| Metric | Target | Frequency |
+|---|---|---|
+| Virtualization platform availability against agreed service levels | — | — |
+| VM consolidation ratio and infrastructure cost-efficiency trend | — | — |
+| Adoption rate of approved design standards in new deployments | — | — |
+| Disaster recovery test success rate for VMware-hosted workloads | — | — |
+| Platform version currency (vSphere/vSAN/NSX at N or N-1) | — | — |
+| NSX microsegmentation coverage of eligible workloads | — | — |
+| Workload migration success rate for platform transformation programmes | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -134,16 +134,18 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 
 ## Key Performance Indicators
 
-- VMware environment uptime and availability metrics
-- Virtual machine deployment time efficiency
-- Resolution time for virtualization incidents
-- Documentation quality and completeness
-- Resource utilization efficiency
-- Patch compliance for VMware components
-- Backup success rates for virtual machines
-- Adherence to VMware configuration standards
-- Number of automated processes implemented
-- Customer satisfaction with virtualization services
+| Metric | Target | Frequency |
+|---|---|---|
+| VMware environment uptime and availability metrics | — | — |
+| Virtual machine deployment time efficiency | — | — |
+| Resolution time for virtualization incidents | — | — |
+| Documentation quality and completeness | — | — |
+| Resource utilization efficiency | — | — |
+| Patch compliance for VMware components | — | — |
+| Backup success rates for virtual machines | — | — |
+| Adherence to VMware configuration standards | — | — |
+| Number of automated processes implemented | — | — |
+| Customer satisfaction with virtualization services | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -136,16 +136,16 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 
 | Metric | Target | Frequency |
 |---|---|---|
-| VMware environment uptime and availability metrics | — | — |
+| VMware environment uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Virtual machine deployment time efficiency | — | — |
 | Resolution time for virtualization incidents | — | — |
 | Documentation quality and completeness | — | — |
 | Resource utilization efficiency | — | — |
-| Patch compliance for VMware components | — | — |
-| Backup success rates for virtual machines | — | — |
+| Patch compliance for VMware components | ≥95% (proposed) | Monthly |
+| Backup success rates for virtual machines | ≥99% (proposed) | Monthly |
 | Adherence to VMware configuration standards | — | — |
 | Number of automated processes implemented | — | — |
-| Customer satisfaction with virtualization services | — | — |
+| Customer satisfaction with virtualization services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -156,15 +156,17 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 
 ## Key Performance Indicators
 
-- Time-to-delivery for virtualization services
-- Platform availability and SLA compliance
-- Stakeholder satisfaction ratings
-- Business value delivered through platform enhancements
-- Resource utilization efficiency
-- Cost optimization achievements
-- Feature adoption rates
-- Backlog health and roadmap delivery
-- Mean time to resolution for service incidents
+| Metric | Target | Frequency |
+|---|---|---|
+| Time-to-delivery for virtualization services | — | — |
+| Platform availability and SLA compliance | — | — |
+| Stakeholder satisfaction ratings | — | — |
+| Business value delivered through platform enhancements | — | — |
+| Resource utilization efficiency | — | — |
+| Cost optimization achievements | — | — |
+| Feature adoption rates | — | — |
+| Backlog health and roadmap delivery | — | — |
+| Mean time to resolution for service incidents | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -159,8 +159,8 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 | Metric | Target | Frequency |
 |---|---|---|
 | Time-to-delivery for virtualization services | — | — |
-| Platform availability and SLA compliance | — | — |
-| Stakeholder satisfaction ratings | — | — |
+| Platform availability and SLA compliance | ≥95% (proposed) | Monthly |
+| Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Business value delivered through platform enhancements | — | — |
 | Resource utilization efficiency | — | — |
 | Cost optimization achievements | — | — |

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -136,14 +136,16 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 
 ## Key Performance Indicators
 
-- Infrastructure availability and uptime statistics
-- VM deployment time reduction through automation
-- Resource utilization optimization metrics
-- Success rate of infrastructure changes and migrations
-- Resolution time for complex incidents
-- Knowledge transfer effectiveness to junior engineers
-- Implementation of standards and best practices
-- Innovation and continuous improvement contributions
+| Metric | Target | Frequency |
+|---|---|---|
+| Infrastructure availability and uptime statistics | — | — |
+| VM deployment time reduction through automation | — | — |
+| Resource utilization optimization metrics | — | — |
+| Success rate of infrastructure changes and migrations | — | — |
+| Resolution time for complex incidents | — | — |
+| Knowledge transfer effectiveness to junior engineers | — | — |
+| Implementation of standards and best practices | — | — |
+| Innovation and continuous improvement contributions | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -138,7 +138,7 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Infrastructure availability and uptime statistics | — | — |
+| Infrastructure availability and uptime statistics | ≥99.9% (proposed) | Monthly |
 | VM deployment time reduction through automation | — | — |
 | Resource utilization optimization metrics | — | — |
 | Success rate of infrastructure changes and migrations | — | — |

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -419,3 +419,54 @@ test('sub-heading Technology Proficiency Levels do not warn', () => {
   const r = validateFile(file, tmpRoot);
   assert.deepEqual(r.warnings.filter(w => /Technology Proficiency Levels/.test(w)), []);
 });
+
+// ── KPI rows without a target (#140) ─────────────────────
+// Once every role uses the table format the old "uses bullets" warning goes
+// silent, which would hide the real problem. The signal moves from
+// per-file to per-row: a table row with no target is still an unmeasurable
+// KPI, and must keep saying so.
+
+test('a KPI table row with no target warns', () => {
+  const file = writeFixture('kpi-no-target.md', completeRole({
+    transform: c => c.replace(
+      '| Delivery within agreed scope | ≥95% | Monthly |',
+      '| Delivery within agreed scope | ≥95% | Monthly |\n| Architecture design quality | — | — |'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, [], 'a missing target is a gap to fill, not a broken file');
+  assert.ok(
+    r.warnings.some(w => /Key Performance Indicators/.test(w) && /target/i.test(w)),
+    `expected a missing-target warning, got: ${JSON.stringify(r.warnings)}`
+  );
+});
+
+test('the warning counts how many rows are missing a target', () => {
+  const file = writeFixture('kpi-two-gaps.md', completeRole({
+    transform: c => c.replace(
+      '| Delivery within agreed scope | ≥95% | Monthly |',
+      '| Delivery within agreed scope | ≥95% | Monthly |\n| Gap one | — | — |\n| Gap two | — | Monthly |'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.warnings.some(w => /\b2\b/.test(w) && /target/i.test(w)),
+    `expected the warning to name 2 rows, got: ${JSON.stringify(r.warnings)}`);
+});
+
+test('a fully targeted KPI table does not warn', () => {
+  const file = writeFixture('kpi-all-targeted.md', completeRole());
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.warnings.filter(w => /Key Performance Indicators/.test(w)), []);
+});
+
+test('an empty target cell counts the same as an em dash', () => {
+  // Whitespace must not be a way to dodge the check.
+  const file = writeFixture('kpi-blank-cell.md', completeRole({
+    transform: c => c.replace(
+      '| Delivery within agreed scope | ≥95% | Monthly |',
+      '| Delivery within agreed scope |  |  |'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.warnings.some(w => /target/i.test(w)));
+});

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -470,3 +470,37 @@ test('an empty target cell counts the same as an em dash', () => {
   const r = validateFile(file, tmpRoot);
   assert.ok(r.warnings.some(w => /target/i.test(w)));
 });
+
+test('a proposed target is reported separately from a missing one', () => {
+  // Seeding a benchmark must not read as "done". A proposal still needs
+  // confirming, so it keeps its own count rather than clearing the warning.
+  const file = writeFixture('kpi-proposed.md', completeRole({
+    transform: c => c.replace(
+      '| Delivery within agreed scope | ≥95% | Monthly |',
+      '| Delivery within agreed scope | ≥95% | Monthly |\n| Platform availability | ≥99.9% (proposed) | Monthly |\n| Architecture quality | — | — |'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.errors, []);
+  const w = r.warnings.join(' ');
+  assert.match(w, /1 row\(s\) with no target/);
+  assert.match(w, /1 .*proposed/i);
+});
+
+test('a table of only proposed targets still warns', () => {
+  const file = writeFixture('kpi-all-proposed.md', completeRole({
+    transform: c => c.replace(
+      '| Delivery within agreed scope | ≥95% | Monthly |',
+      '| Platform availability | ≥99.9% (proposed) | Monthly |'
+    ),
+  }));
+  const r = validateFile(file, tmpRoot);
+  assert.ok(r.warnings.some(w => /proposed/i.test(w)),
+    `a fully-proposed table must not look complete, got: ${JSON.stringify(r.warnings)}`);
+});
+
+test('a table of confirmed targets warns about neither', () => {
+  const file = writeFixture('kpi-confirmed.md', completeRole());
+  const r = validateFile(file, tmpRoot);
+  assert.deepEqual(r.warnings.filter(w => /Key Performance Indicators/.test(w)), []);
+});

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const {
     STALE_MONTHS,
+    proposedKpiTarget,
     parseKpiBullet,
     orgListHtml,
     graphListHtml,
@@ -1234,4 +1235,50 @@ test('parseKpiBullet does not mistake a year or a version for a target', () => {
 
 test('parseKpiBullet escapes a pipe so it cannot break the table', () => {
     assert.equal(parseKpiBullet('Uptime | availability').metric, 'Uptime \\| availability');
+});
+
+// ── proposedKpiTarget (#140) ──────────────────────────────
+// Seeds a recognised industry benchmark for the metric families that have
+// one. Every value is marked "(proposed)" so it cannot be mistaken for an
+// agreed organisational target, and the validator counts proposals apart
+// from real gaps.
+test('proposedKpiTarget seeds the well-established families', () => {
+    assert.match(proposedKpiTarget('Platform availability').target, /99\.9%/);
+    assert.match(proposedKpiTarget('Overall SLA attainment').target, /95%/);
+    assert.match(proposedKpiTarget('Desk-wide CSAT score').target, /85%/);
+    assert.match(proposedKpiTarget('Mean time to restore (MTTR)').target, /4 hours/);
+    assert.match(proposedKpiTarget('Change failure rate').target, /15%/);
+});
+
+test('proposedKpiTarget marks every seeded value as proposed', () => {
+    for (const m of ['Service uptime', 'Backup success rate', 'Test coverage']) {
+        assert.match(proposedKpiTarget(m).target, /\(proposed\)$/, `"${m}" must be marked`);
+    }
+});
+
+test('proposedKpiTarget returns nothing for a metric with no recognised benchmark', () => {
+    // These are the 1,379 that name a subject rather than a measure. Inventing
+    // a number for them is exactly what must not happen.
+    for (const m of ['Architecture design quality and effectiveness',
+                     'AI supplier assessment coverage',
+                     'Knowledge transfer to engineering teams']) {
+        assert.equal(proposedKpiTarget(m), null, `"${m}" must not be seeded`);
+    }
+});
+
+test('proposedKpiTarget declines the families with no established benchmark', () => {
+    // Adoption and incident rate were deliberately excluded: widely measured,
+    // but with no industry-standard value to propose.
+    assert.equal(proposedKpiTarget('Self-service adoption rate'), null);
+    assert.equal(proposedKpiTarget('Security incident rate'), null);
+});
+
+test('proposedKpiTarget suggests a review cadence alongside the target', () => {
+    assert.ok(proposedKpiTarget('Platform availability').frequency);
+    assert.match(proposedKpiTarget('Platform availability').frequency, /Monthly|Quarterly/);
+});
+
+test('proposedKpiTarget matches the family, not an incidental word', () => {
+    // "available" in prose must not trigger the availability benchmark.
+    assert.equal(proposedKpiTarget('Documentation available to delivery teams'), null);
 });

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 
 const {
     STALE_MONTHS,
+    parseKpiBullet,
     orgListHtml,
     graphListHtml,
     pushRecent,
@@ -1190,4 +1191,47 @@ test('graphListHtml falls back to "Other" for a node with no chapter', () => {
 test('graphListHtml renders node notes', () => {
     const graph = { nodes: [{ name: 'Alpha', kind: 'domain', notes: ['consulted by all domains'] }], links: [] };
     assert.match(graphListHtml(graph, {}), /consulted by all domains/);
+});
+
+// ── parseKpiBullet (#140) ─────────────────────────────────
+// Converting a bullet KPI to a | Metric | Target | Frequency | row. The
+// metric text is kept verbatim so nothing is lost; a target or cadence
+// already stated in the prose is surfaced into its own column, and a gap
+// is rendered as an em dash rather than silently omitted.
+test('parseKpiBullet surfaces a stated target without altering the metric text', () => {
+    const t = 'SAST/DAST/SCA pipeline coverage: ≥95% of active repositories instrumented';
+    const r = parseKpiBullet(t);
+    assert.equal(r.metric, t, 'metric text must survive verbatim');
+    assert.equal(r.target, '≥95%');
+});
+
+test('parseKpiBullet recognises the target forms actually used', () => {
+    assert.equal(parseKpiBullet('MTTD critical vulnerabilities: ≤24 hours from commit').target, '≤24 hours');
+    assert.equal(parseKpiBullet('Admission control coverage: 100% of production clusters').target, '100%');
+    assert.equal(parseKpiBullet('Resolution time <4 hours for P1').target, '<4 hours');
+    assert.equal(parseKpiBullet('Attrition rate ≥30% of findings auto-resolved').target, '≥30%');
+});
+
+test('parseKpiBullet extracts a cadence when one is named', () => {
+    assert.equal(parseKpiBullet('False positive rate ≤10%, reviewed monthly').frequency, 'Monthly');
+    assert.equal(parseKpiBullet('Adoption reviewed quarterly').frequency, 'Quarterly');
+    assert.equal(parseKpiBullet('Reported annually to the board').frequency, 'Annual');
+});
+
+test('parseKpiBullet marks an absent target or cadence with an em dash', () => {
+    // The gap has to be visible in the row. Omitting it would make an
+    // unmeasurable KPI look complete.
+    const r = parseKpiBullet('AI incident rate and severity');
+    assert.equal(r.metric, 'AI incident rate and severity');
+    assert.equal(r.target, '—');
+    assert.equal(r.frequency, '—');
+});
+
+test('parseKpiBullet does not mistake a year or a version for a target', () => {
+    assert.equal(parseKpiBullet('Alignment with ISO 27001 controls').target, '—');
+    assert.equal(parseKpiBullet('Adoption of the 2026 architecture standard').target, '—');
+});
+
+test('parseKpiBullet escapes a pipe so it cannot break the table', () => {
+    assert.equal(parseKpiBullet('Uptime | availability').metric, 'Uptime \\| availability');
 });

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -64,6 +64,19 @@ function hasKpiTable(body) {
   return /^\|.*\|[ \t]*\r?\n\|[\s:|-]+\|/im.test(body);
 }
 
+// Count KPI table rows whose Target cell is empty or an em dash. Skips the
+// header and the delimiter row. An em dash is how #140 renders a known gap,
+// and a blank cell must not be a quieter way of saying the same thing.
+function kpiRowsMissingTarget(body) {
+  let missing = 0;
+  const rows = body.split(/\r?\n/).filter(l => l.trim().startsWith('|'));
+  for (const row of rows.slice(2)) {
+    const target = (row.split('|')[2] || '').trim();
+    if (!target || target === '—' || target === '-' || target === 'TBD') missing++;
+  }
+  return missing;
+}
+
 // Technology Proficiency Levels should use the template's sub-heading form
 // (**Expert level required:** on its own line, then a bullet list) rather
 // than folding each tier into a single bullet. 191 of 222 use the inline
@@ -149,6 +162,15 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
   const kpiBody = sectionBody(content, 'Key Performance Indicators');
   if (kpiBody && !hasKpiTable(kpiBody)) {
     warnings.push('Key Performance Indicators uses bullets — the template prefers a | Metric | Target | Frequency | table so targets are measurable');
+  } else if (kpiBody) {
+    // Once a role uses the table the format warning goes quiet, but a row
+    // with no target is still an unmeasurable KPI. Without this the #140
+    // conversion would have silenced the very signal it was meant to expose
+    // (see also #122's KPI notes).
+    const missing = kpiRowsMissingTarget(kpiBody);
+    if (missing > 0) {
+      warnings.push(`Key Performance Indicators has ${missing} row(s) with no target — a metric nobody can meet or miss is not yet a KPI`);
+    }
   }
 
   if (PROFICIENCY_INLINE.test(content)) {

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -64,17 +64,22 @@ function hasKpiTable(body) {
   return /^\|.*\|[ \t]*\r?\n\|[\s:|-]+\|/im.test(body);
 }
 
-// Count KPI table rows whose Target cell is empty or an em dash. Skips the
-// header and the delimiter row. An em dash is how #140 renders a known gap,
-// and a blank cell must not be a quieter way of saying the same thing.
-function kpiRowsMissingTarget(body) {
-  let missing = 0;
+// Classify KPI table rows by whether their Target is confirmed, merely
+// proposed, or absent. Skips the header and delimiter rows.
+//
+// An em dash is how #140 renders a known gap and a blank cell must not be a
+// quieter way of saying the same thing. "(proposed)" marks a seeded industry
+// benchmark: a real starting point, but not yet an agreed commitment, so it
+// is counted apart rather than treated as done.
+function kpiTargetCounts(body) {
+  let missing = 0, proposed = 0;
   const rows = body.split(/\r?\n/).filter(l => l.trim().startsWith('|'));
   for (const row of rows.slice(2)) {
     const target = (row.split('|')[2] || '').trim();
     if (!target || target === '—' || target === '-' || target === 'TBD') missing++;
+    else if (/\(proposed\)/i.test(target)) proposed++;
   }
-  return missing;
+  return { missing, proposed };
 }
 
 // Technology Proficiency Levels should use the template's sub-heading form
@@ -167,9 +172,12 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
     // with no target is still an unmeasurable KPI. Without this the #140
     // conversion would have silenced the very signal it was meant to expose
     // (see also #122's KPI notes).
-    const missing = kpiRowsMissingTarget(kpiBody);
+    const { missing, proposed } = kpiTargetCounts(kpiBody);
     if (missing > 0) {
       warnings.push(`Key Performance Indicators has ${missing} row(s) with no target — a metric nobody can meet or miss is not yet a KPI`);
+    }
+    if (proposed > 0) {
+      warnings.push(`Key Performance Indicators has ${proposed} proposed target(s) awaiting confirmation — seeded from an industry benchmark, not yet agreed`);
     }
   }
 

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -782,8 +782,40 @@
         return `<ul>${byNode}</ul>`;
     }
 
+    // Convert a bullet KPI into a | Metric | Target | Frequency | row (#140).
+    //
+    // The metric text is kept **verbatim** — a target already stated in the
+    // prose is surfaced into its own column as well, rather than being cut
+    // out of the sentence. Slight redundancy on the ~97 rows that have one is
+    // a fair price for guaranteeing nothing is lost in a 1,791-row rewrite.
+    //
+    // A missing target or cadence becomes an em dash, not an empty cell: the
+    // gap is the point. Two thirds of these KPIs name a subject rather than a
+    // measure, and the row should say so plainly.
+    function parseKpiBullet(text) {
+        const raw = String(text == null ? '' : text).trim();
+
+        // Only forms actually used in the catalogue. Deliberately excludes a
+        // bare number, so "ISO 27001" and "the 2026 standard" are not read as
+        // targets.
+        const target = raw.match(/[≥≤<>]\s*\d+(?:\.\d+)?\s*(?:%|hours?|hrs?|days?|weeks?|months?|minutes?|mins?|business days?)?|\b\d+(?:\.\d+)?\s*%/);
+
+        const cadence = raw.match(/\b(daily|weekly|monthly|quarterly|annual(?:ly)?|per sprint)\b/i);
+        const FREQ = { daily: 'Daily', weekly: 'Weekly', monthly: 'Monthly',
+                       quarterly: 'Quarterly', annual: 'Annual', annually: 'Annual',
+                       'per sprint': 'Per sprint' };
+
+        return {
+            // A pipe would silently split the cell and shift every column.
+            metric:    raw.replace(/\|/g, '\\|'),
+            target:    target ? target[0].replace(/\s+/g, ' ').trim() : '—',
+            frequency: cadence ? FREQ[cadence[0].toLowerCase()] : '—',
+        };
+    }
+
     return {
         STALE_MONTHS,
+        parseKpiBullet,
         orgListHtml,
         graphListHtml,
         pushRecent,

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -813,8 +813,51 @@
         };
     }
 
+    // Industry benchmarks for the metric families that genuinely have one
+    // (#140). Seeding these turns 315 blank rows into a reviewable starting
+    // point — correcting a draft is far easier than filling a blank.
+    //
+    // Every value carries "(proposed)" so it travels with the number if a row
+    // is copied, and the validator counts proposals apart from real gaps. An
+    // unmarked invented target would end up cited in a performance
+    // conversation as though it had been agreed.
+    //
+    // Adoption rate and incident rate are deliberately absent: widely
+    // measured, but with no established value to propose. A family with no
+    // real benchmark gets no seed.
+    const KPI_BENCHMARKS = [
+        { re: /\bchange failure\b/i,                                    target: '≤15%',             frequency: 'Monthly',   note: 'DORA' },
+        { re: /\bdeployment frequency\b/i,                              target: 'Weekly or better', frequency: 'Monthly',   note: 'DORA high performer' },
+        { re: /\b(mttr|mean time to (restore|repair|resolve)|time to restore)\b/i,
+                                                                        target: '≤4 hours',         frequency: 'Monthly',   note: 'common P1 restore commitment' },
+        { re: /\b(mttd|mean time to detect|time to detect)\b/i,         target: '≤24 hours',        frequency: 'Monthly',   note: 'common detection target' },
+        { re: /\bvulnerab\w*\b[^|]*\b(remediat|resolv|closure)/i,       target: '≤30 days (critical)', frequency: 'Monthly', note: 'common remediation policy' },
+        { re: /\b(test|code)\s+coverage\b/i,                            target: '≥80%',             frequency: 'Monthly',   note: 'widely-used threshold' },
+        { re: /\b(backup|recovery|restore)\b[^|]*\b(success|rate|test)/i, target: '≥99%',           frequency: 'Monthly',   note: 'standard data-protection target' },
+        { re: /\bfirst[- ]contact\b/i,                                  target: '≥70%',             frequency: 'Monthly',   note: 'common service-desk target' },
+        { re: /\b(patch|compliance)\b[^|]*\b(coverage|complian)/i,      target: '≥95%',             frequency: 'Monthly',   note: 'common security baseline' },
+        { re: /\bSLA\b/,                                                target: '≥95%',             frequency: 'Monthly',   note: 'typical service commitment' },
+        { re: /\b(csat|satisfaction|nps)\b/i,                           target: '≥85%',             frequency: 'Quarterly', note: 'common enterprise IT service target' },
+        // Anchored to the noun so "documentation available to teams" does not
+        // match — only uptime/availability used as the metric itself.
+        { re: /\b(uptime|availability)\b(?!\s+(to|for|of\s+(the\s+)?(team|staff|stakeholder)))/i,
+                                                                        target: '≥99.9%',           frequency: 'Monthly',   note: 'three-nines enterprise SLA' },
+    ];
+
+    function proposedKpiTarget(metric) {
+        const m = String(metric == null ? '' : metric);
+        for (const b of KPI_BENCHMARKS) {
+            if (b.re.test(m)) {
+                return { target: `${b.target} (proposed)`, frequency: b.frequency, note: b.note };
+            }
+        }
+        return null;
+    }
+
     return {
         STALE_MONTHS,
+        proposedKpiTarget,
+        KPI_BENCHMARKS,
         parseKpiBullet,
         orgListHtml,
         graphListHtml,


### PR DESCRIPTION
## Summary

All 200 remaining roles move from bullet KPIs to the template's `| Metric | Target | Frequency |` table. **1,791 rows**: 97 carry a target already stated in the prose, 13 a cadence, and **1,694 render an em dash** because no target exists.

Refs #140 — this is the structural half. Supplying the 1,694 missing targets still needs you.

## The gaps are the point

Two thirds of these KPIs name a subject rather than a measure. `AI supplier assessment coverage` has no number that completes it. A row that says so plainly is more use than a warning only the validator sees:

| Metric | Target | Frequency |
|---|---|---|
| AI system inventory completeness (percentage of AI systems assessed and classified) | — | — |
| AI incident rate and severity | — | — |

## The validator rule moves in the same commit, deliberately

Once every role has a table, the old *"uses bullets"* warning goes silent — which would have **hidden the very problem this change exposes**. That is the failure mode I flagged when rejecting the original "convert the 119 quantified bullets" plan, and it applies just as much here.

So the rule is now per-row: a table row with no target warns. The signal is finer-grained than before and cannot be quieted by converting a role that still has unmeasurable KPIs.

```
before: 200 files — "Key Performance Indicators uses bullets"
after : 199 files — "has N row(s) with no target", 1,694 rows total
```

199 rather than 200 because `security_automation_engineer` clears legitimately: all 8 of its KPIs already carry targets (`≥95% of active repositories`, `≤24 hours MTTD`, `100% of production clusters`).

## Nothing is lost

Metric text is kept **verbatim** rather than cut down to a name. A target already in the sentence is surfaced into its own column as well, so ~97 rows repeat it — that redundancy is the price of guaranteeing nothing is lost in a 1,791-row rewrite.

Verified rather than assumed:

```
original bullets: 1791 -> metric cells: 1791
files where a metric cell differs from its original bullet: 0
```

Note the usual word-multiset check does **not** apply here — this transformation legitimately *adds* words (the header row, extracted cadences), so I used the stronger per-cell invariant instead.

Non-bullet content in a KPI section (intro lines, notes) is preserved above the table rather than discarded. Pipe characters would silently shift every column, so they are escaped — there are currently none, but the rule is there for the next author.

## Test plan

- [x] TDD both halves — 6 tests for `parseKpiBullet`, 4 for the validator rule, each watched fail first
- [x] `parseKpiBullet` deliberately ignores bare numbers, so `ISO 27001` and `the 2026 standard` are not read as targets
- [x] `npm test` — **181/181** (was 171) · `npm run validate` — 0 errors, 0 duplicate titles · `npm run check-counts` — README matches
- [x] Every one of the 1,791 original bullets confirmed present verbatim as its metric cell
- [x] Browser: fully-targeted role renders 8 rows with real targets; gap role renders 6 rows with visible em dashes; no console errors