### PR TITLE
release: 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-06
+
+Every KPI section is now a table, with its gaps visible on the page rather
+than only in a validator warning.
+
+### Changed
+
+- **All 200 remaining roles moved from bullet KPIs to the template's
+  `| Metric | Target | Frequency |` table (#140).** 1,791 rows: 97 carried a
+  target already stated in the prose, 13 a cadence.
+
+  Metric text is kept **verbatim** rather than cut down to a name — a target
+  already in the sentence is surfaced into its own column as well, so ~97
+  rows repeat it. That redundancy is the price of guaranteeing nothing is
+  lost in a 1,791-row rewrite, and it was verified rather than assumed:
+  every original bullet appears unchanged as its metric cell.
+
+- **258 rows seeded with recognised industry benchmarks, each marked
+  `(proposed)` (#140).** Three-nines availability, DORA change failure and
+  deployment frequency, common P1 restore and detection times, standard
+  data-protection and security baselines, widely-used coverage thresholds.
+
+  Correcting a draft is far easier than filling a blank, and a marked
+  proposal carries none of the risk of an unmarked invented number — which
+  would end up cited as though it had been agreed.
+
+  **Adoption rate and incident rate are deliberately not seeded.** Both are
+  widely measured and neither has an industry-standard value to propose.
+
+### Added
+
+- **The validator reports KPI targets per row, not per file.** Previously it
+  warned that a role "uses bullets"; once every role has a table that
+  warning goes silent, which would have hidden the very problem the
+  conversion exists to expose. It now counts rows with **no target**
+  separately from **proposed** targets awaiting confirmation, so neither
+  converting a role nor seeding a benchmark can make it look finished.
+
+  ```
+  before: 200 files — "Key Performance Indicators uses bullets"
+  after :   258 proposed awaiting confirmation
+            1,436 rows still with no target
+  ```
+
+  `security_automation_engineer` is the first role in the catalogue to clear
+  the check outright — all 8 of its KPIs already carry real targets.
+
+### Testing
+
+Suite grown **171 → 190**. New tests assert that `parseKpiBullet` does not
+read `ISO 27001` or `the 2026 standard` as a target, that unmeasurable
+metrics are **not** seeded, and that `documentation available to teams` does
+not trigger the availability benchmark.
+
+### Still open
+
+1,436 rows have no target. Roughly a third name a real metric and need a
+number; the rest name a subject and need rewriting or removal — a KPI nobody
+can quantify is not a KPI. Tracked in #140.
+
 ## [1.11.1] - 2026-08-06
 
 Content readability and test coverage. No behaviour change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

Bumps `package.json` to 1.12.0 and adds the `[1.12.0]` CHANGELOG section.

Every KPI section is now a table with its gaps visible on the page rather than only in a validator warning. **Minor rather than patch** because the validator's behaviour changes. Refs #140.

| | Before | After |
|---|---|---|
| Roles using the KPI table | 26 | **226 (all)** |
| Rows with no target | 1,791 | **1,436** |
| Rows with a proposed benchmark | 0 | **258** |
| Test suite | 171 | **190** |

### The design constraint that shaped this

Converting every role to a table silences the old "uses bullets" warning — which would have **hidden the very problem the conversion exists to expose**. So the validator rule changed in the same commit: it now counts rows with no target separately from proposed targets awaiting confirmation. Neither converting a role nor seeding a benchmark can make it look finished.

`security_automation_engineer` becomes the first role to clear the check outright, with all 8 KPIs carrying real targets.

### On the seeded benchmarks

258 rows carry a recognised industry benchmark marked `(proposed)` — three-nines availability, DORA change failure and deployment frequency, common restore and detection times. **Adoption rate and incident rate were deliberately excluded**: widely measured, but with no industry-standard value to propose.

## Test plan

- [x] `npm test` — 190/190
- [x] `npm run validate` — 0 errors, 0 duplicate titles
- [x] `npm run check-counts` — README matches filesystem
- [x] Every one of the 1,791 original bullets verified present verbatim as its metric cell
- [x] Seeding verified to touch only Target and Frequency — zero metric text altered across 1,368 rows
- [x] Verified in-browser at desktop and on the role pages before merge