### PR TITLE
docs: add onboarding supplements for the four main role levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ roles_master/
 │   ├── CROSS_DOMAIN_INTERACTIONS.md        # Domain ownership and escalation paths
 │   ├── SKILLS_PROGRESSION.md              # Career progression framework
 │   ├── ONBOARDING_TEMPLATE.md             # 30/60/90 day onboarding plan template
+│   ├── onboarding_*_supplement.md         # Level overlays: Engineer, Senior, Architect, PO
 │   ├── onboarding_chapter_lead_template.md # Chapter Lead-specific onboarding variant
 │   ├── CHAPTERS_OVERVIEW.md               # The 7 chapters: focus, lead, detail link
 │   └── chapters/                           # Per-chapter narrative (rendered in the viewer)
@@ -202,6 +203,7 @@ Each role file follows the canonical 14-section structure. See `docs/role_templa
 | `docs/CROSS_DOMAIN_INTERACTIONS.md` | Domain ownership boundaries, key relationships, escalation paths |
 | `docs/SKILLS_PROGRESSION.md` | Engineer → Senior → Architect career ladder per domain |
 | `docs/ONBOARDING_TEMPLATE.md` | 30/60/90 day plan template for new hires |
+| `docs/onboarding_*_supplement.md` | Level overlays (Engineer, Senior Engineer, Architect, Product Owner) — used **alongside** the base template, adding only what differs by level |
 | `docs/onboarding_chapter_lead_template.md` | Onboarding variant for incoming Chapter Leads |
 | `docs/CHAPTERS_OVERVIEW.md` | The 7 chapters, their focus, and links to per-chapter detail |
 | `docs/improvements_and_recommendations.md` | **Closed.** Narrative of the four 2026 review cycles. Open work is in [GitHub Issues](https://github.com/JeanKadang/DOC-ITRoles/issues); what shipped is in [CHANGELOG.md](CHANGELOG.md) |

--- a/docs/onboarding_architect_supplement.md
+++ b/docs/onboarding_architect_supplement.md
@@ -1,0 +1,37 @@
+# Onboarding supplement — Architect
+
+> **Use alongside [`ONBOARDING_TEMPLATE.md`](ONBOARDING_TEMPLATE.md), not instead of it.** The base plan carries the 30/60/90 structure, the manager checklist and the check-in questions. This adds only what differs at Architect level.
+
+Applies to the 49 roles at **Architect** level. 47 of them state a **Domain-wide** scope of influence: the standards other roles work within are set here, which makes the first 90 days as much about understanding existing commitments as about proposing new ones.
+
+## What changes at this level
+
+- **Authority by standard, not by instruction.** The Owns column typically covers architecture standards, reference patterns and technology selection for the domain. Those bind engineers who never report to you.
+- **You inherit decisions you did not make.** Existing reference architectures, guardrails and vendor commitments all constrain what you can change and how quickly.
+- **Governed By is real.** Most Architect definitions sit under the Enterprise Architect for cross-domain standards, and under Security for control requirements. Both are named in *Interactions with Other Roles*.
+
+## 30 days — additions
+
+- [ ] Read every reference architecture and standard the domain currently publishes, before proposing changes to any
+- [ ] Meet the Enterprise Architect and any Security or DevSecOps Architect named in the role's *Interactions* table
+- [ ] Understand the vendor and licensing commitments already in place — they constrain design more than most new Architects expect
+- [ ] Identify the Senior Engineers who escalate to this role, and what they escalate
+
+## 60 days — additions
+
+- [ ] Take a design through the architecture review board, including handling the challenge
+- [ ] Form a view on where the domain's standards are outdated, with evidence rather than preference
+- [ ] Review a Senior Engineer's design and give feedback that improves it without taking it over
+
+## 90 days — additions
+
+- [ ] Own a standard or reference pattern for the domain, published and communicated
+- [ ] Have a 12-month technology direction for the domain, agreed with the Chapter Lead
+- [ ] Retire or consolidate at least one thing — a duplicated pattern, an unused tool, a standard nobody follows
+
+## Common early failure modes
+
+- **Rewriting standards before understanding why they exist.** Most look arbitrary until you find the incident or constraint behind them. Ask before replacing.
+- **Designing without the Senior Engineers who will implement it.** They hold the operational detail that determines whether a design survives contact with production.
+- **Treating Governed By as advisory.** Enterprise architecture and security requirements are constraints, not input. The *Out of Scope* bullets say which decisions are not yours.
+- **Optimising for elegance over adoption.** A standard nobody follows is worse than a rough one everybody does, because it hides the real practice.

--- a/docs/onboarding_engineer_supplement.md
+++ b/docs/onboarding_engineer_supplement.md
@@ -1,0 +1,41 @@
+# Onboarding supplement — Engineer
+
+> **Use alongside [`ONBOARDING_TEMPLATE.md`](ONBOARDING_TEMPLATE.md), not instead of it.** The base plan carries the 30/60/90 structure, the manager checklist and the check-in questions. This adds only what differs at Engineer level, so the two do not drift apart.
+
+Applies to the 61 roles at **Engineer** level. Their defining characteristic in the catalogue is scope: 58 of 61 state a **Team** scope of influence — work is executed to standards someone else sets, and the growth path runs through doing that reliably before widening.
+
+## What "good" looks like at this level
+
+Read the new starter's own role definition alongside this. Three sections carry the expectations that matter here:
+
+- **Role Scope & Boundaries** — the *Out of Scope* bullets name what belongs to someone else. Being clear about that early prevents the most common new-starter mistake: solving a problem that was not theirs to solve.
+- **Escalates To** — usually the Senior Engineer. This is the single most useful contact for the first 90 days.
+- **Experience Anchor** — most Engineer roles state 1–3 years and "works under guidance". Slower, supported ramp is the expectation, not a concession.
+
+## 30 days — additions
+
+- [ ] Identify the Senior Engineer named in *Escalates To* and agree how and when to escalate
+- [ ] Read the *Out of Scope* bullets with the manager and check understanding of each boundary
+- [ ] Complete one task end to end under review, however small — the goal is the workflow, not the size
+- [ ] Confirm access to every tool listed at *Expert* and *Proficient* level in the role's Technology Proficiency block
+
+## 60 days — additions
+
+- [ ] Pick up work from the team backlog without it being individually assigned
+- [ ] Escalate at least once, deliberately, to practise the path before it is needed urgently
+- [ ] Close a task that required consulting a runbook or documentation you had not used before
+- [ ] Identify one *Working Knowledge* technology to move toward *Proficient*, and agree a way to practise it
+
+## 90 days — additions
+
+- [ ] Deliver routine work in the role's area without prior review, within the agreed boundaries
+- [ ] Raise an improvement to a runbook, standard or piece of documentation you used
+- [ ] Discuss the *Potential Next Roles* in the role definition and which appeals, if any
+
+## Common early failure modes
+
+Worth naming explicitly, because each is easier to prevent than to correct:
+
+- **Working beyond scope to be helpful.** The boundaries exist so that accountability is clear. Widening them informally makes it unclear who owns an outcome.
+- **Not escalating soon enough.** At this level escalation is expected behaviour, not an admission. The *Escalated To By* line in the Senior Engineer's role definition says so from the other side.
+- **Treating the role definition as an HR document.** It names the technologies expected at each proficiency level, the roles this one interacts with, and where the career path leads. It is a working reference.

--- a/docs/onboarding_product_owner_supplement.md
+++ b/docs/onboarding_product_owner_supplement.md
@@ -1,0 +1,37 @@
+# Onboarding supplement — Product Owner
+
+> **Use alongside [`ONBOARDING_TEMPLATE.md`](ONBOARDING_TEMPLATE.md), not instead of it.** The base plan carries the 30/60/90 structure, the manager checklist and the check-in questions. This adds only what differs at Product Owner level.
+
+Applies to the 41 roles at **Product Owner** level. These state a **Domain** scope covering the backlog, roadmap and delivery prioritisation — and, unusually in this catalogue, they own no technical decisions at all.
+
+## What changes at this level
+
+- **You own sequence, not design.** The Owns column covers the backlog, roadmap and prioritisation. The paired Architect owns architecture and tooling selection. This split is stated explicitly in nearly every Product Owner definition.
+- **Direct Reports is "None".** The standard phrasing is "owns backlog and roadmap; formal line management sits with the Chapter Lead". Influence here is through prioritisation and transparency, not authority.
+- **Your stakeholders are consuming teams.** The *Interactions* table usually shows *Provides To* the teams who consume the platform, and *Governed By* the Architect whose standards the backlog must respect.
+
+## 30 days — additions
+
+- [ ] Read the paired Architect's role definition — their Owns column is what your backlog must not contradict
+- [ ] Meet the consuming teams named in *Interactions*, and ask what they currently work around
+- [ ] Understand the existing SLAs or service commitments before agreeing to new ones
+- [ ] Review the last two quarters of delivery to see what the team's real throughput is
+
+## 60 days — additions
+
+- [ ] Run a full backlog refinement and prioritisation cycle
+- [ ] Say no to something, explicitly and with a reason — prioritisation that never declines anything is not prioritisation
+- [ ] Establish one metric that shows whether the domain is improving, and start reporting it
+
+## 90 days — additions
+
+- [ ] Own a published roadmap for the domain, agreed with the Chapter Lead and visible to consuming teams
+- [ ] Have retired or de-scoped something as well as adding to it
+- [ ] Be able to justify the top five backlog items with evidence rather than who asked loudest
+
+## Common early failure modes
+
+- **Prioritising by requester seniority.** The most common failure, and the hardest to unwind once teams learn it works.
+- **Straying into technical decisions.** The *Out of Scope* bullets name architecture and tooling selection as the Architect's. Overriding those is how the two roles start duplicating each other.
+- **A backlog that only grows.** If nothing is ever dropped, the backlog stops being a plan and becomes a wish list nobody reads.
+- **Reporting activity instead of outcome.** Items delivered is a throughput measure; whether consuming teams are better off is the actual question.

--- a/docs/onboarding_senior_engineer_supplement.md
+++ b/docs/onboarding_senior_engineer_supplement.md
@@ -1,0 +1,36 @@
+# Onboarding supplement — Senior Engineer
+
+> **Use alongside [`ONBOARDING_TEMPLATE.md`](ONBOARDING_TEMPLATE.md), not instead of it.** The base plan carries the 30/60/90 structure, the manager checklist and the check-in questions. This adds only what differs at Senior Engineer level.
+
+Applies to the 56 roles at **Senior Engineer** level. The step up from Engineer is scope and direction: 45 of them state a **Domain** scope of influence, and most carry direct reports for technical guidance while formal line management stays with the Chapter Lead.
+
+## What changes at this level
+
+- **You are the escalation point.** 132 role definitions state that a Senior Engineer provides day-to-day technical guidance while line management sits with the Chapter Lead. New starters at this level inherit an escalation queue immediately, often before they know the systems well.
+- **Direct reports without line management.** The *Direct Reports* field usually reads "…(day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead)". Knowing which half is yours matters in the first week.
+- **Design, not just delivery.** The Owns column in *Key Decisions & Accountabilities* typically covers implementation approach and operational design within the Architect's standards.
+
+## 30 days — additions
+
+- [ ] Meet every Engineer named in *Direct Reports* individually, and ask what they currently escalate
+- [ ] Agree with the manager where the guidance/line-management boundary sits in practice
+- [ ] Read the domain Architect's role definition — the *Owns* column there is the standard you work within
+- [ ] Review the domain's open incidents and technical debt to learn where the pain actually is
+
+## 60 days — additions
+
+- [ ] Take a real escalation from an Engineer through to resolution, including the follow-up fix
+- [ ] Review someone else's design or change and give substantive feedback, not just approval
+- [ ] Identify one recurring escalation that should be solved structurally rather than repeatedly
+
+## 90 days — additions
+
+- [ ] Own a design decision within the domain, inside the Architect's standards
+- [ ] Have a view on the domain's biggest technical risk, and have raised it
+- [ ] Support at least one Engineer's development explicitly — a skill gap named and a plan agreed
+
+## Common early failure modes
+
+- **Absorbing escalations instead of resolving the cause.** Fixing the ticket is the visible half; noticing the fourth identical ticket is the job.
+- **Assuming the guidance role includes line management.** It generally does not. Career conversations, performance and headcount sit with the Chapter Lead, and acting otherwise creates confusion for the Engineer.
+- **Setting standards that belong to the Architect.** The *Out of Scope* bullets usually say this directly. Propose through the Architect rather than around them.

--- a/index.html
+++ b/index.html
@@ -1640,8 +1640,14 @@
         { group: 'reference',  file: 'docs/CHAPTERS_OVERVIEW.md',                icon: '🗂️', title: 'Chapters Overview' },
         { group: 'reference',  file: 'docs/SKILLS_PROGRESSION.md',               icon: '📈', title: 'Career Paths & Skills Progression' },
         { group: 'reference',  file: 'docs/CROSS_DOMAIN_INTERACTIONS.md',        icon: '🔀', title: 'Domain Interactions' },
-        { group: 'onboarding', file: 'docs/ONBOARDING_TEMPLATE.md',              icon: '📋', title: 'Onboarding Template' },
-        { group: 'onboarding', file: 'docs/onboarding_chapter_lead_template.md', icon: '👑', title: 'Chapter Lead Onboarding Template' },
+        { group: 'onboarding', file: 'docs/ONBOARDING_TEMPLATE.md',                    icon: '📋', title: 'Onboarding Template' },
+        // Level supplements (#149). Each overlays the base template rather than
+        // restating it, so the shared 30/60/90 structure has one home.
+        { group: 'onboarding', file: 'docs/onboarding_engineer_supplement.md',         icon: '🔧', title: '— Engineer supplement' },
+        { group: 'onboarding', file: 'docs/onboarding_senior_engineer_supplement.md',  icon: '🛠️', title: '— Senior Engineer supplement' },
+        { group: 'onboarding', file: 'docs/onboarding_architect_supplement.md',        icon: '📐', title: '— Architect supplement' },
+        { group: 'onboarding', file: 'docs/onboarding_product_owner_supplement.md',    icon: '🎯', title: '— Product Owner supplement' },
+        { group: 'onboarding', file: 'docs/onboarding_chapter_lead_template.md',       icon: '👑', title: 'Chapter Lead Onboarding Template' },
     ];
 
     // ── Chapter → domain groupings ───────────────────────


### PR DESCRIPTION
## This answers #149 differently from how it was filed

The issue asked for variants for *"high-volume roles"* and treated **hiring data as the blocker**. That framing was wrong — you were right that this is simpler than I made it.

**Level is the better axis, and needs no hiring data.** The catalogue already records what differs, and it differs consistently:

| Level | Roles | Scope of influence |
|---|---|---|
| Engineer | 61 | **Team** — 58 of 61 |
| Senior Engineer | 56 | **Domain** — 45 |
| Architect | 49 | **Domain-wide** — 47 |
| Product Owner | 41 | **Domain** (backlog) |

Four level overlays cover **206 of 226 roles**. Naming two or three high-volume roles would have covered two or three.

Closes #149

## Overlays, not copies

Each supplement adds only the level-specific material — the base `ONBOARDING_TEMPLATE.md` keeps the 30/60/90 structure, manager checklist and check-in questions. Duplicating 144 lines four times would guarantee drift, which is the same problem #123 retired a 509-line document over.

Each is ~400 words: what changes at that level, additions to each of the 30/60/90 phases, and the failure modes common at that level.

## Content is derived, not invented

Every claim traces to something already in the catalogue:

- **Engineer** — *"Not escalating soon enough"* comes from the *Escalates To* line, which names the Senior Engineer; *"Working beyond scope"* from the *Out of Scope* bullets
- **Senior Engineer** — *"Assuming the guidance role includes line management"* comes from the phrasing **132 roles** share: "day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead"
- **Architect** — *"Treating Governed By as advisory"* comes from the Interactions table, where Enterprise Architect and Security appear as *Governed By*
- **Product Owner** — *"Straying into technical decisions"* comes from the Owns/Advises split stated in nearly every Product Owner definition

## Test plan

- [x] `npm test` — 190/190 · `npm run validate` — 0 errors · `npm run check-counts` — README matches
- [x] All four render in the **🚀 Onboarding** sidebar group, in level order between the base template and the Chapter Lead variant
- [x] Each opens and renders (463 / 405 / 415 / 408 words); no console errors
- [x] README updated in both the structure tree and the docs table