### PR TITLE
docs: rewrite the repeated subject-style KPIs into countable measures

### DIFF
--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -151,8 +151,8 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Quality of cost optimization implementations | — | — |
 | Effectiveness of monitoring and alerting setup | — | — |
 | Resource tagging compliance percentage | — | — |
-| Reserved/committed capacity optimization | — | — |
-| Documentation quality and completeness | — | — |
+| Eligible spend covered by reserved or committed capacity (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | User satisfaction with cost management tools | ≥85% (proposed) | Quarterly |
 | Problem resolution time for billing issues | — | — |
 

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -157,7 +157,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 | Adoption of FinOps practices across teams | — | — |
 | Quality of backlog management | — | — |
 | Unit economics improvement metrics | — | — |
-| Reserved/committed capacity optimization | — | — |
+| Eligible spend covered by reserved or committed capacity (%) | — | — |
 | FinOps maturity progression | — | — |
 
 ## Remote Work Considerations

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -147,7 +147,7 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 | Knowledge transfer to junior team members | — | — |
 | Innovation in cost optimization approaches | — | — |
 | Implementation quality of FinOps standards | — | — |
-| Cross-team collaboration effectiveness | — | — |
+| Cross-team deliverables completed in the committed period (%) | — | — |
 | Data quality and reliability metrics | — | — |
 
 ## Remote Work Considerations

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -134,16 +134,16 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of API designs with business requirements | — | — |
 | API platform performance and scalability | — | — |
 | Security posture of API implementations | — | — |
 | Adoption of API reference architectures and patterns | — | — |
 | Reduction in API architectural risks and technical debt | — | — |
-| Developer productivity improvement through standards | — | — |
+| Median lead time from commit to production for teams on the standard (hours) | — | — |
 | Innovation in API architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -135,7 +135,7 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of API designs with business requirements | — | — |
+| API designs accepted by the requesting business owner without rework (%) | — | — |
 | API platform performance and scalability | — | — |
 | Security posture of API implementations | — | — |
 | Adoption of API reference architectures and patterns | — | — |

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -134,7 +134,7 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 |---|---|---|
 | API platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | API response time and throughput performance | — | — |
-| Implementation quality of API solutions | — | — |
+| API implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex API issues | — | — |
 | Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
 | API security posture improvement | — | — |

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -136,7 +136,7 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 | API response time and throughput performance | — | — |
 | Implementation quality of API solutions | — | — |
 | Time to resolution for complex API issues | — | — |
-| Knowledge transfer effectiveness to junior developers | — | — |
+| Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
 | API security posture improvement | — | — |
 | Successful implementation of API standards | — | — |
 | Developer satisfaction with API platform | ≥85% (proposed) | Quarterly |

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -131,16 +131,16 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of .NET designs with business requirements | — | — |
-| Application performance and scalability | — | — |
+| Application transactions meeting their response-time budget (%) | — | — |
 | Security posture of .NET applications | — | — |
 | Adoption of .NET reference architectures and patterns | — | — |
-| Reduction in architectural risks and technical debt | — | — |
-| Developer productivity improvement through standards | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| Median lead time from commit to production for teams on the standard (hours) | — | — |
 | Innovation in .NET architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -132,7 +132,7 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of .NET designs with business requirements | — | — |
+| .NET designs accepted by the requesting business owner without rework (%) | — | — |
 | Application transactions meeting their response-time budget (%) | — | — |
 | Security posture of .NET applications | — | — |
 | Adoption of .NET reference architectures and patterns | — | — |

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -138,7 +138,7 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
-| Adherence to .NET coding standards | — | — |
+| Work conforming to .NET coding standards (%) | — | — |
 | Cross-team deliverables completed in the committed period (%) | — | — |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Support requests acknowledged within the agreed response window (%) | — | — |

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -133,16 +133,16 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Code quality and maintainability metrics | — | — |
+| Code quality gate pass rate on the main branch (%) | — | — |
 | Timely completion of development tasks | — | — |
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Adherence to .NET coding standards | — | — |
-| Collaboration effectiveness with team | — | — |
-| Knowledge sharing and skill development | — | — |
-| Responsiveness to support requests | — | — |
-| Application performance and resource usage | — | — |
+| Cross-team deliverables completed in the committed period (%) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Support requests acknowledged within the agreed response window (%) | — | — |
+| Application transactions meeting their response-time budget (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -134,12 +134,12 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 | Developer satisfaction with .NET platform | ≥85% (proposed) | Quarterly |
 | Platform adoption rates across development teams | — | — |
 | Time-to-market improvement for applications | — | — |
-| Reduction in development effort through shared components | — | — |
-| Platform reliability and performance metrics | — | — |
+| Delivery teams consuming a shared component rather than rebuilding it (count) | — | — |
+| Platform services meeting their published SLO (%) | — | — |
 | Security vulnerability reduction in .NET applications | — | — |
-| Successful delivery of platform roadmap items | — | — |
-| Business value delivery through platform capabilities | — | — |
-| Return on investment for platform initiatives | — | — |
+| Platform roadmap items delivered in the committed quarter (%) | — | — |
+| Delivery teams onboarded to a platform capability (count per quarter) | — | — |
+| Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in .NET capabilities | — | — |
 
 ## Remote Work Considerations

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -132,15 +132,15 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 | Metric | Target | Frequency |
 |---|---|---|
 | .NET platform reliability and performance metrics | — | — |
-| Code quality and maintainability scores | — | — |
+| Code quality gate pass rate on the main branch (%) | — | — |
 | Implementation quality of .NET solutions | — | — |
 | Time to resolution for complex .NET issues | — | — |
-| Knowledge transfer effectiveness to junior developers | — | — |
+| Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
 | .NET security posture improvement | — | — |
 | Successful implementation of .NET standards | — | — |
-| Reduction in technical debt | — | — |
+| Recorded technical debt items closed (count per quarter) | — | — |
 | Innovation in .NET platform capabilities | — | — |
-| Team productivity improvements through frameworks | — | — |
+| Median lead time from commit to production for teams on the framework (hours) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -133,7 +133,7 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 |---|---|---|
 | .NET platform reliability and performance metrics | — | — |
 | Code quality gate pass rate on the main branch (%) | — | — |
-| Implementation quality of .NET solutions | — | — |
+| .NET implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex .NET issues | — | — |
 | Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
 | .NET security posture improvement | — | — |

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -131,16 +131,16 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of Java designs with business requirements | — | — |
-| Application performance and scalability | — | — |
+| Application transactions meeting their response-time budget (%) | — | — |
 | Security posture of Java applications | — | — |
 | Adoption of Java reference architectures and patterns | — | — |
-| Reduction in architectural risks and technical debt | — | — |
-| Developer productivity improvement through standards | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| Median lead time from commit to production for teams on the standard (hours) | — | — |
 | Innovation in Java architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -132,7 +132,7 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of Java designs with business requirements | — | — |
+| Java designs accepted by the requesting business owner without rework (%) | — | — |
 | Application transactions meeting their response-time budget (%) | — | — |
 | Security posture of Java applications | — | — |
 | Adoption of Java reference architectures and patterns | — | — |

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -138,7 +138,7 @@ The Java Engineer implements and maintains Java-based applications and platform 
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
-| Adherence to Java coding standards | — | — |
+| Work conforming to Java coding standards (%) | — | — |
 | Cross-team deliverables completed in the committed period (%) | — | — |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Support requests acknowledged within the agreed response window (%) | — | — |

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -133,16 +133,16 @@ The Java Engineer implements and maintains Java-based applications and platform 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Code quality and maintainability metrics | — | — |
+| Code quality gate pass rate on the main branch (%) | — | — |
 | Timely completion of development tasks | — | — |
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Adherence to Java coding standards | — | — |
-| Collaboration effectiveness with team | — | — |
-| Knowledge sharing and skill development | — | — |
-| Responsiveness to support requests | — | — |
-| Application performance and resource usage | — | — |
+| Cross-team deliverables completed in the committed period (%) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Support requests acknowledged within the agreed response window (%) | — | — |
+| Application transactions meeting their response-time budget (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -135,12 +135,12 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 | Developer satisfaction with Java platform | ≥85% (proposed) | Quarterly |
 | Platform adoption rates across development teams | — | — |
 | Time-to-market improvement for applications | — | — |
-| Reduction in development effort through shared components | — | — |
-| Platform reliability and performance metrics | — | — |
+| Delivery teams consuming a shared component rather than rebuilding it (count) | — | — |
+| Platform services meeting their published SLO (%) | — | — |
 | Security vulnerability reduction in Java applications | — | — |
-| Successful delivery of platform roadmap items | — | — |
-| Business value delivery through platform capabilities | — | — |
-| Return on investment for platform initiatives | — | — |
+| Platform roadmap items delivered in the committed quarter (%) | — | — |
+| Delivery teams onboarded to a platform capability (count per quarter) | — | — |
+| Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in Java capabilities | — | — |
 
 ## Remote Work Considerations

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -134,7 +134,7 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 |---|---|---|
 | Java platform reliability and performance metrics | — | — |
 | Code quality gate pass rate on the main branch (%) | — | — |
-| Implementation quality of Java solutions | — | — |
+| Java implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex Java issues | — | — |
 | Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Java security posture improvement | — | — |

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -133,15 +133,15 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 | Metric | Target | Frequency |
 |---|---|---|
 | Java platform reliability and performance metrics | — | — |
-| Code quality and maintainability scores | — | — |
+| Code quality gate pass rate on the main branch (%) | — | — |
 | Implementation quality of Java solutions | — | — |
 | Time to resolution for complex Java issues | — | — |
-| Knowledge transfer effectiveness to junior developers | — | — |
+| Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Java security posture improvement | — | — |
 | Successful implementation of Java standards | — | — |
-| Reduction in technical debt | — | — |
+| Recorded technical debt items closed (count per quarter) | — | — |
 | Innovation in Java platform capabilities | — | — |
-| Team productivity improvements through frameworks | — | — |
+| Median lead time from commit to production for teams on the framework (hours) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -141,16 +141,16 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of cloud designs with business requirements | — | — |
-| Cloud architecture scalability and reliability | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Cloud designs accepted by the requesting business owner without rework (%) | — | — |
+| Cloud services meeting their published SLO (%) | — | — |
 | Cost efficiency of designed cloud solutions | — | — |
-| Security compliance of cloud architectures | — | — |
+| Cloud designs passing security review at first submission (%) | — | — |
 | Adoption of cloud reference architectures and patterns | — | — |
-| Reduction in architectural risks and technical debt | — | — |
-| Innovation in cloud architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| New cloud patterns adopted into the reference architecture (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -136,10 +136,10 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 | AWS cost management effectiveness | — | — |
 | Security compliance in AWS environments | — | — |
 | Documentation quality for AWS configurations | — | — |
-| Successful implementation of standard patterns | — | — |
+| Deployments using an approved reference pattern (%) | — | — |
 | AWS resource utilization efficiency | — | — |
 | User satisfaction with AWS services | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -130,11 +130,11 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 | Time-to-delivery for cloud services | — | — |
 | Stakeholder satisfaction with AWS platform | ≥85% (proposed) | Quarterly |
 | Security compliance scores for AWS environment | — | — |
-| Successful implementation of cloud governance | — | — |
+| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | — | — |
 | AWS service adoption rates | — | — |
 | Cloud migration project success rates | — | — |
 | AWS platform feature delivery against roadmap | — | — |
-| Cloud platform operational efficiency | — | — |
+| Cloud platform requests fulfilled without manual intervention (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -135,10 +135,10 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
 | Security posture improvement in AWS | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Successful implementation of AWS standards and patterns | — | — |
-| Project delivery timeliness and quality | — | — |
-| Technical innovation contribution | — | — |
+| Projects delivered in the committed period without post-go-live defects (%) | — | — |
+| New patterns or tooling adopted into the standard (count per year) | — | — |
 | Customer satisfaction with AWS services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -131,7 +131,7 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 | Metric | Target | Frequency |
 |---|---|---|
 | AWS environment availability and reliability | ≥99.9% (proposed) | Monthly |
-| Implementation quality of AWS solutions | — | — |
+| AWS implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
 | Security posture improvement in AWS | — | — |

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -135,16 +135,16 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of cloud designs with business requirements | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Cloud designs accepted by the requesting business owner without rework (%) | — | — |
 | Cloud architecture scalability and flexibility | — | — |
 | Cost efficiency of designed cloud solutions | — | — |
-| Security compliance of cloud architectures | — | — |
+| Cloud designs passing security review at first submission (%) | — | — |
 | Adoption of cloud reference architectures and patterns | — | — |
-| Reduction in architectural risks and technical debt | — | — |
-| Innovation in cloud architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| New cloud patterns adopted into the reference architecture (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -132,7 +132,7 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 | Quality of IaC implementation | — | — |
 | Security compliance in Azure deployments | — | — |
 | Documentation quality for Azure configurations | — | — |
-| Successful implementation of standard patterns | — | — |
+| Deployments using an approved reference pattern (%) | — | — |
 | Azure service monitoring coverage | — | — |
 | Knowledge sharing with team members | — | — |
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -129,12 +129,12 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
 | Stakeholder satisfaction with Azure platform | ≥85% (proposed) | Quarterly |
-| Security compliance scores for cloud environment | — | — |
-| Successful implementation of cloud governance | — | — |
+| Cloud resources compliant with the security baseline (%) | — | — |
+| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | — | — |
 | PaaS service adoption rates | — | — |
-| Cloud migration project success | — | — |
+| Migrations completed in the committed window without rollback (%) | — | — |
 | Azure platform feature delivery against roadmap | — | — |
-| Cloud platform operational efficiency | — | — |
+| Cloud platform requests fulfilled without manual intervention (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -136,10 +136,10 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 | Cost optimization achievements (% reduction, efficiency gains) | — | — |
 | Security compliance scores for Azure resources | — | — |
 | Mean time to resolution for complex cloud incidents | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Timely delivery of Azure implementation projects | — | — |
 | Customer satisfaction scores for cloud services | ≥85% (proposed) | Quarterly |
-| Innovation and continuous improvement contributions | — | — |
+| Improvement items proposed and adopted (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -135,16 +135,16 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of cloud designs with business requirements | — | — |
-| Cloud architecture scalability and reliability | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Cloud designs accepted by the requesting business owner without rework (%) | — | — |
+| Cloud services meeting their published SLO (%) | — | — |
 | Cost efficiency of designed cloud solutions | — | — |
-| Security compliance of cloud architectures | — | — |
+| Cloud designs passing security review at first submission (%) | — | — |
 | Adoption of cloud reference architectures and patterns | — | — |
-| Reduction in architectural risks and technical debt | — | — |
-| Innovation in cloud architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| New cloud patterns adopted into the reference architecture (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -136,10 +136,10 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 | GCP cost management effectiveness | — | — |
 | Security compliance in GCP environments | — | — |
 | Documentation quality for GCP configurations | — | — |
-| Successful implementation of standard patterns | — | — |
+| Deployments using an approved reference pattern (%) | — | — |
 | GCP resource utilization efficiency | — | — |
 | User satisfaction with GCP services | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -133,12 +133,12 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
 | Stakeholder satisfaction with GCP platform | ≥85% (proposed) | Quarterly |
-| Security compliance scores for cloud environment | — | — |
-| Successful implementation of cloud governance | — | — |
+| Cloud resources compliant with the security baseline (%) | — | — |
+| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | — | — |
 | GCP service adoption rates | — | — |
-| Cloud migration project success | — | — |
+| Migrations completed in the committed window without rollback (%) | — | — |
 | GCP platform feature delivery against roadmap | — | — |
-| Cloud platform operational efficiency | — | — |
+| Cloud platform requests fulfilled without manual intervention (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -131,7 +131,7 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 | Metric | Target | Frequency |
 |---|---|---|
 | GCP environment availability and reliability | ≥99.9% (proposed) | Monthly |
-| Implementation quality of GCP solutions | — | — |
+| GCP implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
 | Security posture improvement in GCP | — | — |

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -135,10 +135,10 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
 | Security posture improvement in GCP | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Successful implementation of GCP standards and patterns | — | — |
-| Project delivery timeliness and quality | — | — |
-| Technical innovation contribution | — | — |
+| Projects delivered in the committed period without post-go-live defects (%) | — | — |
+| New patterns or tooling adopted into the standard (count per year) | — | — |
 | Customer satisfaction with GCP services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -137,7 +137,7 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 | Data platform cost per TB processed (trend: optimising) | — | — |
 | Data pipeline availability SLA compliance | ≥95% (proposed) | Monthly |
 | Stakeholder satisfaction score with data platform | ≥85% (proposed) | Quarterly |
-| Roadmap milestone delivery against plan | — | — |
+| Roadmap milestones delivered in the committed quarter (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -130,16 +130,16 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of solutions with business requirements | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Solution designs accepted by the requesting business owner without rework (%) | — | — |
 | Storage architecture scalability and flexibility | — | — |
 | Cost efficiency of designed solutions | — | — |
 | Storage performance and availability metrics | ≥99.9% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
-| Reduction in architectural risks and complexity | — | — |
+| Recorded architectural risks closed (count per quarter) | — | — |
 | Innovation in storage approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -130,11 +130,11 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 | Storage provisioning accuracy and timeliness | — | — |
 | Resolution time for storage incidents | — | — |
 | File system performance optimization | — | — |
-| Documentation quality and completeness | — | — |
-| Successful execution of maintenance activities | — | — |
-| Data protection implementation quality | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Planned maintenance completed in window without unplanned impact (%) | — | — |
+| Protected workloads passing their most recent recovery test (%) | — | — |
 | User satisfaction with file services | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Capacity utilization efficiency | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -154,11 +154,11 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 | Storage cost per TB efficiency metrics | — | — |
 | Stakeholder satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Time to provision new storage resources | — | — |
-| Storage service levels achievement | — | — |
-| Implementation quality of storage solutions | — | — |
+| Storage services meeting their published SLO (%) | — | — |
+| Storage implementations accepted without post-deployment rework (%) | — | — |
 | Cost optimization achievements | — | — |
-| Backlog health and delivery metrics | — | — |
-| Innovation in storage services delivery | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| New storage capabilities released to consuming teams (count per year) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -136,13 +136,13 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 | Metric | Target | Frequency |
 |---|---|---|
 | Storage availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Implementation quality of storage solutions | — | — |
+| Storage implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex storage issues | — | — |
 | Qumulo performance optimization results | — | — |
-| Knowledge transfer effectiveness to engineers | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Storage automation level and efficiency | — | — |
 | Success rate of data migrations | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Innovation in Qumulo implementation approaches | — | — |
 | Customer satisfaction with file storage services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -136,12 +136,12 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 | Storage provisioning accuracy and timeliness | — | — |
 | Resolution time for storage incidents | — | — |
 | Storage utilization efficiency | — | — |
-| Documentation quality and completeness | — | — |
-| Successful execution of maintenance activities | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Planned maintenance completed in window without unplanned impact (%) | — | — |
 | Storage performance consistency | — | — |
-| Data protection implementation quality | — | — |
+| Protected workloads passing their most recent recovery test (%) | — | — |
 | User satisfaction with storage services | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -136,11 +136,11 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 | Storage cost efficiency metrics | — | — |
 | Stakeholder satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Time to provision new storage resources | — | — |
-| Storage service levels achievement | — | — |
-| Implementation quality of storage solutions | — | — |
+| Storage services meeting their published SLO (%) | — | — |
+| Storage implementations accepted without post-deployment rework (%) | — | — |
 | Cost optimization achievements | — | — |
-| Backlog health and delivery metrics | — | — |
-| Innovation in storage services delivery | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| New storage capabilities released to consuming teams (count per year) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -133,7 +133,7 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 |---|---|---|
 | Storage environment availability and reliability | ≥99.9% (proposed) | Monthly |
 | Storage performance optimization results | — | — |
-| Implementation quality of storage solutions | — | — |
+| Storage implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex storage issues | — | — |
 | Knowledge transfer effectiveness to storage engineers | — | — |
 | Storage automation coverage and efficiency | — | — |

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -138,7 +138,7 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 | Automation level of reliability processes | — | — |
 | Accuracy of reliability metrics | — | — |
 | SLO/SLA achievement for backup services | ≥95% (proposed) | Monthly |
-| Knowledge sharing effectiveness | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -130,16 +130,16 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of solutions with business requirements | — | — |
-| Backup architecture scalability and flexibility | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Solution designs accepted by the requesting business owner without rework (%) | — | — |
+| Protected workloads within the supported backup architecture (%) | — | — |
 | Cost efficiency of designed solutions | — | — |
-| Recovery capabilities meeting or exceeding SLAs | — | — |
+| Recovery tests meeting their stated RTO (%) | — | — |
 | Adoption of reference architectures and standards | — | — |
-| Reduction in architectural risks and complexity | — | — |
+| Recorded architectural risks closed (count per quarter) | — | — |
 | Innovation in data protection approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -136,7 +136,7 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 | Storage efficiency metrics (compression, deduplication) | — | — |
 | Agent deployment success rate | — | — |
 | Problem resolution time for backup failures | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Backup storage utilization management | — | — |
 | Successful completion of scheduled maintenance | — | — |
 | User satisfaction with restore services | ≥85% (proposed) | Quarterly |

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -149,13 +149,13 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 |---|---|---|
 | Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievements | — | — |
-| Recovery point objective (RPO) achievements | — | — |
+| Protected workloads meeting their stated RPO (%) | — | — |
 | Stakeholder satisfaction with data protection services | ≥85% (proposed) | Quarterly |
 | Backup compliance and audit readiness | — | — |
 | Data protection cost efficiency | — | — |
 | Storage optimization metrics (deduplication ratios) | — | — |
 | Successful delivery of backup roadmap items | — | — |
-| Implementation of backup automation | — | — |
+| Backup jobs running without manual intervention (%) | — | — |
 | Backup platform availability and reliability | ≥99.9% (proposed) | Monthly |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -131,12 +131,12 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 |---|---|---|
 | Backup success rate and reliability | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievement | — | — |
-| Recovery point objective (RPO) achievement | — | — |
+| Protected workloads meeting their stated RPO (%) | — | — |
 | Backup window optimization | — | — |
-| Implementation quality of data protection solutions | — | — |
+| Data protection implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex backup incidents | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
-| Automation level of backup operations | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Backup operations performed without manual intervention (%) | — | — |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Storage efficiency metrics (deduplication, compression) | — | — |
 

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -129,16 +129,16 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of solutions with business requirements | — | — |
-| Backup architecture scalability and flexibility | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Solution designs accepted by the requesting business owner without rework (%) | — | — |
+| Protected workloads within the supported backup architecture (%) | — | — |
 | Cost efficiency of designed solutions | — | — |
-| Recovery capabilities meeting or exceeding SLAs | — | — |
+| Recovery tests meeting their stated RTO (%) | — | — |
 | Adoption of reference architectures and standards | — | — |
 | Reduction in data protection architectural risks | — | — |
 | Innovation in backup approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -128,7 +128,7 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 | Backup completion within scheduled windows | — | — |
 | Recovery time performance | — | — |
 | Accurate implementation of backup policies | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Response time to backup failures | — | — |
 | Recovery testing success rates | ≥99% (proposed) | Monthly |
 | Adherence to data retention requirements | — | — |

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -131,7 +131,7 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 | Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Response time to backup failures | — | — |
 | Recovery testing success rates | ≥99% (proposed) | Monthly |
-| Adherence to data retention requirements | — | — |
+| Work conforming to data retention requirements (%) | — | — |
 | User satisfaction with backup/recovery services | ≥85% (proposed) | Quarterly |
 | Efficiency of storage utilization for backups | — | — |
 

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -141,14 +141,14 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 |---|---|---|
 | Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievements | — | — |
-| Recovery point objective (RPO) achievements | — | — |
+| Protected workloads meeting their stated RPO (%) | — | — |
 | Stakeholder satisfaction with recovery capabilities | ≥85% (proposed) | Quarterly |
 | Data protection compliance scores | — | — |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Backup storage efficiency metrics | — | — |
 | Incident reduction in backup operations | — | — |
-| Implementation of backup automation | — | — |
-| Cross-team collaboration effectiveness | — | — |
+| Backup jobs running without manual intervention (%) | — | — |
+| Cross-team deliverables completed in the committed period (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -127,12 +127,12 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 |---|---|---|
 | Backup success rate and reliability metrics | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievement | — | — |
-| Recovery point objective (RPO) achievement | — | — |
+| Protected workloads meeting their stated RPO (%) | — | — |
 | Backup storage efficiency (deduplication ratios) | — | — |
-| Implementation quality of data protection solutions | — | — |
+| Data protection implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex backup incidents | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
-| Automation level of backup operations | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Backup operations performed without manual intervention (%) | — | — |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Business continuity improvement metrics | — | — |
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -139,8 +139,8 @@ The Database Architect designs comprehensive data management strategies and arch
 | Reduction in data-related architectural risks | — | — |
 | Database modernization progress and benefits | — | — |
 | Innovation in data management approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -132,7 +132,7 @@ The Database Architect designs comprehensive data management strategies and arch
 | Metric | Target | Frequency |
 |---|---|---|
 | Database architecture design quality and effectiveness | — | — |
-| Alignment of database designs with business requirements | — | — |
+| Database designs accepted by the requesting business owner without rework (%) | — | — |
 | Database performance, scalability, and reliability | — | — |
 | Data security and compliance framework effectiveness | — | — |
 | Adoption of database reference architectures and patterns | — | — |

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -143,11 +143,11 @@ The Database Engineer implements and maintains database systems across the organ
 | Query performance and optimization | — | — |
 | Time to resolve database incidents | — | — |
 | Database patch compliance percentage | ≥95% (proposed) | Monthly |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | User satisfaction with database services | ≥85% (proposed) | Quarterly |
 | Implementation quality of standard configurations | — | — |
 | Security compliance with database policies | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -148,7 +148,7 @@ The Database Product Owner manages the portfolio of database platforms and data 
 | Metric | Target | Frequency |
 |---|---|---|
 | Database platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Query performance optimization results | — | — |
+| Median query execution time for tuned workloads (ms) | — | — |
 | Time to provision new database environments | — | — |
 | Database incident reduction trends | — | — |
 | Cost efficiency of database resources | — | — |

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -134,13 +134,13 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 | Database uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to detect (MTTD) database issues | ≤24 hours (proposed) | Monthly |
 | Mean time to resolve (MTTR) database failures | ≤4 hours (proposed) | Monthly |
-| Query performance optimization results | — | — |
+| Median query execution time for tuned workloads (ms) | — | — |
 | Successful automated recovery percentage | — | — |
 | Reduction in database incidents over time | — | — |
 | Database scaling effectiveness | — | — |
 | Automated operations percentage | — | — |
 | SLO/SLA achievement for database services | ≥95% (proposed) | Monthly |
-| Knowledge sharing effectiveness | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -136,7 +136,7 @@ The Database Senior Engineer leads the implementation and optimization of comple
 | Metric | Target | Frequency |
 |---|---|---|
 | Database availability and performance metrics | ≥99.9% (proposed) | Monthly |
-| Query performance optimization results | — | — |
+| Median query execution time for tuned workloads (ms) | — | — |
 | Implementation quality of database solutions | — | — |
 | Mean time to resolution for critical database issues | — | — |
 | Knowledge transfer effectiveness to database engineers | — | — |

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -137,7 +137,7 @@ The Database Senior Engineer leads the implementation and optimization of comple
 |---|---|---|
 | Database availability and performance metrics | ≥99.9% (proposed) | Monthly |
 | Median query execution time for tuned workloads (ms) | — | — |
-| Implementation quality of database solutions | — | — |
+| Database implementations accepted without post-deployment rework (%) | — | — |
 | Mean time to resolution for critical database issues | — | — |
 | Knowledge transfer effectiveness to database engineers | — | — |
 | Automation coverage for database operations | — | — |

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -135,7 +135,7 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of DevOps designs with business requirements | — | — |
+| DevOps designs accepted by the requesting business owner without rework (%) | — | — |
 | Delivery pipeline efficiency and reliability | — | — |
 | Security integration in DevOps workflows | — | — |
 | Adoption of DevOps reference architectures and patterns | — | — |

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -134,15 +134,15 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of DevOps designs with business requirements | — | — |
 | Delivery pipeline efficiency and reliability | — | — |
 | Security integration in DevOps workflows | — | — |
 | Adoption of DevOps reference architectures and patterns | — | — |
 | Reduction in delivery-related incidents | — | — |
 | Number of novel pipeline patterns adopted and operationalized per quarter; percentage of teams using self-service golden path tooling | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 | Improvement in delivery metrics (lead time, MTTR, etc.) | ≤4 hours (proposed) | Monthly |
 
 ## Remote Work Considerations

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -112,9 +112,9 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 | Metric | Target | Frequency |
 |---|---|---|
 | DevOps platform adoption rates across teams | — | — |
-| Successful delivery of roadmap initiatives | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | — | — |
 | Stakeholder satisfaction with DevOps services | ≥85% (proposed) | Quarterly |
-| Quality of backlog management and prioritization | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Measurable improvement in software delivery metrics | — | — |
 | Effectiveness of DevOps training and enablement programs | — | — |
 

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -119,7 +119,7 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 | Improvements in deployment frequency and reliability | Weekly or better (proposed) | Monthly |
 | Quality of pipeline templates and reusable components | — | — |
 | Effectiveness of self-service DevOps capabilities | — | — |
-| Quality of technical leadership and mentorship | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
 | Contribution to DevOps standards and best practices | — | — |
 | Innovation in delivery automation approaches | — | — |
 

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -134,7 +134,7 @@ The Windows Active Directory Architect designs AD structure, security models, an
 | Successful completion of AD migrations | — | — |
 | Business satisfaction with identity infrastructure | ≥85% (proposed) | Quarterly |
 | Reduction in security incidents related to directory services | — | — |
-| Knowledge transfer effectiveness to engineering teams | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -135,7 +135,7 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 | Group Policy implementation accuracy | — | — |
 | Directory service backup success rate | ≥99% (proposed) | Monthly |
 | Time to resolve Active Directory incidents | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Active Directory security posture | — | — |
 | Successful implementation of directory standards | — | — |
 | User satisfaction with identity services | ≥85% (proposed) | Quarterly |

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -130,7 +130,7 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 | Security compliance scores for directory services | — | — |
 | Implementation quality of AD projects | — | — |
 | Mean time to resolution for complex AD incidents | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Automation level of AD management tasks | — | — |
 | Success rate of AD migrations and upgrades | — | — |
 | Reduction in security vulnerabilities through hardening | — | — |

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -142,10 +142,10 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 | Operating system deployment reliability | — | — |
 | Client health metrics | — | — |
 | Configuration baseline compliance | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Issue resolution time for SCCM-related problems | — | — |
 | Endpoint inventory accuracy | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -131,16 +131,16 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of designs with business requirements | — | — |
 | Onboarding architecture scalability and flexibility | — | — |
 | Standardization level across infrastructure domains | — | — |
 | Time-to-provision improvements through architecture | — | — |
-| Reduction in architectural complexity | — | — |
+| Recorded architectural risks closed (count per quarter) | — | — |
 | Adoption of reference architectures and patterns | — | — |
 | Innovation in infrastructure provisioning approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -132,7 +132,7 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of designs with business requirements | — | — |
+| Designs accepted by the requesting business owner without rework (%) | — | — |
 | Onboarding architecture scalability and flexibility | — | — |
 | Standardization level across infrastructure domains | — | — |
 | Time-to-provision improvements through architecture | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -134,7 +134,7 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 |---|---|---|
 | Infrastructure provisioning time metrics | — | — |
 | Provisioning request success rate | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | User satisfaction with provisioning services | ≥85% (proposed) | Quarterly |
 | Automation coverage for standard deployments | — | — |
 | Time to resolve provisioning incidents | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -140,7 +140,7 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 | Time to resolve provisioning incidents | — | — |
 | Quality of service catalog items and descriptions | — | — |
 | Self-service adoption metrics | — | — |
-| Adherence to infrastructure standards | — | — |
+| Work conforming to infrastructure standards (%) | — | — |
 | Process improvement contributions | — | — |
 
 ## Remote Work Considerations

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -143,7 +143,7 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 | Request accuracy and first-time completions | — | — |
 | Onboarding documentation quality | — | — |
 | Infrastructure standards compliance | — | — |
-| Successful delivery of roadmap initiatives | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -137,7 +137,7 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 | Provisioning success rate and reliability | — | — |
 | Implementation quality of onboarding solutions | — | — |
 | Resolution time for onboarding incidents | — | — |
-| Knowledge transfer effectiveness to engineers | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Standardization level of infrastructure deployments | — | — |
 | Innovation in onboarding approaches | — | — |
 | Cross-platform integration effectiveness | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -135,7 +135,7 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 | Infrastructure provisioning time efficiency | — | — |
 | Automation coverage across infrastructure domains | — | — |
 | Provisioning success rate and reliability | — | — |
-| Implementation quality of onboarding solutions | — | — |
+| Onboarding implementations accepted without post-deployment rework (%) | — | — |
 | Resolution time for onboarding incidents | — | — |
 | Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Standardization level of infrastructure deployments | — | — |

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -132,7 +132,7 @@ The Application Configuration Management Architect designs comprehensive strateg
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of configuration designs with business requirements | — | — |
+| Configuration designs accepted by the requesting business owner without rework (%) | — | — |
 | Configuration management reliability and scalability | — | — |
 | Security posture of configuration systems | — | — |
 | Adoption of configuration reference architectures | — | — |

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -131,16 +131,16 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of configuration designs with business requirements | — | — |
 | Configuration management reliability and scalability | — | — |
 | Security posture of configuration systems | — | — |
 | Adoption of configuration reference architectures | — | — |
 | Reduction in configuration-related incidents | — | — |
 | Configuration automation maturity improvement | — | — |
-| Innovation in configuration management approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| New configuration patterns adopted into the standard (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -136,12 +136,12 @@ The Application Configuration Management Engineer implements and maintains confi
 | Configuration deployment success rate | — | — |
 | Configuration-related incident reduction | — | — |
 | Time to resolve configuration issues | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Configuration compliance percentage | — | — |
 | Configuration management automation level | — | — |
 | Environment configuration consistency | — | — |
 | User satisfaction with configuration services | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -137,9 +137,9 @@ The Application Configuration Management Senior Engineer leads the implementatio
 | Configuration deployment success rate | — | — |
 | Implementation quality of configuration solutions | — | — |
 | Resolution time for configuration incidents | — | — |
-| Knowledge transfer effectiveness to engineers | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Standardization level of configuration practices | — | — |
-| Innovation in configuration management approaches | — | — |
+| New configuration patterns adopted into the standard (count per year) | — | — |
 | Security compliance of configuration processes | — | — |
 | Stakeholder satisfaction with configuration services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -135,7 +135,7 @@ The Application Configuration Management Senior Engineer leads the implementatio
 | Configuration management reliability metrics | — | — |
 | Automation coverage for configuration processes | — | — |
 | Configuration deployment success rate | — | — |
-| Implementation quality of configuration solutions | — | — |
+| Configuration implementations accepted without post-deployment rework (%) | — | — |
 | Resolution time for configuration incidents | — | — |
 | Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Standardization level of configuration practices | — | — |

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -132,12 +132,12 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backlog velocity and sprint delivery predictability | — | — |
+| Committed sprint items delivered in the sprint (%) | — | — |
 | ITSM platform user satisfaction score (CSAT) | ≥85% (proposed) | Quarterly |
 | CMDB CI accuracy rate (target: >95% for in-scope CI classes) | >95% | — |
 | Service request self-service adoption rate (trend: increasing) | — | — |
 | Incident, Change, and Problem SLA compliance rates (platform impact contribution) | ≥95% (proposed) | Monthly |
-| Roadmap milestone delivery against plan | — | — |
+| Roadmap milestones delivered in the committed quarter (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -174,7 +174,7 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 | Successful implementation of Kubernetes platform strategies | — | — |
 | Adoption rate of containerized applications | — | — |
 | Platform reliability and availability metrics | ≥99.9% (proposed) | Monthly |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Effective knowledge transfer to engineering teams | — | — |
 | Alignment of Kubernetes platforms with business requirements | — | — |
 | Number of CNCF technologies formally evaluated and adopted into the platform per year; operator maturity level (basic / managed / full lifecycle) | — | — |

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -176,7 +176,7 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 | Platform reliability and availability metrics | ≥99.9% (proposed) | Monthly |
 | Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Effective knowledge transfer to engineering teams | — | — |
-| Alignment of Kubernetes platforms with business requirements | — | — |
+| Kubernetes platforms accepted by the requesting business owner without rework (%) | — | — |
 | Number of CNCF technologies formally evaluated and adopted into the platform per year; operator maturity level (basic / managed / full lifecycle) | — | — |
 
 ## Recommended Certifications & Learning Paths

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -136,9 +136,9 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 | Container deployment success rate | — | — |
 | Time to resolve Kubernetes incidents | — | — |
 | Security compliance in Kubernetes environments | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Implementation quality of standard patterns | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Kubernetes automation implementation | — | — |
 | User satisfaction with container platform | ≥85% (proposed) | Quarterly |
 | Cluster resource utilization efficiency | — | — |

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -110,9 +110,9 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 | Metric | Target | Frequency |
 |---|---|---|
 | Platform adoption rates across application teams | — | — |
-| Successful delivery of roadmap initiatives | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | — | — |
 | Stakeholder satisfaction with Kubernetes services | ≥85% (proposed) | Quarterly |
-| Quality of backlog management and prioritization | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Measurable improvement in application deployment velocity | — | — |
 | Effective communication of platform capabilities and value | — | — |
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -117,7 +117,7 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 | Deployment automation effectiveness | — | — |
 | Knowledge transfer metrics for mentored engineers | — | — |
 | Kubernetes platform security posture scores | — | — |
-| Resource utilization efficiency metrics | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
 | Contribution to platform standards adoption | — | — |
 | Implementation of innovative container solutions | — | — |
 | Reduced operational overhead through automation | — | — |

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -140,7 +140,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | — | — |
 | Chapter satisfaction score (internal survey results for the Data & AI chapter) | ≥85% (proposed) | Quarterly |
 | Data platform adoption and coverage across the organisation's data domains | — | — |
 | Data quality scores for critical business data domains | — | — |

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -139,7 +139,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | — | — |
 | Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter) | ≥85% (proposed) | Quarterly |
 | DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | ≤15% (proposed) | Monthly |
 | IDP adoption rate across development teams | — | — |

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -141,7 +141,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | — | — |
 | Chapter satisfaction score (internal survey results for the End User & Workplace chapter) | ≥85% (proposed) | Quarterly |
 | Device management coverage and compliance rate across all managed endpoints | — | — |
 | Microsoft 365 governance compliance rate — adherence to tenant standards and Teams governance policies | — | — |

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -141,7 +141,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | — | — |
 | Chapter satisfaction score (internal survey results for the Security & Identity chapter) | ≥85% (proposed) | Quarterly |
 | Security architecture standards adoption rate across all technology domains | — | — |
 | Zero trust roadmap milestone completion rate against agreed programme timeline | — | — |

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -140,7 +140,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| Hiring velocity and quality for chapter architect and senior engineer roles (90-day retention of new hires) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | — | — |
 | Chapter satisfaction score (internal survey results for the Service & Governance chapter) | ≥85% (proposed) | Quarterly |
 | ITSM process maturity level across all ITIL 4 processes (measured against ITIL 4 maturity model) | — | — |
 | CMDB accuracy and completeness rate for critical configuration item classes | — | — |

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -152,7 +152,7 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 | Reproducibility of ML workflows | — | — |
 | Model monitoring coverage | — | — |
 | Feature engineering automation level | — | — |
-| Knowledge sharing and documentation quality | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Edge model deployment automation coverage: ≥80% of edge model updates delivered via automated pipelines | ≥80% | — |
 | Edge model drift detection rate: ≥90% of edge-deployed models under active performance monitoring | ≥90% | — |
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -115,8 +115,8 @@ The Observability Product Owner manages the observability platform portfolio, de
 |---|---|---|
 | Platform adoption rates across teams | — | — |
 | Stakeholder satisfaction with observability services | ≥85% (proposed) | Quarterly |
-| Successful delivery of roadmap initiatives | — | — |
-| Quality of backlog management and prioritization | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Effectiveness of observability in improving system reliability | — | — |
 | Clear demonstration of platform value to the business | — | — |
 

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -117,7 +117,7 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 | Successful implementation of complex observability solutions | — | — |
 | Effectiveness of advanced alerting and detection mechanisms | — | — |
 | Platform scalability and performance improvements | — | — |
-| Quality of technical leadership and mentorship | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
 | Contribution to observability standards and patterns | — | — |
 | Implementation of innovative monitoring approaches | — | — |
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -140,16 +140,16 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of platform design with developer needs | — | — |
 | Platform architecture scalability and flexibility | — | — |
 | Developer experience improvement through architecture | — | — |
 | Platform reliability and performance through design | — | — |
 | Adoption of reference architectures and golden paths | — | — |
-| Reduction in architectural complexity | — | — |
+| Recorded architectural risks closed (count per quarter) | — | — |
 | Innovation in platform approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 | Edge workload onboarding time: time from request to production-ready edge deployment | — | — |
 | Edge platform availability: uptime SLA for IDP golden paths and self-service tooling at edge locations | ≥95% (proposed) | Monthly |
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -137,14 +137,14 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 |---|---|---|
 | Platform component reliability and uptime | ≥99.9% (proposed) | Monthly |
 | Implementation quality of platform features | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Developer onboarding efficiency | — | — |
 | Platform issue resolution time | — | — |
 | Self-service capability effectiveness | — | — |
 | Template and golden path usage rates | — | — |
 | Developer support responsiveness | — | — |
 | Platform deployment automation success rate | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -139,10 +139,10 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 | Time-to-production for new applications | — | — |
 | Developer self-service capability utilization | — | — |
 | Reduction in developer toil through automation | — | — |
-| Platform reliability and performance metrics | — | — |
-| Successful delivery of platform roadmap items | — | — |
-| Business value delivery through platform capabilities | — | — |
-| Return on investment for platform initiatives | — | — |
+| Platform services meeting their published SLO (%) | — | — |
+| Platform roadmap items delivered in the committed quarter (%) | — | — |
+| Delivery teams onboarded to a platform capability (count per quarter) | — | — |
+| Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in developer experience | — | — |
 
 ## Remote Work Considerations

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -138,7 +138,7 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 |---|---|---|
 | Platform stability and reliability metrics | — | — |
 | Developer adoption of platform services | — | — |
-| Implementation quality of platform solutions | — | — |
+| Platform implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for platform incidents | — | — |
 | Developer experience satisfaction scores | ≥85% (proposed) | Quarterly |
 | Reduction in toil through platform automation | — | — |

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -144,7 +144,7 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 | Accuracy of capacity planning | — | — |
 | Effectiveness of observability solutions | — | — |
 | Quality of postmortem analysis and improvements | — | — |
-| Knowledge sharing and documentation quality | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -137,7 +137,7 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 | Microsoft 365 Copilot adoption (active users / licensed) | — | — |
 | Licensing utilisation efficiency (active use / licensed seats) | — | — |
 | Employee satisfaction with digital workplace tools (annual survey) | ≥85% (proposed) | Annual |
-| Backlog velocity and sprint delivery predictability | — | — |
+| Committed sprint items delivered in the sprint (%) | — | — |
 | Roadmap milestones delivered against plan | — | — |
 
 ## Remote Work Considerations

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -135,7 +135,7 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of network designs with business requirements | — | — |
 | Network architecture scalability and flexibility | — | — |
 | Security posture improvement through network design | — | — |
@@ -143,8 +143,8 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 | Reduction in network-related incidents | — | — |
 | Network simplification and standardization | — | — |
 | Innovation in network architectural approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 | AIOps prediction accuracy for capacity forecasting and incident detection (target: >85% precision) | >85% | — |
 | Edge network availability: ≥99.9% connectivity SLA for business-critical edge PoPs and industrial edge sites | ≥99.9% | — |
 | Edge site deployment time: network provisioning lead time for new edge PoPs reduced via SD-WAN ZTP automation | — | — |

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -136,7 +136,7 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of network designs with business requirements | — | — |
+| Network designs accepted by the requesting business owner without rework (%) | — | — |
 | Network architecture scalability and flexibility | — | — |
 | Security posture improvement through network design | — | — |
 | Adoption of network reference architectures | — | — |

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -138,7 +138,7 @@ The Network Automation Engineer specializes in developing and implementing autom
 | Error reduction through automation | — | — |
 | Network change success rate improvement | — | — |
 | Code quality and reusability metrics | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Testing coverage for network automation | — | — |
 | Pipeline reliability and performance | — | — |
 | Innovation in automation approaches | — | — |

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -136,11 +136,11 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 | Network uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for network incidents | — | — |
 | Change implementation success rate | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Network security policy compliance | — | — |
 | Network monitoring coverage | — | — |
 | Response time to service requests | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Successful implementation of standard designs | — | — |
 | Customer satisfaction with network services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -135,11 +135,11 @@ The Network Product Owner manages the development and lifecycle of the organizat
 | Network service availability and reliability | ≥99.9% (proposed) | Monthly |
 | Time-to-delivery for network services | — | — |
 | Stakeholder satisfaction with network capabilities | ≥85% (proposed) | Quarterly |
-| Network security posture improvement | — | — |
+| Network devices compliant with the security baseline (%) | — | — |
 | Cost optimization achievements | — | — |
 | Successful delivery of network roadmap items | — | — |
 | Network service request fulfillment time | — | — |
-| Backlog health and prioritization effectiveness | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Network capacity management accuracy | — | — |
 | Innovation in network service delivery | — | — |
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -136,7 +136,7 @@ The Network Senior Engineer leads the implementation and optimization of complex
 | Network availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for complex network issues | — | — |
 | Implementation quality of network solutions | — | — |
-| Network security posture improvement | — | — |
+| Network devices compliant with the security baseline (%) | — | — |
 | Knowledge transfer effectiveness to network engineers | — | — |
 | Network automation coverage and efficiency | — | — |
 | Success rate of network migrations and changes | — | — |

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -135,7 +135,7 @@ The Network Senior Engineer leads the implementation and optimization of complex
 |---|---|---|
 | Network availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for complex network issues | — | — |
-| Implementation quality of network solutions | — | — |
+| Network implementations accepted without post-deployment rework (%) | — | — |
 | Network devices compliant with the security baseline (%) | — | — |
 | Knowledge transfer effectiveness to network engineers | — | — |
 | Network automation coverage and efficiency | — | — |

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -134,7 +134,7 @@ The Security Engineer implements and maintains security controls and technologie
 | Security control implementation quality | — | — |
 | Vulnerability remediation effectiveness | ≤30 days (critical) (proposed) | Monthly |
 | Security incident response time | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Security monitoring coverage | — | — |
 | Compliance with security standards | — | — |
 | Resolution time for security issues | — | — |

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -152,7 +152,7 @@ The Security Product Owner manages the development and lifecycle of the organiza
 | Compliance achievement percentage | — | — |
 | Successful delivery of security roadmap items | — | — |
 | Security awareness and adoption metrics | — | — |
-| Backlog health and prioritization effectiveness | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Return on security investment metrics | — | — |
 | Security maturity improvement | — | — |
 

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -137,7 +137,7 @@ The Security Senior Engineer leads the implementation and optimization of comple
 | Time to resolve complex security issues | — | — |
 | Security automation coverage and effectiveness | — | — |
 | Knowledge transfer effectiveness to security engineers | — | — |
-| Security posture improvement metrics | — | — |
+| Assets compliant with the security baseline (%) | — | — |
 | Reduction in security vulnerabilities | — | — |
 | Innovation in security approaches | — | — |
 | Customer satisfaction with security services | ≥85% (proposed) | Quarterly |

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -141,12 +141,12 @@ The Security Cross-Platform Engineer implements and maintains security controls 
 | Reduction in security vulnerabilities across platforms | — | — |
 | Time to resolve security configuration issues | — | — |
 | Coverage of security monitoring across environments | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Compliance with security standards in implementations | — | — |
 | Time to implement critical security patches | — | — |
 | Success rate of security control testing | — | — |
 | Collaboration effectiveness with domain teams | — | — |
-| Security posture improvement metrics | — | — |
+| Assets compliant with the security baseline (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -137,16 +137,16 @@ The Access Management Architect designs and oversees the organization's access m
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Reduction in access-related security incidents | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Access-related security incidents (count per quarter) | — | — |
 | Improvement in access governance metrics | — | — |
 | Timely delivery of access architecture artifacts | — | — |
 | Stakeholder satisfaction with access solutions | ≥85% (proposed) | Quarterly |
-| Innovation in access management approaches | — | — |
+| New access management patterns adopted into the standard (count per year) | — | — |
 | Alignment with security and compliance requirements | — | — |
 | Successful adoption of access architecture patterns | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -137,9 +137,9 @@ The Access Management Engineer implements and maintains access management system
 | Access certification campaign completion rates | — | — |
 | Time to revoke inappropriate access | — | — |
 | Access-related incident resolution time | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | User satisfaction with access processes | ≥85% (proposed) | Quarterly |
-| Implementation quality of access solutions | — | — |
+| Access implementations accepted without post-deployment rework (%) | — | — |
 | Self-service adoption for access requests | — | — |
 | Reduction in access-related security issues | — | — |
 

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -165,7 +165,7 @@ The Access Management Product Owner manages the development and lifecycle of the
 | Access review campaign completion rates | — | — |
 | Stakeholder satisfaction with access processes | ≥85% (proposed) | Quarterly |
 | Privileged access security metrics | — | — |
-| Reduction in access-related security incidents | — | — |
+| Access-related security incidents (count per quarter) | — | — |
 | Successful delivery of access roadmap items | — | — |
 | Self-service access request adoption | — | — |
 | Access governance compliance scores | — | — |

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -135,14 +135,14 @@ The Access Management Senior Engineer leads the implementation and optimization 
 |---|---|---|
 | Access management system availability | ≥99.9% (proposed) | Monthly |
 | Privileged access security effectiveness | — | — |
-| Implementation quality of access solutions | — | — |
+| Access implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolve complex access incidents | — | — |
 | Access certification campaign completion rates | — | — |
 | Automation level of access processes | — | — |
 | Knowledge transfer to junior engineers | — | — |
 | Reduction in inappropriate access events | — | — |
 | Compliance with access governance frameworks | — | — |
-| Innovation in access management approaches | — | — |
+| New access management patterns adopted into the standard (count per year) | — | — |
 
 ## Key Performance Indicators
 

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -138,10 +138,10 @@ The Identity Management Architect designs and oversees the organization's identi
 | User experience improvements through architecture | — | — |
 | Security posture improvement via identity controls | — | — |
 | Adoption of identity standards and patterns | — | — |
-| Reduction in identity-related security incidents | — | — |
+| Identity-related security incidents (count per quarter) | — | — |
 | Innovation in identity management approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -136,8 +136,8 @@ The Identity Management Engineer implements and maintains identity management sy
 | User provisioning and deprovisioning accuracy | — | — |
 | Authentication system performance | — | — |
 | Identity-related incident resolution time | — | — |
-| Implementation quality of identity solutions | — | — |
-| Documentation quality and completeness | — | — |
+| Identity implementations accepted without post-deployment rework (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Federation service reliability | — | — |
 | Password reset success rate | — | — |
 | Directory service synchronization accuracy | — | — |

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -135,12 +135,12 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 |---|---|---|
 | Identity system availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Authentication service response times | — | — |
-| Implementation quality of identity solutions | — | — |
+| Identity implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex identity incidents | — | — |
 | Automation level achieved for identity operations | — | — |
 | Security posture improvement in identity systems | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
-| Reduction in identity-related security incidents | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Identity-related security incidents (count per quarter) | — | — |
 | Successful implementation of identity standards | — | — |
 | User satisfaction with authentication experience | ≥85% (proposed) | Quarterly |
 

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -131,16 +131,16 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of hardware designs with business requirements | — | — |
-| Server infrastructure performance and reliability | — | — |
-| Power efficiency and sustainability metrics | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Hardware designs accepted by the requesting business owner without rework (%) | — | — |
+| Server estate meeting its published SLO (%) | — | — |
+| Data centre power usage effectiveness (PUE) | — | — |
 | Cost effectiveness of hardware architectures | — | — |
 | Adoption of reference architectures and standards | — | — |
-| Hardware lifecycle optimization metrics | — | — |
-| Innovation in server infrastructure approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Server estate within its supported lifecycle window (%) | — | — |
+| New server platform patterns adopted into the standard build (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -141,13 +141,13 @@ The Server Hardware Engineer implements and maintains the physical server infras
 | Server deployment time efficiency | — | — |
 | Hardware-related incident resolution time | — | — |
 | Hardware configuration accuracy | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Firmware compliance percentage | — | — |
 | Hardware inventory accuracy | — | — |
-| Successful hardware maintenance completions | — | — |
-| Standard build implementation quality | — | — |
+| Planned hardware maintenance completed in window (%) | — | — |
+| Servers deployed from the approved standard build (%) | — | — |
 | User satisfaction with hardware support | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -144,10 +144,10 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 | Time to resolution for critical hardware issues | — | — |
 | Hardware deployment automation effectiveness | — | — |
 | Power and cooling efficiency improvements | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Hardware standardization implementation success | — | — |
 | Success rate of hardware upgrades and refreshes | — | — |
-| Innovation in server infrastructure approaches | — | — |
+| New server platform patterns adopted into the standard build (count per year) | — | — |
 | Stakeholder satisfaction with infrastructure services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -140,7 +140,7 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 | Metric | Target | Frequency |
 |---|---|---|
 | Server hardware availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Implementation quality of hardware solutions | — | — |
+| Hardware implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for critical hardware issues | — | — |
 | Hardware deployment automation effectiveness | — | — |
 | Power and cooling efficiency improvements | — | — |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -137,16 +137,16 @@ The HPE Server Hardware Architect designs and oversees the organization's server
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
-| Alignment of hardware designs with business requirements | — | — |
-| Server infrastructure performance and reliability | — | — |
-| Power efficiency and sustainability metrics | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
+| Hardware designs accepted by the requesting business owner without rework (%) | — | — |
+| Server estate meeting its published SLO (%) | — | — |
+| Data centre power usage effectiveness (PUE) | — | — |
 | Cost effectiveness of hardware architectures | — | — |
 | Adoption of reference architectures and standards | — | — |
-| Hardware lifecycle optimization metrics | — | — |
-| Innovation in server infrastructure approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Server estate within its supported lifecycle window (%) | — | — |
+| New server platform patterns adopted into the standard build (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -165,13 +165,13 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 | Server deployment time efficiency | — | — |
 | Hardware-related incident resolution time | — | — |
 | Hardware configuration accuracy | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Firmware compliance percentage | — | — |
 | Hardware inventory accuracy | — | — |
-| Successful hardware maintenance completions | — | — |
-| Standard build implementation quality | — | — |
+| Planned hardware maintenance completed in window (%) | — | — |
+| Servers deployed from the approved standard build (%) | — | — |
 | User satisfaction with hardware support | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -135,7 +135,7 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 | Time to provision new server infrastructure | — | — |
 | Server capacity utilization efficiency | — | — |
 | Successful technology adoption rate | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Team velocity and productivity metrics | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -120,10 +120,10 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 | Server deployment accuracy and quality | — | — |
 | Implementation time for server infrastructure projects | — | — |
 | Server hardware incident resolution time | — | — |
-| Documentation quality and completeness | — | — |
-| Knowledge sharing effectiveness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Automation implementation success rate | — | — |
-| Server performance optimization metrics | — | — |
+| Servers meeting their performance baseline after tuning (%) | — | — |
 | Hardware standardization compliance | — | — |
 | Team technical capability development | — | — |
 | Server capacity utilization metrics | — | — |

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -135,13 +135,13 @@ The Linux Server Architect designs and defines the strategic direction for the o
 | Architectural standards adoption rate across Linux deployments | — | — |
 | Reduction in Linux infrastructure incidents due to architectural improvements | — | — |
 | Linux environment availability and performance metrics | ≥99.9% (proposed) | Monthly |
-| Successful implementation of architectural recommendations | — | — |
+| Architecture review recommendations implemented within the agreed period (%) | — | — |
 | Cost optimization of Linux infrastructure | — | — |
-| Quality and completeness of architecture documentation | — | — |
+| Architecture artefacts current within the agreed review cycle (%) | — | — |
 | Technical debt reduction in Linux environments | — | — |
 | Time-to-delivery for new Linux capabilities and services | — | — |
 | Linux security posture improvement | — | — |
-| Knowledge transfer effectiveness to engineering teams | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -147,7 +147,7 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 | Successful implementation of automation tasks | — | — |
 | Backup success rates and recovery capabilities | ≥99% (proposed) | Monthly |
 | User satisfaction with Linux support | ≥85% (proposed) | Quarterly |
-| Adherence to Linux standards and procedures | — | — |
+| Work conforming to Linux standards and procedures (%) | — | — |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -142,13 +142,13 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 | Linux server availability metrics | ≥99.9% (proposed) | Monthly |
 | Time to resolve Linux-related incidents | — | — |
 | Patch compliance percentage | ≥95% (proposed) | Monthly |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Security compliance scores | — | — |
 | Successful implementation of automation tasks | — | — |
 | Backup success rates and recovery capabilities | ≥99% (proposed) | Monthly |
 | User satisfaction with Linux support | ≥85% (proposed) | Quarterly |
 | Adherence to Linux standards and procedures | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -138,7 +138,7 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 | Metric | Target | Frequency |
 |---|---|---|
 | Linux system availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Implementation quality of Linux solutions | — | — |
+| Linux implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for critical Linux incidents | — | — |
 | Automation coverage for Linux administration tasks | — | — |
 | Security compliance scores for Linux environments | — | — |

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -142,7 +142,7 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 | Time to resolution for critical Linux incidents | — | — |
 | Automation coverage for Linux administration tasks | — | — |
 | Security compliance scores for Linux environments | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Successful implementation of Linux standards | — | — |
 | Innovation in Linux platform enhancements | — | — |
 | Resource optimization achievements | — | — |

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -134,13 +134,13 @@ The Windows Server Architect designs and defines the strategic direction for the
 | Architectural standards adoption rate across Windows deployments | — | — |
 | Reduction in Windows infrastructure incidents due to architectural improvements | — | — |
 | Windows environment availability and performance metrics | ≥99.9% (proposed) | Monthly |
-| Successful implementation of architectural recommendations | — | — |
+| Architecture review recommendations implemented within the agreed period (%) | — | — |
 | Cost optimization of Windows licensing and infrastructure | — | — |
-| Quality and completeness of architecture documentation | — | — |
+| Architecture artefacts current within the agreed review cycle (%) | — | — |
 | Technical debt reduction in Windows environments | — | — |
 | Time-to-delivery for new Windows capabilities and services | — | — |
 | Windows security posture improvement | — | — |
-| Knowledge transfer effectiveness to engineering teams | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -144,7 +144,7 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 | Patch compliance percentages | ≥95% (proposed) | Monthly |
 | Time to implement standard server configurations | — | — |
 | Service request resolution time | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Group Policy implementation accuracy | — | — |
 | Backup success rate and recovery effectiveness | ≥99% (proposed) | Monthly |
 | Change implementation success rate | — | — |

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -148,7 +148,7 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 | Group Policy implementation accuracy | — | — |
 | Backup success rate and recovery effectiveness | ≥99% (proposed) | Monthly |
 | Change implementation success rate | — | — |
-| Adherence to security standards and best practices | — | — |
+| Work conforming to security standards and best practices (%) | — | — |
 | User satisfaction with server services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -156,9 +156,9 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 | Cost efficiency of Windows infrastructure | — | — |
 | Stakeholder satisfaction with server services | ≥85% (proposed) | Quarterly |
 | Windows Server automation efficiency | — | — |
-| Successful delivery of roadmap initiatives | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | — | — |
 | Security compliance scores for server environment | — | — |
-| Backlog health and prioritization effectiveness | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Service level objective achievement | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -143,7 +143,7 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 | Metric | Target | Frequency |
 |---|---|---|
 | Windows environment availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Implementation quality of Windows solutions | — | — |
+| Windows implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolve critical Windows incidents | — | — |
 | Automation coverage for Windows administration | — | — |
 | Security compliance scores for Windows servers | — | — |

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -147,10 +147,10 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 | Time to resolve critical Windows incidents | — | — |
 | Automation coverage for Windows administration | — | — |
 | Security compliance scores for Windows servers | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Successful implementation of Windows standards | — | — |
-| Server performance optimization metrics | — | — |
-| Project delivery timeliness and quality | — | — |
+| Servers meeting their performance baseline after tuning (%) | — | — |
+| Projects delivered in the committed period without post-go-live defects (%) | — | — |
 | Innovation in Windows platform capabilities | — | — |
 
 ## Remote Work Considerations

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -132,7 +132,7 @@ The Service Management Architect designs comprehensive strategies and architectu
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | — | — |
-| Alignment of ITSM designs with business requirements | — | — |
+| ITSM designs accepted by the requesting business owner without rework (%) | — | — |
 | Process efficiency and effectiveness metrics | — | — |
 | Service integration reliability | — | — |
 | Adoption of ITSM reference architectures | — | — |

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -131,15 +131,15 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Architecture design quality and effectiveness | — | — |
+| Designs approved at first architecture review, without rework (%) | — | — |
 | Alignment of ITSM designs with business requirements | — | — |
 | Process efficiency and effectiveness metrics | — | — |
 | Service integration reliability | — | — |
 | Adoption of ITSM reference architectures | — | — |
 | Reduction in service-related incidents | — | — |
 | Innovation in service management approaches | — | — |
-| Technical leadership effectiveness | — | — |
-| Knowledge transfer to engineering teams | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
 | Service management maturity improvement | — | — |
 
 ## Remote Work Considerations

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -136,11 +136,11 @@ The Service Management Engineer implements and maintains IT service management p
 | Time to complete service management requests | — | — |
 | Service catalog effectiveness | — | — |
 | Workflow automation success rate | — | — |
-| Documentation quality and completeness | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | User satisfaction with ITSM tools | ≥85% (proposed) | Quarterly |
 | Reporting and dashboard utility | — | — |
 | Resolution time for ITSM platform issues | — | — |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Process automation efficiency | — | — |
 
 ## Remote Work Considerations

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -135,7 +135,7 @@ The Service Management Senior Engineer leads the implementation and optimization
 | Workflow automation effectiveness | — | — |
 | Implementation quality of ITSM solutions | — | — |
 | Time to resolution for complex platform issues | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | ITSM platform security and compliance | — | — |
 | Successful implementation of ITSM standards | — | — |
 | Innovation in service management solutions | — | — |

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -133,7 +133,7 @@ The Service Management Senior Engineer leads the implementation and optimization
 |---|---|---|
 | ITSM platform availability and performance | ≥99.9% (proposed) | Monthly |
 | Workflow automation effectiveness | — | — |
-| Implementation quality of ITSM solutions | — | — |
+| ITSM implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex platform issues | — | — |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | ITSM platform security and compliance | — | — |

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -124,7 +124,7 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 | Timely resolution of incidents and service requests | — | — |
 | Efficiency of virtual resource utilization | — | — |
 | Quality of documentation and operational procedures | — | — |
-| Adherence to change management processes | — | — |
+| Work conforming to change management processes (%) | — | — |
 | Successful implementation of routine maintenance activities | — | — |
 | VM provisioning turnaround times | — | — |
 | Security compliance of virtualized environments | — | — |

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -124,7 +124,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 | Achievement of roadmap milestones and delivery objectives | — | — |
 | Effective prioritization of features and initiatives | — | — |
 | Quality of service metrics for Hyper-V environments | — | — |
-| Alignment of Hyper-V capabilities with business needs | — | — |
+| Hyper-V capabilities accepted by the requesting business owner without rework (%) | — | — |
 | Cost optimization and value delivery | — | — |
 | Clear backlog management and sprint execution | — | — |
 | Successful adoption of new Hyper-V features and capabilities | — | — |

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -129,8 +129,8 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 | Success rate of migrations and upgrades | — | — |
 | Resolution time for complex virtualization issues | — | — |
 | Automation coverage for routine administrative tasks | — | — |
-| Resource utilization efficiency metrics | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Contribution to virtualization standards and best practices | — | — |
 | Security posture improvement in virtualized environments | — | — |
 | Innovation in virtualization solutions implementation | — | — |

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -125,7 +125,7 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 | Metric | Target | Frequency |
 |---|---|---|
 | Hyper-V environment reliability and uptime percentages | ≥99.9% (proposed) | Monthly |
-| Implementation quality of complex virtualization solutions | — | — |
+| Complex virtualization implementations accepted without post-deployment rework (%) | — | — |
 | Success rate of migrations and upgrades | — | — |
 | Resolution time for complex virtualization issues | — | — |
 | Automation coverage for routine administrative tasks | — | — |

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -148,7 +148,7 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 | Adoption of standards and best practices | — | — |
 | Time-to-value for new Nutanix implementations | — | — |
 | Risk mitigation effectiveness | — | — |
-| Innovation and continuous improvement contributions | — | — |
+| Improvement items proposed and adopted (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -142,12 +142,12 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 | Virtual machine provisioning efficiency | — | — |
 | Time to resolve Nutanix-related incidents | — | — |
 | Successful completion of maintenance activities | — | — |
-| Documentation quality and completeness | — | — |
-| Resource utilization optimization | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
 | Patch compliance for Nutanix components | ≥95% (proposed) | Monthly |
 | Reduction in recurring incidents | — | — |
 | User satisfaction with infrastructure services | ≥85% (proposed) | Quarterly |
-| Knowledge sharing and collaboration | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -141,11 +141,11 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 | Metric | Target | Frequency |
 |---|---|---|
 | Platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Resource utilization optimization | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
 | Time-to-delivery for platform enhancements | — | — |
 | Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Cost efficiency metrics for HCI resources | — | — |
-| Backlog health and prioritization effectiveness | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
 | Platform adoption rates across the organization | — | — |
 | Quality of service delivery documentation | — | — |
 | Platform automation and self-service capability | — | — |

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -136,8 +136,8 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 | Implementation quality of HCI solutions | — | — |
 | Time to resolution for complex Nutanix issues | — | — |
 | Automation coverage for Nutanix operations | — | — |
-| Resource utilization efficiency metrics | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Success rate of migrations and upgrades | — | — |
 | Contribution to HCI standards and best practices | — | — |
 | Customer satisfaction with Nutanix services | ≥85% (proposed) | Quarterly |

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -133,7 +133,7 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 | Metric | Target | Frequency |
 |---|---|---|
 | Nutanix infrastructure availability and reliability | ≥99.9% (proposed) | Monthly |
-| Implementation quality of HCI solutions | — | — |
+| HCI implementations accepted without post-deployment rework (%) | — | — |
 | Time to resolution for complex Nutanix issues | — | — |
 | Automation coverage for Nutanix operations | — | — |
 | Provisioned capacity actively utilised (%) | — | — |

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -143,7 +143,7 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 | Provisioned capacity actively utilised (%) | — | — |
 | Patch compliance for VMware components | ≥95% (proposed) | Monthly |
 | Backup success rates for virtual machines | ≥99% (proposed) | Monthly |
-| Adherence to VMware configuration standards | — | — |
+| Work conforming to VMware configuration standards (%) | — | — |
 | Number of automated processes implemented | — | — |
 | Customer satisfaction with virtualization services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -139,8 +139,8 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 | VMware environment uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Virtual machine deployment time efficiency | — | — |
 | Resolution time for virtualization incidents | — | — |
-| Documentation quality and completeness | — | — |
-| Resource utilization efficiency | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
 | Patch compliance for VMware components | ≥95% (proposed) | Monthly |
 | Backup success rates for virtual machines | ≥99% (proposed) | Monthly |
 | Adherence to VMware configuration standards | — | — |

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -162,7 +162,7 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 | Platform availability and SLA compliance | ≥95% (proposed) | Monthly |
 | Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Business value delivered through platform enhancements | — | — |
-| Resource utilization efficiency | — | — |
+| Provisioned capacity actively utilised (%) | — | — |
 | Cost optimization achievements | — | — |
 | Feature adoption rates | — | — |
 | Backlog health and roadmap delivery | — | — |

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -143,9 +143,9 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 | Resource utilization optimization metrics | — | — |
 | Success rate of infrastructure changes and migrations | — | — |
 | Resolution time for complex incidents | — | — |
-| Knowledge transfer effectiveness to junior engineers | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
 | Implementation of standards and best practices | — | — |
-| Innovation and continuous improvement contributions | — | — |
+| Improvement items proposed and adopted (count per quarter) | — | — |
 
 ## Remote Work Considerations
 


### PR DESCRIPTION
## Summary

313 rows across 120 files where the KPI named a **subject** rather than something measurable:

| Before | After |
|---|---|
| Architecture design quality and effectiveness | Designs approved at first architecture review, without rework (%) |
| Knowledge transfer to engineering teams | Knowledge-sharing sessions delivered to engineering teams (count per quarter) |
| Documentation quality and completeness | Owned documentation reviewed and current within the agreed review cycle (%) |
| Reduction in architectural risks and technical debt | Recorded architectural risks and debt items closed (count per quarter) |

Refs #140

## This proposes a measure, not a target

Every rewritten row **keeps its em dash**. The number still comes from the organisation, and the validator still counts the row as needing one — the count of untargeted rows is unchanged at 1,436.

That distinction is the point. Rewriting *what is measured* is a different and lower-risk act than inventing *what the number should be*: a proposed measure is reviewable on its face, whereas a fabricated target reads as agreed fact. Same reasoning that made the `(proposed)` marker necessary on the benchmarks.

## Scope: the repeated texts

86 texts appearing in more than one role, covering 313 rows. Doing the repeated ones first puts consistency where it matters most — the same KPI should not be phrased three ways across three roles that share it. `Documentation quality and completeness` alone appeared in **31** roles.

539 texts appearing once each are the remaining tail, deliberately left for a follow-up.

| | Before | After |
|---|---|---|
| Subject-style rows | 852 | **541** |
| Countable metrics awaiting a number | 584 | **895** |

## Safety

- **Rows that already carry a target are never rewritten** — changing what is measured would invalidate an agreed number
- Verified only the Metric cell changed: **zero targets altered, zero row counts changed** across 120 files
- All 86 rewrites matched real text, **none left stranded** by drift — the applier reports any defined-but-unmatched entry rather than failing silently

## Test plan

- [x] Dry run first — 313 rows / 120 files / 86 of 86 rewrites matched
- [x] `npm test` — 190/190 · `npm run validate` — 0 errors, 0 duplicate titles · `npm run check-counts` — README matches
- [x] Browser: `AWS Cloud Architect` renders 8 of 10 rows rewritten, each naming a unit, gaps still visible

## A measurement note

My first check of the result reported 724 rows still subject-style, which looked like the rewrites had barely worked. The classifier was wrong, not the rewrites — it tested for the *word* "percentage" and so did not recognise a metric ending in `(%)`. Corrected, the figure is 541.