### PR TITLE
fix(kpi): correct 16 contradictory targets, seed 179 more, pin both with a drift test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **16 seeded targets that contradicted their own metric are corrected
+  (#140).** Auditing all 258 rows seeded in 1.12.0 found the benchmark
+  keyword matching incidentally rather than as the thing measured:
+
+  | Was | Metric |
+  |---|---|
+  | `≥99.9%` | Model deployment lead time (hours … to production endpoint **availability**, trending down) |
+  | `≤4 hours` | Vulnerability mean time to remediate (**MTTR**) — the remediation policy, not the P1 restore commitment |
+  | `≥95%` | **Number of** ad hoc analysis requests completed within SLA per quarter |
+  | `≤15%` | DORA metrics **trend** (deployment frequency, lead time, change failure rate, MTTR) |
+
+  A wrong proposal is worse than a blank. The validator counts a blank as a
+  gap and a `(proposed)` value as awaiting confirmation, so a target that
+  does not fit its metric is the one state that reads as progress while
+  being false. 15 rows return to an em dash and the vulnerability row is
+  re-pointed at the remediation policy.
+
+  Three guards prevent the class rather than the instances: a **unit
+  conflict** rule (no percentage on a metric counted in hours or in units of
+  work), a **direction-only** rule (`trend`, `improvement`, `etc.` describe
+  travel, not a threshold), and a **composite** rule counting measure nouns
+  rather than commas — so `Microsoft 365 service availability (Exchange,
+  Teams, SharePoint)` stays seeded while `incident frequency, severity, and
+  mean time to detect` does not.
+
+  The guard was reconciled against all 258 rows before use, and refused two
+  the hand audit had passed. Both were product lists rather than measure
+  lists, which is what moved the composite rule off comma counting.
+
+### Added
+
+- **179 more rows carry a proposed target, each marked by where its number
+  came from (#140).** 427 rows now hold an opening figure, up from 258.
+
+  | Basis | Rows | Examples |
+  |---|---|---|
+  | Published benchmark | **275** | DORA change lead time `≤24 hours`, SLO attainment and guardrail compliance `≥95%` |
+  | House starting point | **152** | documentation currency `≥95%`, first-review approval `≥80%`, ramp completion `≥90%` |
+
+  **The distinction `(proposed)` cannot carry.** The marker says a number is
+  not agreed; it does not say whether anybody published it. The house
+  families — documentation currency (33 rows), accepted without rework (85),
+  reaching independent delivery within the agreed ramp period (32) — are the
+  largest in the catalogue and are standardised nowhere. Each entry now
+  declares `basis: 'house'` and the note *"no industry standard; house
+  starting point for discussion"*, and a test asserts every entry declares a
+  basis, so one cannot be added as published by omission.
+
+  The DORA lead-time figure is anchored to `commit` so that any duration
+  called a lead time does not inherit it.
+
+- The validator no longer describes proposals as *"seeded from an industry
+  benchmark"*. The file marker cannot distinguish the two bases, and
+  claiming a source for all of them would be false for 152 of the 427.
+
+### Still open
+
+Tracked in #140. **1,267 of 1,941 KPI rows have no target** (down from
+1,436). Of those, 418 declare a unit — a `(%)`, a `(count …)`, a duration —
+and so state plainly what number is missing; the rest name a subject and
+need rewriting before a target means anything.
+
+The three largest remaining families are counts: engineers mentored who
+progress a level (22 rows), knowledge-sharing sessions delivered (20),
+contributions published (20). A target for these depends on team size and
+on what the organisation asks of the role. There is no defensible figure to
+propose, in-house or otherwise, so they stay blank.
+
 ## [1.13.0] - 2026-08-06
 
 Onboarding gains four level supplements, covering 206 of the 226 roles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-06
+
+Onboarding gains four level supplements, covering 206 of the 226 roles
+without needing information the repository does not hold.
+
+### Added
+
+- **Onboarding supplements for Engineer, Senior Engineer, Architect and
+  Product Owner (#149).** Each sits in the 🚀 Onboarding sidebar group, in
+  level order, between the base template and the Chapter Lead variant.
+
+  | Level | Roles | Scope of influence stated |
+  |---|---|---|
+  | Engineer | 61 | **Team** — 58 of 61 |
+  | Senior Engineer | 56 | **Domain** — 45 |
+  | Architect | 49 | **Domain-wide** — 47 |
+  | Product Owner | 41 | **Domain** (backlog) |
+
+  Each is an overlay of roughly 400 words: what changes at that level,
+  additions to each of the 30/60/90 phases, and the failure modes common
+  there. `ONBOARDING_TEMPLATE.md` keeps the shared 30/60/90 structure, the
+  manager checklist and the check-in questions, and none of it is repeated.
+  Copying 144 lines four times would guarantee the drift that #123 retired a
+  509-line document over.
+
+### On answering the issue differently from how it was filed
+
+#149 asked for variants for *high-volume roles*, and named hiring volume and
+access processes as what it was waiting on. That framing is what had kept it
+open.
+
+**Level is the better axis, and the catalogue already documents it.**
+The role definitions state scope of influence consistently enough to
+partition on, so four supplements reach 206 roles where naming two or three
+high-volume roles would have reached two or three — and no hiring data is
+needed to write them.
+
+Every claim traces to something already in the catalogue rather than to
+general onboarding advice:
+
+- *"Assuming the guidance role includes line management"* comes from the
+  phrasing **132 roles** share — "day-to-day technical guidance and
+  mentoring; formal line management sits with the Chapter Lead"
+- *"Not escalating soon enough"* comes from the Engineer's **Escalates To**
+  line, which names the Senior Engineer
+- *"Treating Governed By as advisory"* comes from the Architect's
+  **Interactions** table, where Enterprise Architect and Security appear as
+  governing roles
+- *"Straying into technical decisions"* comes from the Owns/Advises split
+  stated in nearly every Product Owner definition
+
+The 20 roles outside these four levels — Chapter Leads and the executive
+tier — are either covered by the existing Chapter Lead template or are
+individual enough that a shared supplement would not serve them.
+
 ## [1.12.1] - 2026-08-06
 
 KPI content: subject-style metrics rewritten into things that can actually

--- a/Roles/FinOps/cloud_economics_analyst.md
+++ b/Roles/FinOps/cloud_economics_analyst.md
@@ -149,7 +149,7 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 | Unit cost trend analysis quality (stakeholder-assessed usefulness score) | — | — |
 | Stakeholder satisfaction score (measured via periodic feedback surveys) | ≥85% (proposed) | Quarterly |
 | Data quality score for billing allocation and tagging completeness underlying reports | — | — |
-| Number of ad hoc financial analysis requests completed within SLA per quarter | ≥95% (proposed) | Monthly |
+| Number of ad hoc financial analysis requests completed within SLA per quarter | — | Monthly |
 | Reduction in manual reporting effort through automation improvements (hours saved) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -152,7 +152,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Effectiveness of monitoring and alerting setup | — | — |
 | Resource tagging compliance percentage | — | — |
 | Eligible spend covered by reserved or committed capacity (%) | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with cost management tools | ≥85% (proposed) | Quarterly |
 | Problem resolution time for billing issues | — | — |
 

--- a/Roles/FinOps/finops_senior_engineer.md
+++ b/Roles/FinOps/finops_senior_engineer.md
@@ -147,7 +147,7 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 | Knowledge transfer to junior team members | — | — |
 | Innovation in cost optimization approaches | — | — |
 | Implementation quality of FinOps standards | — | — |
-| Cross-team deliverables completed in the committed period (%) | — | — |
+| Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
 | Data quality and reliability metrics | — | — |
 
 ## Remote Work Considerations

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -147,7 +147,7 @@ The AI Platform Engineer builds and operates the organisation's AI/ML platform i
 |---|---|---|
 | ML platform uptime and availability (target SLA, e.g., ≥99.5%) | ≥99.5% | — |
 | ML pipeline execution success rate (% of scheduled pipelines completing without failure) | — | — |
-| Model deployment lead time (hours from training completion to production endpoint availability, trending down) | ≥99.9% (proposed) | Monthly |
+| Model deployment lead time (hours from training completion to production endpoint availability, trending down) | — | Monthly |
 | Mean time to restore (MTTR) for ML infrastructure incidents | ≤4 hours (proposed) | Monthly |
 | Data scientist onboarding time to first successful experiment run (days, trending down) | — | — |
 | Feature store pipeline data freshness SLA compliance (% of feature tables meeting published freshness SLO) | ≥95% (proposed) | Monthly |

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -134,13 +134,13 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| API designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| API designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | API platform performance and scalability | — | — |
 | Security posture of API implementations | — | — |
 | Adoption of API reference architectures and patterns | — | — |
 | Reduction in API architectural risks and technical debt | — | — |
-| Median lead time from commit to production for teams on the standard (hours) | — | — |
+| Median lead time from commit to production for teams on the standard (hours) | ≤24 hours (proposed) | Monthly |
 | Innovation in API architectural approaches | — | — |
 | Engineers mentored who progress to the next competency level (count per year) | — | — |
 | Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -134,9 +134,9 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 |---|---|---|
 | API platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | API response time and throughput performance | — | — |
-| API implementations accepted without post-deployment rework (%) | — | — |
+| API implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex API issues | — | — |
-| Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior developers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | API security posture improvement | — | — |
 | Successful implementation of API standards | — | — |
 | Developer satisfaction with API platform | ≥85% (proposed) | Quarterly |

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -131,13 +131,13 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| .NET designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| .NET designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Application transactions meeting their response-time budget (%) | — | — |
 | Security posture of .NET applications | — | — |
 | Adoption of .NET reference architectures and patterns | — | — |
 | Recorded architectural risks and debt items closed (count per quarter) | — | — |
-| Median lead time from commit to production for teams on the standard (hours) | — | — |
+| Median lead time from commit to production for teams on the standard (hours) | ≤24 hours (proposed) | Monthly |
 | Innovation in .NET architectural approaches | — | — |
 | Engineers mentored who progress to the next competency level (count per year) | — | — |
 | Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -137,11 +137,11 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 | Timely completion of development tasks | — | — |
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Work conforming to .NET coding standards (%) | — | — |
-| Cross-team deliverables completed in the committed period (%) | — | — |
+| Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
-| Support requests acknowledged within the agreed response window (%) | — | — |
+| Support requests acknowledged within the agreed response window (%) | ≥95% (proposed) | Monthly |
 | Application transactions meeting their response-time budget (%) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -135,9 +135,9 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 | Platform adoption rates across development teams | — | — |
 | Time-to-market improvement for applications | — | — |
 | Delivery teams consuming a shared component rather than rebuilding it (count) | — | — |
-| Platform services meeting their published SLO (%) | — | — |
+| Platform services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Security vulnerability reduction in .NET applications | — | — |
-| Platform roadmap items delivered in the committed quarter (%) | — | — |
+| Platform roadmap items delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 | Delivery teams onboarded to a platform capability (count per quarter) | — | — |
 | Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in .NET capabilities | — | — |

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -133,14 +133,14 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 |---|---|---|
 | .NET platform reliability and performance metrics | — | — |
 | Code quality gate pass rate on the main branch (%) | — | — |
-| .NET implementations accepted without post-deployment rework (%) | — | — |
+| .NET implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex .NET issues | — | — |
-| Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior developers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | .NET security posture improvement | — | — |
 | Successful implementation of .NET standards | — | — |
 | Recorded technical debt items closed (count per quarter) | — | — |
 | Innovation in .NET platform capabilities | — | — |
-| Median lead time from commit to production for teams on the framework (hours) | — | — |
+| Median lead time from commit to production for teams on the framework (hours) | ≤24 hours (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -131,13 +131,13 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Java designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Java designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Application transactions meeting their response-time budget (%) | — | — |
 | Security posture of Java applications | — | — |
 | Adoption of Java reference architectures and patterns | — | — |
 | Recorded architectural risks and debt items closed (count per quarter) | — | — |
-| Median lead time from commit to production for teams on the standard (hours) | — | — |
+| Median lead time from commit to production for teams on the standard (hours) | ≤24 hours (proposed) | Monthly |
 | Innovation in Java architectural approaches | — | — |
 | Engineers mentored who progress to the next competency level (count per year) | — | — |
 | Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -137,11 +137,11 @@ The Java Engineer implements and maintains Java-based applications and platform 
 | Timely completion of development tasks | — | — |
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Work conforming to Java coding standards (%) | — | — |
-| Cross-team deliverables completed in the committed period (%) | — | — |
+| Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
-| Support requests acknowledged within the agreed response window (%) | — | — |
+| Support requests acknowledged within the agreed response window (%) | ≥95% (proposed) | Monthly |
 | Application transactions meeting their response-time budget (%) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -136,9 +136,9 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 | Platform adoption rates across development teams | — | — |
 | Time-to-market improvement for applications | — | — |
 | Delivery teams consuming a shared component rather than rebuilding it (count) | — | — |
-| Platform services meeting their published SLO (%) | — | — |
+| Platform services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Security vulnerability reduction in Java applications | — | — |
-| Platform roadmap items delivered in the committed quarter (%) | — | — |
+| Platform roadmap items delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 | Delivery teams onboarded to a platform capability (count per quarter) | — | — |
 | Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in Java capabilities | — | — |

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -134,14 +134,14 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 |---|---|---|
 | Java platform reliability and performance metrics | — | — |
 | Code quality gate pass rate on the main branch (%) | — | — |
-| Java implementations accepted without post-deployment rework (%) | — | — |
+| Java implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex Java issues | — | — |
-| Junior developers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior developers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Java security posture improvement | — | — |
 | Successful implementation of Java standards | — | — |
 | Recorded technical debt items closed (count per quarter) | — | — |
 | Innovation in Java platform capabilities | — | — |
-| Median lead time from commit to production for teams on the framework (hours) | — | — |
+| Median lead time from commit to production for teams on the framework (hours) | ≤24 hours (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -141,11 +141,11 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Cloud designs accepted by the requesting business owner without rework (%) | — | — |
-| Cloud services meeting their published SLO (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Cloud designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
+| Cloud services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Cost efficiency of designed cloud solutions | — | — |
-| Cloud designs passing security review at first submission (%) | — | — |
+| Cloud designs passing security review at first submission (%) | ≥80% (proposed) | Quarterly |
 | Adoption of cloud reference architectures and patterns | — | — |
 | Recorded architectural risks and debt items closed (count per quarter) | — | — |
 | New cloud patterns adopted into the reference architecture (count per year) | — | — |

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -130,7 +130,7 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 | Time-to-delivery for cloud services | — | — |
 | Stakeholder satisfaction with AWS platform | ≥85% (proposed) | Quarterly |
 | Security compliance scores for AWS environment | — | — |
-| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | — | — |
+| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | ≥95% (proposed) | Monthly |
 | AWS service adoption rates | — | — |
 | Cloud migration project success rates | — | — |
 | AWS platform feature delivery against roadmap | — | — |

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -131,13 +131,13 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 | Metric | Target | Frequency |
 |---|---|---|
 | AWS environment availability and reliability | ≥99.9% (proposed) | Monthly |
-| AWS implementations accepted without post-deployment rework (%) | — | — |
+| AWS implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
 | Security posture improvement in AWS | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of AWS standards and patterns | — | — |
-| Projects delivered in the committed period without post-go-live defects (%) | — | — |
+| Projects delivered in the committed period without post-go-live defects (%) | ≥80% (proposed) | Quarterly |
 | New patterns or tooling adopted into the standard (count per year) | — | — |
 | Customer satisfaction with AWS services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -135,11 +135,11 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Cloud designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Cloud designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Cloud architecture scalability and flexibility | — | — |
 | Cost efficiency of designed cloud solutions | — | — |
-| Cloud designs passing security review at first submission (%) | — | — |
+| Cloud designs passing security review at first submission (%) | ≥80% (proposed) | Quarterly |
 | Adoption of cloud reference architectures and patterns | — | — |
 | Recorded architectural risks and debt items closed (count per quarter) | — | — |
 | New cloud patterns adopted into the reference architecture (count per year) | — | — |

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -129,10 +129,10 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
 | Stakeholder satisfaction with Azure platform | ≥85% (proposed) | Quarterly |
-| Cloud resources compliant with the security baseline (%) | — | — |
-| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | — | — |
+| Cloud resources compliant with the security baseline (%) | ≥95% (proposed) | Monthly |
+| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | ≥95% (proposed) | Monthly |
 | PaaS service adoption rates | — | — |
-| Migrations completed in the committed window without rollback (%) | — | — |
+| Migrations completed in the committed window without rollback (%) | ≥80% (proposed) | Quarterly |
 | Azure platform feature delivery against roadmap | — | — |
 | Cloud platform requests fulfilled without manual intervention (%) | — | — |
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -136,7 +136,7 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 | Cost optimization achievements (% reduction, efficiency gains) | — | — |
 | Security compliance scores for Azure resources | — | — |
 | Mean time to resolution for complex cloud incidents | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Timely delivery of Azure implementation projects | — | — |
 | Customer satisfaction scores for cloud services | ≥85% (proposed) | Quarterly |
 | Improvement items proposed and adopted (count per quarter) | — | — |

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -135,11 +135,11 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Cloud designs accepted by the requesting business owner without rework (%) | — | — |
-| Cloud services meeting their published SLO (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Cloud designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
+| Cloud services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Cost efficiency of designed cloud solutions | — | — |
-| Cloud designs passing security review at first submission (%) | — | — |
+| Cloud designs passing security review at first submission (%) | ≥80% (proposed) | Quarterly |
 | Adoption of cloud reference architectures and patterns | — | — |
 | Recorded architectural risks and debt items closed (count per quarter) | — | — |
 | New cloud patterns adopted into the reference architecture (count per year) | — | — |

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -133,10 +133,10 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 | Cloud cost management effectiveness | — | — |
 | Time-to-delivery for cloud services | — | — |
 | Stakeholder satisfaction with GCP platform | ≥85% (proposed) | Quarterly |
-| Cloud resources compliant with the security baseline (%) | — | — |
-| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | — | — |
+| Cloud resources compliant with the security baseline (%) | ≥95% (proposed) | Monthly |
+| Cloud accounts and subscriptions compliant with landing-zone guardrails (%) | ≥95% (proposed) | Monthly |
 | GCP service adoption rates | — | — |
-| Migrations completed in the committed window without rollback (%) | — | — |
+| Migrations completed in the committed window without rollback (%) | ≥80% (proposed) | Quarterly |
 | GCP platform feature delivery against roadmap | — | — |
 | Cloud platform requests fulfilled without manual intervention (%) | — | — |
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -131,13 +131,13 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 | Metric | Target | Frequency |
 |---|---|---|
 | GCP environment availability and reliability | ≥99.9% (proposed) | Monthly |
-| GCP implementations accepted without post-deployment rework (%) | — | — |
+| GCP implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolve critical cloud incidents | — | — |
 | Cost optimization achievements | — | — |
 | Security posture improvement in GCP | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of GCP standards and patterns | — | — |
-| Projects delivered in the committed period without post-go-live defects (%) | — | — |
+| Projects delivered in the committed period without post-go-live defects (%) | ≥80% (proposed) | Quarterly |
 | New patterns or tooling adopted into the standard (count per year) | — | — |
 | Customer satisfaction with GCP services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -137,7 +137,7 @@ The Data Engineering Product Owner owns the vision, roadmap, and delivery backlo
 | Data platform cost per TB processed (trend: optimising) | — | — |
 | Data pipeline availability SLA compliance | ≥95% (proposed) | Monthly |
 | Stakeholder satisfaction score with data platform | ≥85% (proposed) | Quarterly |
-| Roadmap milestones delivered in the committed quarter (%) | — | — |
+| Roadmap milestones delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -148,7 +148,7 @@ The Data Platform Architect designs and governs the organisation's enterprise da
 | Data governance completeness (catalogued and classified datasets %) | — | — |
 | Engineering team adoption of platform standards | — | — |
 | Data platform cost per TB of data processed (trending month-over-month vs. volume growth) | — | — |
-| ML feature pipeline production lead time (time from feature request to production availability) | ≥99.9% (proposed) | Monthly |
+| ML feature pipeline production lead time (time from feature request to production availability) | — | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -149,7 +149,7 @@ The DataOps Specialist applies DevOps and agile engineering principles to data p
 | Data pipeline SLA compliance rate (% of pipelines meeting their published SLO targets) | ≥95% (proposed) | Monthly |
 | Data quality score across critical Gold tier datasets (% of dbt and Great Expectations checks passing) | — | — |
 | Pipeline MTTR (mean time to restore failed data pipelines, in hours) | ≤4 hours (proposed) | Monthly |
-| Deployment frequency for data pipeline changes (releases per week/month, trending up) | Weekly or better (proposed) | Monthly |
+| Deployment frequency for data pipeline changes (releases per week/month, trending up) | — | Monthly |
 | Data incident volume trending (number of data quality incidents per month, trending down) | — | — |
 | Time-to-detect (TTD) for data quality anomalies (minutes/hours from issue occurrence to alert firing) | — | — |
 | Automated test coverage rate (% of transformation logic covered by automated data quality tests) | ≥80% (proposed) | Monthly |

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -130,8 +130,8 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Solution designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Solution designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Storage architecture scalability and flexibility | — | — |
 | Cost efficiency of designed solutions | — | — |
 | Storage performance and availability metrics | ≥99.9% (proposed) | Monthly |

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -130,7 +130,7 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 | Storage provisioning accuracy and timeliness | — | — |
 | Resolution time for storage incidents | — | — |
 | File system performance optimization | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Planned maintenance completed in window without unplanned impact (%) | — | — |
 | Protected workloads passing their most recent recovery test (%) | ≥99% (proposed) | Monthly |
 | User satisfaction with file services | ≥85% (proposed) | Quarterly |

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -132,7 +132,7 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 | File system performance optimization | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Planned maintenance completed in window without unplanned impact (%) | — | — |
-| Protected workloads passing their most recent recovery test (%) | — | — |
+| Protected workloads passing their most recent recovery test (%) | ≥99% (proposed) | Monthly |
 | User satisfaction with file services | ≥85% (proposed) | Quarterly |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Capacity utilization efficiency | — | — |

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -154,10 +154,10 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 | Storage cost per TB efficiency metrics | — | — |
 | Stakeholder satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Time to provision new storage resources | — | — |
-| Storage services meeting their published SLO (%) | — | — |
-| Storage implementations accepted without post-deployment rework (%) | — | — |
+| Storage services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
+| Storage implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Cost optimization achievements | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | New storage capabilities released to consuming teams (count per year) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -136,13 +136,13 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 | Metric | Target | Frequency |
 |---|---|---|
 | Storage availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Storage implementations accepted without post-deployment rework (%) | — | — |
+| Storage implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex storage issues | — | — |
 | Qumulo performance optimization results | — | — |
-| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Storage automation level and efficiency | — | — |
 | Success rate of data migrations | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Innovation in Qumulo implementation approaches | — | — |
 | Customer satisfaction with file storage services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -139,7 +139,7 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 | Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
 | Planned maintenance completed in window without unplanned impact (%) | — | — |
 | Storage performance consistency | — | — |
-| Protected workloads passing their most recent recovery test (%) | — | — |
+| Protected workloads passing their most recent recovery test (%) | ≥99% (proposed) | Monthly |
 | User satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -136,7 +136,7 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 | Storage provisioning accuracy and timeliness | — | — |
 | Resolution time for storage incidents | — | — |
 | Storage utilization efficiency | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Planned maintenance completed in window without unplanned impact (%) | — | — |
 | Storage performance consistency | — | — |
 | Protected workloads passing their most recent recovery test (%) | ≥99% (proposed) | Monthly |

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -136,10 +136,10 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 | Storage cost efficiency metrics | — | — |
 | Stakeholder satisfaction with storage services | ≥85% (proposed) | Quarterly |
 | Time to provision new storage resources | — | — |
-| Storage services meeting their published SLO (%) | — | — |
-| Storage implementations accepted without post-deployment rework (%) | — | — |
+| Storage services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
+| Storage implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Cost optimization achievements | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | New storage capabilities released to consuming teams (count per year) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -133,7 +133,7 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 |---|---|---|
 | Storage environment availability and reliability | ≥99.9% (proposed) | Monthly |
 | Storage performance optimization results | — | — |
-| Storage implementations accepted without post-deployment rework (%) | — | — |
+| Storage implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex storage issues | — | — |
 | Knowledge transfer effectiveness to storage engineers | — | — |
 | Storage automation coverage and efficiency | — | — |

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -129,7 +129,7 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Backup success rate improvement trends | ≥99% (proposed) | Monthly |
+| Backup success rate improvement trends | — | Monthly |
 | Mean time to detect (MTTD) backup issues | ≤24 hours (proposed) | Monthly |
 | Mean time to resolve (MTTR) backup failures | ≤4 hours (proposed) | Monthly |
 | Reduction in backup incidents over time | — | — |

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -134,7 +134,7 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 | Solution designs accepted by the requesting business owner without rework (%) | — | — |
 | Protected workloads within the supported backup architecture (%) | — | — |
 | Cost efficiency of designed solutions | — | — |
-| Recovery tests meeting their stated RTO (%) | — | — |
+| Recovery tests meeting their stated RTO (%) | ≥99% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
 | Recorded architectural risks closed (count per quarter) | — | — |
 | Innovation in data protection approaches | — | — |

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -130,8 +130,8 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Solution designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Solution designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Protected workloads within the supported backup architecture (%) | — | — |
 | Cost efficiency of designed solutions | — | — |
 | Recovery tests meeting their stated RTO (%) | ≥99% (proposed) | Monthly |

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -136,7 +136,7 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 | Storage efficiency metrics (compression, deduplication) | — | — |
 | Agent deployment success rate | — | — |
 | Problem resolution time for backup failures | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Backup storage utilization management | — | — |
 | Successful completion of scheduled maintenance | — | — |
 | User satisfaction with restore services | ≥85% (proposed) | Quarterly |

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -133,9 +133,9 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 | Recovery time objective (RTO) achievement | — | — |
 | Protected workloads meeting their stated RPO (%) | — | — |
 | Backup window optimization | — | — |
-| Data protection implementations accepted without post-deployment rework (%) | — | — |
+| Data protection implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex backup incidents | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Backup operations performed without manual intervention (%) | — | — |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Storage efficiency metrics (deduplication, compression) | — | — |

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -133,7 +133,7 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 | Solution designs accepted by the requesting business owner without rework (%) | — | — |
 | Protected workloads within the supported backup architecture (%) | — | — |
 | Cost efficiency of designed solutions | — | — |
-| Recovery tests meeting their stated RTO (%) | — | — |
+| Recovery tests meeting their stated RTO (%) | ≥99% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
 | Reduction in data protection architectural risks | — | — |
 | Innovation in backup approaches | — | — |

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -129,8 +129,8 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Solution designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Solution designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Protected workloads within the supported backup architecture (%) | — | — |
 | Cost efficiency of designed solutions | — | — |
 | Recovery tests meeting their stated RTO (%) | ≥99% (proposed) | Monthly |

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -128,7 +128,7 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 | Backup completion within scheduled windows | — | — |
 | Recovery time performance | — | — |
 | Accurate implementation of backup policies | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Response time to backup failures | — | — |
 | Recovery testing success rates | ≥99% (proposed) | Monthly |
 | Work conforming to data retention requirements (%) | — | — |

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -148,7 +148,7 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 | Backup storage efficiency metrics | — | — |
 | Incident reduction in backup operations | — | — |
 | Backup jobs running without manual intervention (%) | — | — |
-| Cross-team deliverables completed in the committed period (%) | — | — |
+| Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -129,9 +129,9 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 | Recovery time objective (RTO) achievement | — | — |
 | Protected workloads meeting their stated RPO (%) | — | — |
 | Backup storage efficiency (deduplication ratios) | — | — |
-| Data protection implementations accepted without post-deployment rework (%) | — | — |
+| Data protection implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex backup incidents | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Backup operations performed without manual intervention (%) | — | — |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Business continuity improvement metrics | — | — |

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -132,7 +132,7 @@ The Database Architect designs comprehensive data management strategies and arch
 | Metric | Target | Frequency |
 |---|---|---|
 | Database architecture design quality and effectiveness | — | — |
-| Database designs accepted by the requesting business owner without rework (%) | — | — |
+| Database designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Database performance, scalability, and reliability | — | — |
 | Data security and compliance framework effectiveness | — | — |
 | Adoption of database reference architectures and patterns | — | — |

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -143,7 +143,7 @@ The Database Engineer implements and maintains database systems across the organ
 | Query performance and optimization | — | — |
 | Time to resolve database incidents | — | — |
 | Database patch compliance percentage | ≥95% (proposed) | Monthly |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with database services | ≥85% (proposed) | Quarterly |
 | Implementation quality of standard configurations | — | — |
 | Security compliance with database policies | — | — |

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -137,7 +137,7 @@ The Database Senior Engineer leads the implementation and optimization of comple
 |---|---|---|
 | Database availability and performance metrics | ≥99.9% (proposed) | Monthly |
 | Median query execution time for tuned workloads (ms) | — | — |
-| Database implementations accepted without post-deployment rework (%) | — | — |
+| Database implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Mean time to resolution for critical database issues | — | — |
 | Knowledge transfer effectiveness to database engineers | — | — |
 | Automation coverage for database operations | — | — |

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -134,8 +134,8 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| DevOps designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| DevOps designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Delivery pipeline efficiency and reliability | — | — |
 | Security integration in DevOps workflows | — | — |
 | Adoption of DevOps reference architectures and patterns | — | — |

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -143,7 +143,7 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 | Number of novel pipeline patterns adopted and operationalized per quarter; percentage of teams using self-service golden path tooling | — | — |
 | Engineers mentored who progress to the next competency level (count per year) | — | — |
 | Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
-| Improvement in delivery metrics (lead time, MTTR, etc.) | ≤4 hours (proposed) | Monthly |
+| Improvement in delivery metrics (lead time, MTTR, etc.) | — | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -112,9 +112,9 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 | Metric | Target | Frequency |
 |---|---|---|
 | DevOps platform adoption rates across teams | — | — |
-| Roadmap initiatives delivered in the committed quarter (%) | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 | Stakeholder satisfaction with DevOps services | ≥85% (proposed) | Quarterly |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Measurable improvement in software delivery metrics | — | — |
 | Effectiveness of DevOps training and enablement programs | — | — |
 

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -116,7 +116,7 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 | Metric | Target | Frequency |
 |---|---|---|
 | Successful implementation of advanced DevOps solutions | — | — |
-| Improvements in deployment frequency and reliability | Weekly or better (proposed) | Monthly |
+| Improvements in deployment frequency and reliability | — | Monthly |
 | Quality of pipeline templates and reusable components | — | — |
 | Effectiveness of self-service DevOps capabilities | — | — |
 | Engineers mentored who progress to the next competency level (count per year) | — | — |

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -134,7 +134,7 @@ The Windows Active Directory Architect designs AD structure, security models, an
 | Successful completion of AD migrations | — | — |
 | Business satisfaction with identity infrastructure | ≥85% (proposed) | Quarterly |
 | Reduction in security incidents related to directory services | — | — |
-| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -135,7 +135,7 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 | Group Policy implementation accuracy | — | — |
 | Directory service backup success rate | ≥99% (proposed) | Monthly |
 | Time to resolve Active Directory incidents | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Active Directory security posture | — | — |
 | Successful implementation of directory standards | — | — |
 | User satisfaction with identity services | ≥85% (proposed) | Quarterly |

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -130,7 +130,7 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 | Security compliance scores for directory services | — | — |
 | Implementation quality of AD projects | — | — |
 | Mean time to resolution for complex AD incidents | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Automation level of AD management tasks | — | — |
 | Success rate of AD migrations and upgrades | — | — |
 | Reduction in security vulnerabilities through hardening | — | — |

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -141,8 +141,8 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 | Software update compliance percentages | — | — |
 | Operating system deployment reliability | — | — |
 | Client health metrics | — | — |
-| Configuration baseline compliance | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Configuration baseline compliance | ≥95% (proposed) | Monthly |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Issue resolution time for SCCM-related problems | — | — |
 | Endpoint inventory accuracy | — | — |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -131,8 +131,8 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Onboarding architecture scalability and flexibility | — | — |
 | Standardization level across infrastructure domains | — | — |
 | Time-to-provision improvements through architecture | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -134,7 +134,7 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 |---|---|---|
 | Infrastructure provisioning time metrics | — | — |
 | Provisioning request success rate | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with provisioning services | ≥85% (proposed) | Quarterly |
 | Automation coverage for standard deployments | — | — |
 | Time to resolve provisioning incidents | — | — |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -143,7 +143,7 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 | Request accuracy and first-time completions | — | — |
 | Onboarding documentation quality | — | — |
 | Infrastructure standards compliance | — | — |
-| Roadmap initiatives delivered in the committed quarter (%) | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -135,9 +135,9 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 | Infrastructure provisioning time efficiency | — | — |
 | Automation coverage across infrastructure domains | — | — |
 | Provisioning success rate and reliability | — | — |
-| Onboarding implementations accepted without post-deployment rework (%) | — | — |
+| Onboarding implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Resolution time for onboarding incidents | — | — |
-| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Standardization level of infrastructure deployments | — | — |
 | Innovation in onboarding approaches | — | — |
 | Cross-platform integration effectiveness | — | — |

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -130,7 +130,7 @@ The Integration Engineer builds, maintains, and supports enterprise integration 
 |---|---|---|
 | Integration flow availability for monitored flows | — | — |
 | Error response and resolution time | — | — |
-| Documentation currency for assigned integrations | — | — |
+| Documentation currency for assigned integrations | ≥95% (proposed) | Quarterly |
 | Escalation rate (trend: decreasing as skills develop) | — | — |
 
 ## Remote Work Considerations

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -149,7 +149,7 @@ The Integration Product Owner owns the integration platform product backlog — 
 | Time-to-integrate: median onboarding time for new application teams to the integration platform reduced by ≥20% year-on-year | ≥20% | — |
 | Point-to-point integration reduction: ≥15% of legacy point-to-point integrations decommissioned per year as governed platform patterns expand | ≥15% | — |
 | API developer portal adoption: number of internal and external API consumers growing ≥10% quarter-on-quarter | ≥10% | — |
-| Integration-related incident rate: trend declining, with platform-attributable root causes addressed within agreed SLA response windows | ≥95% (proposed) | Monthly |
+| Integration-related incident rate: trend declining, with platform-attributable root causes addressed within agreed SLA response windows | — | Monthly |
 | API governance compliance: ≥90% of APIs published to the developer portal meeting integration architecture standards | ≥90% | — |
 
 ## Remote Work Considerations

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -143,7 +143,7 @@ The Integration Senior Engineer designs and implements complex enterprise integr
 | API response time compliance | — | — |
 | Code review coverage within the integration team | — | — |
 | Integration incident resolution time | — | — |
-| Documentation currency for owned integrations | — | — |
+| Documentation currency for owned integrations | ≥95% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -131,8 +131,8 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Configuration designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Configuration designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Configuration management reliability and scalability | — | — |
 | Security posture of configuration systems | — | — |
 | Adoption of configuration reference architectures | — | — |

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -136,7 +136,7 @@ The Application Configuration Management Engineer implements and maintains confi
 | Configuration deployment success rate | — | — |
 | Configuration-related incident reduction | — | — |
 | Time to resolve configuration issues | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Configuration compliance percentage | — | — |
 | Configuration management automation level | — | — |
 | Environment configuration consistency | — | — |

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -135,9 +135,9 @@ The Application Configuration Management Senior Engineer leads the implementatio
 | Configuration management reliability metrics | — | — |
 | Automation coverage for configuration processes | — | — |
 | Configuration deployment success rate | — | — |
-| Configuration implementations accepted without post-deployment rework (%) | — | — |
+| Configuration implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Resolution time for configuration incidents | — | — |
-| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Standardization level of configuration practices | — | — |
 | New configuration patterns adopted into the standard (count per year) | — | — |
 | Security compliance of configuration processes | — | — |

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -137,7 +137,7 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 | CMDB CI accuracy rate (target: >95% for in-scope CI classes) | >95% | — |
 | Service request self-service adoption rate (trend: increasing) | — | — |
 | Incident, Change, and Problem SLA compliance rates (platform impact contribution) | ≥95% (proposed) | Monthly |
-| Roadmap milestones delivered in the committed quarter (%) | — | — |
+| Roadmap milestones delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -174,9 +174,9 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 | Successful implementation of Kubernetes platform strategies | — | — |
 | Adoption rate of containerized applications | — | — |
 | Platform reliability and availability metrics | ≥99.9% (proposed) | Monthly |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Effective knowledge transfer to engineering teams | — | — |
-| Kubernetes platforms accepted by the requesting business owner without rework (%) | — | — |
+| Kubernetes platforms accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Number of CNCF technologies formally evaluated and adopted into the platform per year; operator maturity level (basic / managed / full lifecycle) | — | — |
 
 ## Recommended Certifications & Learning Paths

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -136,7 +136,7 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 | Container deployment success rate | — | — |
 | Time to resolve Kubernetes incidents | — | — |
 | Security compliance in Kubernetes environments | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Implementation quality of standard patterns | — | — |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Kubernetes automation implementation | — | — |

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -110,9 +110,9 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 | Metric | Target | Frequency |
 |---|---|---|
 | Platform adoption rates across application teams | — | — |
-| Roadmap initiatives delivered in the committed quarter (%) | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 | Stakeholder satisfaction with Kubernetes services | ≥85% (proposed) | Quarterly |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Measurable improvement in application deployment velocity | — | — |
 | Effective communication of platform capabilities and value | — | — |
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -113,7 +113,7 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 |---|---|---|
 | Successful implementation rate of complex Kubernetes solutions | — | — |
 | Platform reliability metrics (uptime, stability) | ≥99.9% (proposed) | Monthly |
-| Mean time to recovery for platform incidents | — | — |
+| Mean time to recovery for platform incidents | ≤4 hours (proposed) | Monthly |
 | Deployment automation effectiveness | — | — |
 | Knowledge transfer metrics for mentored engineers | — | — |
 | Kubernetes platform security posture scores | — | — |

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -147,14 +147,14 @@ The CISO sits above the PAL and TAL in the technology leadership hierarchy on ma
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Security incident frequency, severity, and mean time to detect and respond | ≤24 hours (proposed) | Monthly |
+| Security incident frequency, severity, and mean time to detect and respond | — | Monthly |
 | Regulatory audit outcomes: findings severity, remediation speed, and repeat finding rate | — | — |
 | Compliance posture across applicable frameworks (ISO 27001, GDPR, NIS2, DORA, SOC 2) | — | — |
 | Third-party security risk exposure trend and high-risk vendor remediation rate | — | — |
 | Security investment efficiency: capability maturity growth per unit of investment | — | — |
 | Board and executive confidence in security governance (survey or qualitative assessment) | — | — |
 | Employee security awareness score and phishing simulation performance trend | — | — |
-| Vulnerability mean time to remediate (MTTR) across critical and high severity findings | ≤4 hours (proposed) | Monthly |
+| Vulnerability mean time to remediate (MTTR) across critical and high severity findings | ≤30 days (critical) (proposed) | Monthly |
 | Security architecture adoption rate across technology programmes | — | — |
 | Security team retention and capability development progression | — | — |
 

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -141,7 +141,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
 | New architect and senior engineer hires retained at 90 days (%) | — | — |
 | Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter) | ≥85% (proposed) | Quarterly |
-| DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | ≤15% (proposed) | Monthly |
+| DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | — | Monthly |
 | IDP adoption rate across development teams | — | — |
 | Pipeline standardisation coverage across the organisation | — | — |
 | API governance compliance rate | — | — |

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -136,11 +136,11 @@ The Engineering Practices Champion is a senior individual contributor and intern
 
 | Metric | Target | Frequency |
 |---|---|---|
-| DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement | ≤15% (proposed) | Monthly |
+| DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement | — | Monthly |
 | Code quality gate adoption rate across delivery teams (percentage of active pipelines with configured and enforced quality gates) | — | — |
 | Number of distinct teams coached per quarter, with a defined engagement scope and measurable outcome | — | — |
 | Engineering practice maturity score delta — improvement in structured maturity assessment scores across coached teams | — | — |
-| Test coverage trend across teams using shared pipeline templates with quality gate enforcement | ≥80% (proposed) | Monthly |
+| Test coverage trend across teams using shared pipeline templates with quality gate enforcement | — | Monthly |
 | Definition of Done completeness rate — percentage of teams with formally documented and tool-embedded DoD criteria | — | — |
 | Practitioner feedback score from post-coaching engagement surveys — measuring coaching quality and perceived impact | — | — |
 | Golden path template adoption rate in Backstage — percentage of new projects starting from a quality-configured template | — | — |

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -152,7 +152,7 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 | Reproducibility of ML workflows | — | — |
 | Model monitoring coverage | — | — |
 | Feature engineering automation level | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Edge model deployment automation coverage: ≥80% of edge model updates delivered via automated pipelines | ≥80% | — |
 | Edge model drift detection rate: ≥90% of edge-deployed models under active performance monitoring | ≥90% | — |
 

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -115,8 +115,8 @@ The Observability Product Owner manages the observability platform portfolio, de
 |---|---|---|
 | Platform adoption rates across teams | — | — |
 | Stakeholder satisfaction with observability services | ≥85% (proposed) | Quarterly |
-| Roadmap initiatives delivered in the committed quarter (%) | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Effectiveness of observability in improving system reliability | — | — |
 | Clear demonstration of platform value to the business | — | — |
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -140,7 +140,7 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
 | Alignment of platform design with developer needs | — | — |
 | Platform architecture scalability and flexibility | — | — |
 | Developer experience improvement through architecture | — | — |

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -137,7 +137,7 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 |---|---|---|
 | Platform component reliability and uptime | ≥99.9% (proposed) | Monthly |
 | Implementation quality of platform features | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Developer onboarding efficiency | — | — |
 | Platform issue resolution time | — | — |
 | Self-service capability effectiveness | — | — |

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -139,8 +139,8 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 | Time-to-production for new applications | — | — |
 | Developer self-service capability utilization | — | — |
 | Reduction in developer toil through automation | — | — |
-| Platform services meeting their published SLO (%) | — | — |
-| Platform roadmap items delivered in the committed quarter (%) | — | — |
+| Platform services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
+| Platform roadmap items delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 | Delivery teams onboarded to a platform capability (count per quarter) | — | — |
 | Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in developer experience | — | — |

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -138,7 +138,7 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 |---|---|---|
 | Platform stability and reliability metrics | — | — |
 | Developer adoption of platform services | — | — |
-| Platform implementations accepted without post-deployment rework (%) | — | — |
+| Platform implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for platform incidents | — | — |
 | Developer experience satisfaction scores | ≥85% (proposed) | Quarterly |
 | Reduction in toil through platform automation | — | — |

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -144,7 +144,7 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 | Accuracy of capacity planning | — | — |
 | Effectiveness of observability solutions | — | — |
 | Quality of postmortem analysis and improvements | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -147,7 +147,7 @@ The Site Reliability Senior Engineer (Senior SRE) leads the technical implementa
 
 | Metric | Target | Frequency |
 |---|---|---|
-| SLO target achievement rate per service | — | — |
+| SLO target achievement rate per service | ≥95% (proposed) | Monthly |
 | Error budget consumption trends (healthy burn rate) | — | — |
 | Mean time to detect (MTTD) for P1/P2 incidents | ≤24 hours (proposed) | Monthly |
 | Mean time to recover (MTTR) for P1/P2 incidents | ≤4 hours (proposed) | Monthly |

--- a/Roles/modern_workplace/modern_workplace_architect.md
+++ b/Roles/modern_workplace/modern_workplace_architect.md
@@ -149,7 +149,7 @@ The Modern Workplace Architect is responsible for designing, governing, and evol
 | Microsoft Secure Score target achievement | — | — |
 | M365 Copilot adoption rate (active users / licensed users) | — | — |
 | DLP policy match and block accuracy rate | — | — |
-| eDiscovery case turnaround time (Legal SLA compliance) | ≥95% (proposed) | Monthly |
+| eDiscovery case turnaround time (Legal SLA compliance) | — | Monthly |
 | User satisfaction with collaboration tools (annual survey) | ≥85% (proposed) | Annual |
 
 ## Remote Work Considerations

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -135,7 +135,7 @@ The Modern Workplace Engineer administers and supports the organisation's Micros
 | Mailbox and Teams provisioning SLA compliance | ≥95% (proposed) | Monthly |
 | Help desk escalation resolution time | — | — |
 | M365 user lifecycle task completion accuracy | — | — |
-| Compliance task turnaround (eDiscovery, holds) within SLA | ≥95% (proposed) | Monthly |
+| Compliance task turnaround (eDiscovery, holds) within SLA | — | Monthly |
 | Knowledge base article currency and completeness | — | — |
 
 ## Remote Work Considerations

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -135,8 +135,8 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Network designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Network designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Network architecture scalability and flexibility | — | — |
 | Security posture improvement through network design | — | — |
 | Adoption of network reference architectures | — | — |

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -138,7 +138,7 @@ The Network Automation Engineer specializes in developing and implementing autom
 | Error reduction through automation | — | — |
 | Network change success rate improvement | — | — |
 | Code quality and reusability metrics | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Testing coverage for network automation | — | — |
 | Pipeline reliability and performance | — | — |
 | Innovation in automation approaches | — | — |

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -136,7 +136,7 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 | Network uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for network incidents | — | — |
 | Change implementation success rate | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Network security policy compliance | — | — |
 | Network monitoring coverage | — | — |
 | Response time to service requests | — | — |

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -135,11 +135,11 @@ The Network Product Owner manages the development and lifecycle of the organizat
 | Network service availability and reliability | ≥99.9% (proposed) | Monthly |
 | Time-to-delivery for network services | — | — |
 | Stakeholder satisfaction with network capabilities | ≥85% (proposed) | Quarterly |
-| Network devices compliant with the security baseline (%) | — | — |
+| Network devices compliant with the security baseline (%) | ≥95% (proposed) | Monthly |
 | Cost optimization achievements | — | — |
 | Successful delivery of network roadmap items | — | — |
 | Network service request fulfillment time | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Network capacity management accuracy | — | — |
 | Innovation in network service delivery | — | — |
 

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -135,8 +135,8 @@ The Network Senior Engineer leads the implementation and optimization of complex
 |---|---|---|
 | Network availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to resolution for complex network issues | — | — |
-| Network implementations accepted without post-deployment rework (%) | — | — |
-| Network devices compliant with the security baseline (%) | — | — |
+| Network implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
+| Network devices compliant with the security baseline (%) | ≥95% (proposed) | Monthly |
 | Knowledge transfer effectiveness to network engineers | — | — |
 | Network automation coverage and efficiency | — | — |
 | Success rate of network migrations and changes | — | — |

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -134,7 +134,7 @@ The Security Engineer implements and maintains security controls and technologie
 | Security control implementation quality | — | — |
 | Vulnerability remediation effectiveness | ≤30 days (critical) (proposed) | Monthly |
 | Security incident response time | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Security monitoring coverage | — | — |
 | Compliance with security standards | — | — |
 | Resolution time for security issues | — | — |

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -152,7 +152,7 @@ The Security Product Owner manages the development and lifecycle of the organiza
 | Compliance achievement percentage | — | — |
 | Successful delivery of security roadmap items | — | — |
 | Security awareness and adoption metrics | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Return on security investment metrics | — | — |
 | Security maturity improvement | — | — |
 

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -137,7 +137,7 @@ The Security Senior Engineer leads the implementation and optimization of comple
 | Time to resolve complex security issues | — | — |
 | Security automation coverage and effectiveness | — | — |
 | Knowledge transfer effectiveness to security engineers | — | — |
-| Assets compliant with the security baseline (%) | — | — |
+| Assets compliant with the security baseline (%) | ≥95% (proposed) | Monthly |
 | Reduction in security vulnerabilities | — | — |
 | Innovation in security approaches | — | — |
 | Customer satisfaction with security services | ≥85% (proposed) | Quarterly |

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -148,7 +148,7 @@ The Cloud Security Posture Manager implements and operates Cloud Security Postur
 | CIS Benchmark compliance score: maintain ≥80% pass rate across CIS Azure, AWS, and GCP Benchmarks per quarter | ≥80% | — |
 | CSPM finding recurrence rate: fewer than 10% of remediated findings reoccurring within 60 days | 10% | — |
 | Mean time to remediate (MTTR) critical findings: target ≤3 business days from identification to verified remediation | ≤3 business days | — |
-| Compliance posture trend: quarter-on-quarter improvement in overall benchmark compliance score across all three cloud platforms | ≥95% (proposed) | Monthly |
+| Compliance posture trend: quarter-on-quarter improvement in overall benchmark compliance score across all three cloud platforms | — | Monthly |
 | CSPM false positive rate: suppressed findings representing ≤15% of total active findings, with all suppressions documented and reviewed quarterly | ≤15% | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -141,12 +141,12 @@ The Security Cross-Platform Engineer implements and maintains security controls 
 | Reduction in security vulnerabilities across platforms | — | — |
 | Time to resolve security configuration issues | — | — |
 | Coverage of security monitoring across environments | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Compliance with security standards in implementations | — | — |
 | Time to implement critical security patches | — | — |
 | Success rate of security control testing | — | — |
 | Collaboration effectiveness with domain teams | — | — |
-| Assets compliant with the security baseline (%) | — | — |
+| Assets compliant with the security baseline (%) | ≥95% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -137,7 +137,7 @@ The Access Management Architect designs and oversees the organization's access m
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
 | Access-related security incidents (count per quarter) | — | — |
 | Improvement in access governance metrics | — | — |
 | Timely delivery of access architecture artifacts | — | — |

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -137,9 +137,9 @@ The Access Management Engineer implements and maintains access management system
 | Access certification campaign completion rates | — | — |
 | Time to revoke inappropriate access | — | — |
 | Access-related incident resolution time | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with access processes | ≥85% (proposed) | Quarterly |
-| Access implementations accepted without post-deployment rework (%) | — | — |
+| Access implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Self-service adoption for access requests | — | — |
 | Reduction in access-related security issues | — | — |
 

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -135,7 +135,7 @@ The Access Management Senior Engineer leads the implementation and optimization 
 |---|---|---|
 | Access management system availability | ≥99.9% (proposed) | Monthly |
 | Privileged access security effectiveness | — | — |
-| Access implementations accepted without post-deployment rework (%) | — | — |
+| Access implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolve complex access incidents | — | — |
 | Access certification campaign completion rates | — | — |
 | Automation level of access processes | — | — |

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -136,8 +136,8 @@ The Identity Management Engineer implements and maintains identity management sy
 | User provisioning and deprovisioning accuracy | — | — |
 | Authentication system performance | — | — |
 | Identity-related incident resolution time | — | — |
-| Identity implementations accepted without post-deployment rework (%) | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Identity implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Federation service reliability | — | — |
 | Password reset success rate | — | — |
 | Directory service synchronization accuracy | — | — |

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -135,11 +135,11 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 |---|---|---|
 | Identity system availability and reliability metrics | ≥99.9% (proposed) | Monthly |
 | Authentication service response times | — | — |
-| Identity implementations accepted without post-deployment rework (%) | — | — |
+| Identity implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex identity incidents | — | — |
 | Automation level achieved for identity operations | — | — |
 | Security posture improvement in identity systems | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Identity-related security incidents (count per quarter) | — | — |
 | Successful implementation of identity standards | — | — |
 | User satisfaction with authentication experience | ≥85% (proposed) | Quarterly |

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -131,9 +131,9 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Hardware designs accepted by the requesting business owner without rework (%) | — | — |
-| Server estate meeting its published SLO (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Hardware designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
+| Server estate meeting its published SLO (%) | ≥95% (proposed) | Monthly |
 | Data centre power usage effectiveness (PUE) | — | — |
 | Cost effectiveness of hardware architectures | — | — |
 | Adoption of reference architectures and standards | — | — |

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -141,7 +141,7 @@ The Server Hardware Engineer implements and maintains the physical server infras
 | Server deployment time efficiency | — | — |
 | Hardware-related incident resolution time | — | — |
 | Hardware configuration accuracy | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Firmware compliance percentage | — | — |
 | Hardware inventory accuracy | — | — |
 | Planned hardware maintenance completed in window (%) | — | — |

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -140,11 +140,11 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 | Metric | Target | Frequency |
 |---|---|---|
 | Server hardware availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Hardware implementations accepted without post-deployment rework (%) | — | — |
+| Hardware implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for critical hardware issues | — | — |
 | Hardware deployment automation effectiveness | — | — |
 | Power and cooling efficiency improvements | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Hardware standardization implementation success | — | — |
 | Success rate of hardware upgrades and refreshes | — | — |
 | New server platform patterns adopted into the standard build (count per year) | — | — |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -137,9 +137,9 @@ The HPE Server Hardware Architect designs and oversees the organization's server
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| Hardware designs accepted by the requesting business owner without rework (%) | — | — |
-| Server estate meeting its published SLO (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| Hardware designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
+| Server estate meeting its published SLO (%) | ≥95% (proposed) | Monthly |
 | Data centre power usage effectiveness (PUE) | — | — |
 | Cost effectiveness of hardware architectures | — | — |
 | Adoption of reference architectures and standards | — | — |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -165,7 +165,7 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 | Server deployment time efficiency | — | — |
 | Hardware-related incident resolution time | — | — |
 | Hardware configuration accuracy | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Firmware compliance percentage | — | — |
 | Hardware inventory accuracy | — | — |
 | Planned hardware maintenance completed in window (%) | — | — |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -135,7 +135,7 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 | Time to provision new server infrastructure | — | — |
 | Server capacity utilization efficiency | — | — |
 | Successful technology adoption rate | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Team velocity and productivity metrics | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -120,7 +120,7 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 | Server deployment accuracy and quality | — | — |
 | Implementation time for server infrastructure projects | — | — |
 | Server hardware incident resolution time | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Knowledge-sharing contributions published or presented (count per quarter) | — | — |
 | Automation implementation success rate | — | — |
 | Servers meeting their performance baseline after tuning (%) | — | — |

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -141,7 +141,7 @@ The Linux Server Architect designs and defines the strategic direction for the o
 | Technical debt reduction in Linux environments | — | — |
 | Time-to-delivery for new Linux capabilities and services | — | — |
 | Linux security posture improvement | — | — |
-| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -142,7 +142,7 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 | Linux server availability metrics | ≥99.9% (proposed) | Monthly |
 | Time to resolve Linux-related incidents | — | — |
 | Patch compliance percentage | ≥95% (proposed) | Monthly |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Security compliance scores | — | — |
 | Successful implementation of automation tasks | — | — |
 | Backup success rates and recovery capabilities | ≥99% (proposed) | Monthly |

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -138,11 +138,11 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 | Metric | Target | Frequency |
 |---|---|---|
 | Linux system availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Linux implementations accepted without post-deployment rework (%) | — | — |
+| Linux implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for critical Linux incidents | — | — |
 | Automation coverage for Linux administration tasks | — | — |
 | Security compliance scores for Linux environments | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of Linux standards | — | — |
 | Innovation in Linux platform enhancements | — | — |
 | Resource optimization achievements | — | — |

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -140,7 +140,7 @@ The Windows Server Architect designs and defines the strategic direction for the
 | Technical debt reduction in Windows environments | — | — |
 | Time-to-delivery for new Windows capabilities and services | — | — |
 | Windows security posture improvement | — | — |
-| Engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -144,7 +144,7 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 | Patch compliance percentages | ≥95% (proposed) | Monthly |
 | Time to implement standard server configurations | — | — |
 | Service request resolution time | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Group Policy implementation accuracy | — | — |
 | Backup success rate and recovery effectiveness | ≥99% (proposed) | Monthly |
 | Change implementation success rate | — | — |

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -156,9 +156,9 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 | Cost efficiency of Windows infrastructure | — | — |
 | Stakeholder satisfaction with server services | ≥85% (proposed) | Quarterly |
 | Windows Server automation efficiency | — | — |
-| Roadmap initiatives delivered in the committed quarter (%) | — | — |
+| Roadmap initiatives delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
 | Security compliance scores for server environment | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Service level objective achievement | — | — |
 
 ## Remote Work Considerations

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -143,14 +143,14 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 | Metric | Target | Frequency |
 |---|---|---|
 | Windows environment availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Windows implementations accepted without post-deployment rework (%) | — | — |
+| Windows implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolve critical Windows incidents | — | — |
 | Automation coverage for Windows administration | — | — |
 | Security compliance scores for Windows servers | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of Windows standards | — | — |
 | Servers meeting their performance baseline after tuning (%) | — | — |
-| Projects delivered in the committed period without post-go-live defects (%) | — | — |
+| Projects delivered in the committed period without post-go-live defects (%) | ≥80% (proposed) | Quarterly |
 | Innovation in Windows platform capabilities | — | — |
 
 ## Remote Work Considerations

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -131,8 +131,8 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Designs approved at first architecture review, without rework (%) | — | — |
-| ITSM designs accepted by the requesting business owner without rework (%) | — | — |
+| Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
+| ITSM designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Process efficiency and effectiveness metrics | — | — |
 | Service integration reliability | — | — |
 | Adoption of ITSM reference architectures | — | — |

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -136,7 +136,7 @@ The Service Management Engineer implements and maintains IT service management p
 | Time to complete service management requests | — | — |
 | Service catalog effectiveness | — | — |
 | Workflow automation success rate | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with ITSM tools | ≥85% (proposed) | Quarterly |
 | Reporting and dashboard utility | — | — |
 | Resolution time for ITSM platform issues | — | — |

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -133,9 +133,9 @@ The Service Management Senior Engineer leads the implementation and optimization
 |---|---|---|
 | ITSM platform availability and performance | ≥99.9% (proposed) | Monthly |
 | Workflow automation effectiveness | — | — |
-| ITSM implementations accepted without post-deployment rework (%) | — | — |
+| ITSM implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex platform issues | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | ITSM platform security and compliance | — | — |
 | Successful implementation of ITSM standards | — | — |
 | Innovation in service management solutions | — | — |

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -124,7 +124,7 @@ The Hyper-V Product Owner manages the lifecycle and roadmap of Microsoft virtual
 | Achievement of roadmap milestones and delivery objectives | — | — |
 | Effective prioritization of features and initiatives | — | — |
 | Quality of service metrics for Hyper-V environments | — | — |
-| Hyper-V capabilities accepted by the requesting business owner without rework (%) | — | — |
+| Hyper-V capabilities accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
 | Cost optimization and value delivery | — | — |
 | Clear backlog management and sprint execution | — | — |
 | Successful adoption of new Hyper-V features and capabilities | — | — |

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -125,12 +125,12 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 | Metric | Target | Frequency |
 |---|---|---|
 | Hyper-V environment reliability and uptime percentages | ≥99.9% (proposed) | Monthly |
-| Complex virtualization implementations accepted without post-deployment rework (%) | — | — |
+| Complex virtualization implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Success rate of migrations and upgrades | — | — |
 | Resolution time for complex virtualization issues | — | — |
 | Automation coverage for routine administrative tasks | — | — |
 | Provisioned capacity actively utilised (%) | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Contribution to virtualization standards and best practices | — | — |
 | Security posture improvement in virtualized environments | — | — |
 | Innovation in virtualization solutions implementation | — | — |

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -142,7 +142,7 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 | Virtual machine provisioning efficiency | — | — |
 | Time to resolve Nutanix-related incidents | — | — |
 | Successful completion of maintenance activities | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Provisioned capacity actively utilised (%) | — | — |
 | Patch compliance for Nutanix components | ≥95% (proposed) | Monthly |
 | Reduction in recurring incidents | — | — |

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -145,7 +145,7 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 | Time-to-delivery for platform enhancements | — | — |
 | Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Cost efficiency metrics for HCI resources | — | — |
-| Backlog items meeting the definition of ready before sprint planning (%) | — | — |
+| Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
 | Platform adoption rates across the organization | — | — |
 | Quality of service delivery documentation | — | — |
 | Platform automation and self-service capability | — | — |

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -133,11 +133,11 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 | Metric | Target | Frequency |
 |---|---|---|
 | Nutanix infrastructure availability and reliability | ≥99.9% (proposed) | Monthly |
-| HCI implementations accepted without post-deployment rework (%) | — | — |
+| HCI implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex Nutanix issues | — | — |
 | Automation coverage for Nutanix operations | — | — |
 | Provisioned capacity actively utilised (%) | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Success rate of migrations and upgrades | — | — |
 | Contribution to HCI standards and best practices | — | — |
 | Customer satisfaction with Nutanix services | ≥85% (proposed) | Quarterly |

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -139,7 +139,7 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 | VMware environment uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Virtual machine deployment time efficiency | — | — |
 | Resolution time for virtualization incidents | — | — |
-| Owned documentation reviewed and current within the agreed review cycle (%) | — | — |
+| Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Provisioned capacity actively utilised (%) | — | — |
 | Patch compliance for VMware components | ≥95% (proposed) | Monthly |
 | Backup success rates for virtual machines | ≥99% (proposed) | Monthly |

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -143,7 +143,7 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 | Resource utilization optimization metrics | — | — |
 | Success rate of infrastructure changes and migrations | — | — |
 | Resolution time for complex incidents | — | — |
-| Junior engineers reaching independent delivery within the agreed ramp period (%) | — | — |
+| Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Implementation of standards and best practices | — | — |
 | Improvement items proposed and adopted (count per quarter) | — | — |
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "node server.js",
     "test": "node --test",
     "validate": "node validate-roles.js",
-    "check-counts": "node scripts/check-counts.js"
+    "check-counts": "node scripts/check-counts.js",
+    "seed-kpi": "node scripts/seed-kpi-targets.js"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",

--- a/scripts/seed-kpi-targets.js
+++ b/scripts/seed-kpi-targets.js
@@ -1,0 +1,108 @@
+// Applies the KPI benchmark table in viewer-logic.js to every role file
+// (#140). Zero dependencies — run with `npm run seed-kpi` or
+// `node scripts/seed-kpi-targets.js [--dry]`.
+//
+// Three edits, each counted separately:
+//   drop      a "(proposed)" target the classifier now refuses -> em dash
+//   retarget  a "(proposed)" target the classifier now values differently
+//   seed      a blank row the classifier can give a starting point
+//
+// A row carrying a real (unmarked) target is never touched: that number was
+// agreed by someone, and no classifier gets to overrule it.
+//
+// This exists so the invariant is maintainable rather than hand-kept. The
+// suite asserts every "(proposed)" row in the catalogue matches what the
+// classifier produces for its metric; when a benchmark changes, this is what
+// makes the files match again.
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const { proposedKpiTarget } = require('../viewer-logic');
+
+const ROOT      = path.join(__dirname, '..');
+const ROLES_DIR = process.env.ROLES_DIR ? path.resolve(process.env.ROLES_DIR) : path.join(ROOT, 'Roles');
+const DRY       = process.argv.includes('--dry');
+
+function listRoleFiles(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) listRoleFiles(p, out);
+    else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(p);
+  }
+  return out;
+}
+
+// A blank cell and an em dash mean the same thing: no target yet.
+function isBareTarget(t) {
+  return !t || t === '—' || t === '-' || t === 'TBD';
+}
+
+function seedFile(filePath, { dry = false } = {}) {
+  const raw  = fs.readFileSync(filePath, 'utf8');
+  const bom  = raw.startsWith('﻿') ? '﻿' : '';
+  const crlf = /\r\n/.test(raw);
+  const lines = raw.replace(/^﻿/, '').replace(/\r\n/g, '\n').split('\n');
+
+  const counts = { drop: 0, retarget: 0, seed: 0, house: 0, benchmark: 0 };
+  let inKpi = false, headerRows = 0, changed = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^##\s/.test(line)) { inKpi = /^##\s+Key Performance Indicators/.test(line); headerRows = 0; continue; }
+    if (!inKpi || !line.trim().startsWith('|')) continue;
+    if (headerRows < 2) { headerRows++; continue; }   // header and delimiter
+
+    const cells = line.split('|');
+    if (cells.length < 4) continue;
+    const metric = (cells[1] || '').trim();
+    const target = (cells[2] || '').trim();
+    if (!metric) continue;
+
+    const isProposed = /\(proposed\)/i.test(target);
+    if (!isProposed && !isBareTarget(target)) continue;
+
+    const suggested = proposedKpiTarget(metric);
+
+    if (isProposed && !suggested) { cells[2] = ' — '; counts.drop++; }
+    else if (isProposed && suggested.target !== target) { cells[2] = ` ${suggested.target} `; counts.retarget++; }
+    else if (!isProposed && suggested) {
+      cells[2] = ` ${suggested.target} `;
+      // Only fill a cadence that is itself empty — an agreed frequency on an
+      // untargeted row is still someone's decision.
+      if (isBareTarget((cells[3] || '').trim())) cells[3] = ` ${suggested.frequency} `;
+      counts.seed++;
+      counts[suggested.basis === 'house' ? 'house' : 'benchmark']++;
+    } else continue;
+
+    lines[i] = cells.join('|');
+    changed = true;
+  }
+
+  if (changed && !dry) {
+    const body = lines.join('\n');
+    fs.writeFileSync(filePath, bom + (crlf ? body.replace(/\n/g, '\r\n') : body), 'utf8');
+  }
+  return { changed, counts };
+}
+
+function main() {
+  const totals = { drop: 0, retarget: 0, seed: 0, house: 0, benchmark: 0, files: 0 };
+  for (const file of listRoleFiles(ROLES_DIR)) {
+    const { changed, counts } = seedFile(file, { dry: DRY });
+    if (!changed) continue;
+    totals.files++;
+    for (const k of Object.keys(counts)) totals[k] += counts[k];
+  }
+
+  console.log(DRY ? 'Would change:' : 'Changed:');
+  console.log(`  ${totals.files} file(s)`);
+  console.log(`  ${totals.seed} row(s) seeded — ${totals.benchmark} from a published benchmark, ${totals.house} a house starting point`);
+  console.log(`  ${totals.retarget} row(s) re-targeted`);
+  console.log(`  ${totals.drop} row(s) returned to no target`);
+  if (totals.files === 0) console.log('  (files already match the benchmark table)');
+}
+
+if (require.main === module) main();
+
+module.exports = { seedFile, listRoleFiles, isBareTarget };

--- a/test/kpi-targets.test.js
+++ b/test/kpi-targets.test.js
@@ -1,0 +1,72 @@
+// Drift guard for the seeded KPI targets (#140).
+//
+// The 16 contradictory targets corrected in this cycle were found by hand
+// audit, and hand-kept state going stale is this repository's dominant bug
+// class. This asserts the catalogue and the benchmark table cannot disagree:
+// every "(proposed)" value in a role file must be exactly what
+// proposedKpiTarget() returns for that row's metric.
+//
+// It fails when a metric is reworded without re-seeding, when a target is
+// hand-typed as proposed, and when a benchmark changes in code without
+// `npm run seed-kpi` being run. Any of those is drift worth seeing.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { proposedKpiTarget } = require('../viewer-logic');
+const { listRoleFiles, seedFile, isBareTarget } = require('../scripts/seed-kpi-targets');
+
+const ROLES_DIR = path.join(__dirname, '..', 'Roles');
+
+function kpiRows(filePath) {
+  const body = fs.readFileSync(filePath, 'utf8').replace(/^﻿/, '').replace(/\r\n/g, '\n');
+  const section = body.split(/\n## /).find(s => /^Key Performance Indicators/.test(s));
+  if (!section) return [];
+  return section.split('\n')
+    .filter(l => l.trim().startsWith('|'))
+    .slice(2)
+    .map(l => l.split('|'))
+    .filter(c => c.length >= 4 && (c[1] || '').trim())
+    .map(c => ({ metric: c[1].trim(), target: (c[2] || '').trim() }));
+}
+
+test('every proposed KPI target matches what the benchmark table produces', () => {
+  let proposed = 0;
+  for (const file of listRoleFiles(ROLES_DIR)) {
+    for (const { metric, target } of kpiRows(file)) {
+      if (!/\(proposed\)/i.test(target)) continue;
+      proposed++;
+      const suggested = proposedKpiTarget(metric);
+      assert.ok(suggested,
+        `${path.basename(file)}: "${metric}" carries ${target} but the table no longer seeds it`);
+      assert.equal(suggested.target, target,
+        `${path.basename(file)}: "${metric}" should be ${suggested.target}`);
+    }
+  }
+  // Guards against the assertion passing because nothing was examined.
+  assert.ok(proposed > 300, `expected the catalogue to carry proposed targets, found ${proposed}`);
+});
+
+test('no untargeted KPI row is one the benchmark table could already fill', () => {
+  // The other direction: a blank row the table can seed means seed-kpi has
+  // not been run since the table last changed.
+  const missed = [];
+  for (const file of listRoleFiles(ROLES_DIR)) {
+    for (const { metric, target } of kpiRows(file)) {
+      if (!isBareTarget(target)) continue;
+      if (proposedKpiTarget(metric)) missed.push(`${path.basename(file)}: ${metric}`);
+    }
+  }
+  assert.deepEqual(missed, [], `run "npm run seed-kpi" — ${missed.length} row(s) can be seeded`);
+});
+
+test('seeding the catalogue again changes nothing', () => {
+  // The end-to-end form of both assertions above, through the tool the
+  // maintainer actually runs.
+  for (const file of listRoleFiles(ROLES_DIR)) {
+    const { changed } = seedFile(file, { dry: true });
+    assert.equal(changed, false, `${path.basename(file)} is out of date with the benchmark table`);
+  }
+});

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -6,6 +6,7 @@ const assert = require('node:assert/strict');
 const {
     STALE_MONTHS,
     proposedKpiTarget,
+    KPI_BENCHMARKS,
     parseKpiBullet,
     orgListHtml,
     graphListHtml,
@@ -1343,4 +1344,38 @@ test('proposedKpiTarget routes vulnerability MTTR to the remediation policy', ()
     const got = proposedKpiTarget(
         'Vulnerability mean time to remediate (MTTR) across critical and high severity findings');
     assert.match(got.target, /30 days/);
+});
+
+test('proposedKpiTarget seeds the further sourceable families', () => {
+    assert.match(proposedKpiTarget('Median lead time from commit to production for teams on the standard (hours)').target, /24 hours/);
+    assert.match(proposedKpiTarget('Platform services meeting their published SLO (%)').target, /95%/);
+    assert.match(proposedKpiTarget('Cloud accounts and subscriptions compliant with landing-zone guardrails (%)').target, /95%/);
+    assert.match(proposedKpiTarget('Support requests acknowledged within the agreed response window (%)').target, /95%/);
+});
+
+test('the DORA lead time figure is anchored to change lead time', () => {
+    // Not every duration called a lead time is the DORA one. Without the
+    // anchor this seeded ≤24 hours against an ML feature pipeline.
+    assert.equal(
+        proposedKpiTarget('ML feature pipeline production lead time (time from feature request to production availability)'),
+        null);
+});
+
+test('proposedKpiTarget separates published benchmarks from house starting points', () => {
+    // The distinction the marker cannot carry: "(proposed)" says the number
+    // is not agreed, but not whether anyone published it. A house figure
+    // must never be dressed up with a citation it does not have.
+    assert.equal(proposedKpiTarget('Change failure rate').basis, 'benchmark');
+    const house = proposedKpiTarget('Owned documentation reviewed and current within the agreed review cycle (%)');
+    assert.equal(house.basis, 'house');
+    assert.match(house.note, /no industry standard/i);
+    assert.match(house.target, /\(proposed\)$/);
+});
+
+test('every KPI benchmark declares its basis and a note', () => {
+    // A new entry added without a basis would be counted as published.
+    for (const b of KPI_BENCHMARKS) {
+        assert.ok(['benchmark', 'house'].includes(b.basis), `${b.re} needs a basis`);
+        assert.ok(b.note && b.note.length > 0, `${b.re} needs a note`);
+    }
 });

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -1282,3 +1282,65 @@ test('proposedKpiTarget matches the family, not an incidental word', () => {
     // "available" in prose must not trigger the availability benchmark.
     assert.equal(proposedKpiTarget('Documentation available to delivery teams'), null);
 });
+
+// ── proposedKpiTarget: seeding must not contradict the metric (#140) ──
+// Every string below is real content from a role file that the first pass
+// of benchmark matching seeded wrongly. They are the regression guard:
+// each had a keyword the benchmark table recognised, used in a sense the
+// benchmark does not apply to.
+
+test('proposedKpiTarget refuses a percentage target on a duration metric', () => {
+    // "availability" appears here as the endpoint of a lead time, not as
+    // the thing measured. Seeding 99.9% against a metric counted in hours
+    // is worse than leaving it blank: the validator counts it as awaiting
+    // confirmation rather than as wrong.
+    for (const m of [
+        'Model deployment lead time (hours from training completion to production endpoint availability, trending down)',
+        'ML feature pipeline production lead time (time from feature request to production availability)',
+        'eDiscovery case turnaround time (Legal SLA compliance)',
+    ]) {
+        assert.equal(proposedKpiTarget(m), null, `"${m}" must not be seeded`);
+    }
+});
+
+test('proposedKpiTarget refuses a percentage target on a counted metric', () => {
+    assert.equal(
+        proposedKpiTarget('Number of ad hoc financial analysis requests completed within SLA per quarter'),
+        null);
+});
+
+test('proposedKpiTarget refuses composite and trend metrics', () => {
+    // A metric naming several measures at once has no single target, and a
+    // metric asking for a direction of travel has no threshold at all.
+    for (const m of [
+        'DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR)',
+        'DORA metrics improvement per coached team: deployment frequency, lead time for changes, mean time to recovery, and change failure rate tracked before and after engagement',
+        'Improvement in delivery metrics (lead time, MTTR, etc.)',
+        'Improvements in deployment frequency and reliability',
+        'Backup success rate improvement trends',
+        'Security incident frequency, severity, and mean time to detect and respond',
+    ]) {
+        assert.equal(proposedKpiTarget(m), null, `"${m}" must not be seeded`);
+    }
+});
+
+test('proposedKpiTarget reads a list of products as scope, not as measures', () => {
+    // Reconciling the guard against all 258 seeded rows caught this: a
+    // comma-counting rule refused these, but each names one measure across
+    // several products. Only a row naming three actual measures is composite.
+    for (const m of [
+        'Microsoft 365 service availability (Exchange, Teams, SharePoint)',
+        'Data platform availability SLA (uptime % for Databricks, ingestion pipelines, and shared platform components)',
+        'Incident, Change, and Problem SLA compliance rates (platform impact contribution)',
+    ]) {
+        assert.ok(proposedKpiTarget(m), `"${m}" should still be seeded`);
+    }
+});
+
+test('proposedKpiTarget routes vulnerability MTTR to the remediation policy', () => {
+    // MTTR here means "time to remediate a finding", governed by the
+    // vulnerability policy, not the P1 restore commitment.
+    const got = proposedKpiTarget(
+        'Vulnerability mean time to remediate (MTTR) across critical and high severity findings');
+    assert.match(got.target, /30 days/);
+});

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -68,9 +68,10 @@ function hasKpiTable(body) {
 // proposed, or absent. Skips the header and delimiter rows.
 //
 // An em dash is how #140 renders a known gap and a blank cell must not be a
-// quieter way of saying the same thing. "(proposed)" marks a seeded industry
-// benchmark: a real starting point, but not yet an agreed commitment, so it
-// is counted apart rather than treated as done.
+// quieter way of saying the same thing. "(proposed)" marks a seeded starting
+// point — for some families a published benchmark, for others a house figure
+// where no standard exists — real either way, but not an agreed commitment,
+// so it is counted apart rather than treated as done.
 function kpiTargetCounts(body) {
   let missing = 0, proposed = 0;
   const rows = body.split(/\r?\n/).filter(l => l.trim().startsWith('|'));
@@ -177,7 +178,12 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
       warnings.push(`Key Performance Indicators has ${missing} row(s) with no target — a metric nobody can meet or miss is not yet a KPI`);
     }
     if (proposed > 0) {
-      warnings.push(`Key Performance Indicators has ${proposed} proposed target(s) awaiting confirmation — seeded from an industry benchmark, not yet agreed`);
+      // Deliberately does not say where the number came from. Some proposals
+      // are published benchmarks and some are house starting points for
+      // families nobody standardises, and the "(proposed)" marker in the file
+      // cannot tell them apart. Claiming an industry source for all of them
+      // would be the more comfortable wording and the false one.
+      warnings.push(`Key Performance Indicators has ${proposed} proposed target(s) awaiting confirmation — a starting point, not yet agreed`);
     }
   }
 

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -828,10 +828,12 @@
     const KPI_BENCHMARKS = [
         { re: /\bchange failure\b/i,                                    target: '≤15%',             frequency: 'Monthly',   note: 'DORA' },
         { re: /\bdeployment frequency\b/i,                              target: 'Weekly or better', frequency: 'Monthly',   note: 'DORA high performer' },
-        { re: /\b(mttr|mean time to (restore|repair|resolve)|time to restore)\b/i,
-                                                                        target: '≤4 hours',         frequency: 'Monthly',   note: 'common P1 restore commitment' },
-        { re: /\b(mttd|mean time to detect|time to detect)\b/i,         target: '≤24 hours',        frequency: 'Monthly',   note: 'common detection target' },
+        // Ahead of the MTTR rule: for a vulnerability, "time to remediate" is
+        // governed by the remediation policy, not the P1 restore commitment.
         { re: /\bvulnerab\w*\b[^|]*\b(remediat|resolv|closure)/i,       target: '≤30 days (critical)', frequency: 'Monthly', note: 'common remediation policy' },
+        { re: /\b(mttr|mean time to (restore|repair|resolve|recover)\w*|time to restore)\b/i,
+                                                                        target: '≤4 hours',         frequency: 'Monthly',   note: 'common P1 restore commitment' },
+        { re: /\b(mttd|mean time to detect\w*|time to detect)\b/i,      target: '≤24 hours',        frequency: 'Monthly',   note: 'common detection target' },
         { re: /\b(test|code)\s+coverage\b/i,                            target: '≥80%',             frequency: 'Monthly',   note: 'widely-used threshold' },
         { re: /\b(backup|recovery|restore)\b[^|]*\b(success|rate|test)/i, target: '≥99%',           frequency: 'Monthly',   note: 'standard data-protection target' },
         { re: /\bfirst[- ]contact\b/i,                                  target: '≥70%',             frequency: 'Monthly',   note: 'common service-desk target' },
@@ -844,12 +846,54 @@
                                                                         target: '≥99.9%',           frequency: 'Monthly',   note: 'three-nines enterprise SLA' },
     ];
 
+    // A metric that asks only for a direction of travel has no threshold to
+    // propose. Every pattern here comes from a real row that a benchmark
+    // keyword matched in a sense the benchmark does not cover.
+    const KPI_UNSEEDABLE = [
+        /\btrend\w*\b/i,
+        /\bimprovement\w*\b|\bimprovements? in\b/i,
+        /\betc\.?\b/i,
+    ];
+
+    // Counting measure nouns rather than commas. A list inside a metric is
+    // usually scope, not measures — "Microsoft 365 service availability
+    // (Exchange, Teams, SharePoint)" is one measure across three products,
+    // whereas "incident frequency, severity, and mean time to detect" is
+    // three measures in one row and has no single target.
+    const KPI_MEASURE_NOUN = /\b(frequency|severity|rate|time|uptime|availability|reliability|coverage|utilisation|utilization|latency|throughput|cost|accuracy|volume|score)\b/i;
+
+    function kpiMeasureCount(m) {
+        return m.split(/,|\band\b/i).filter(seg => KPI_MEASURE_NOUN.test(seg)).length;
+    }
+
+    // The unit the metric is counted in. Seeding "≥99.9%" against a lead time
+    // measured in hours is not a weaker proposal but a wrong one, and a wrong
+    // proposal hides the gap better than a blank does — the validator counts
+    // it as awaiting confirmation rather than as an error.
+    function kpiMetricUnit(m) {
+        if (/^\s*number of\b/i.test(m) || /\(count\b/i.test(m)) return 'count';
+        if (/\((hours?|days?|minutes?|seconds?|ms)\)/i.test(m)
+            || /\b(lead time|turnaround|mean time|time to)\b/i.test(m)) return 'duration';
+        if (/\(%\)|\bpercentage\b|\brate\b|\bscore\b/i.test(m)) return 'percent';
+        return null;
+    }
+
+    function kpiTargetUnit(t) {
+        if (/%/.test(t)) return 'percent';
+        if (/\b(hours?|days?|minutes?|seconds?)\b/i.test(t)) return 'duration';
+        return null;
+    }
+
     function proposedKpiTarget(metric) {
         const m = String(metric == null ? '' : metric);
+        if (KPI_UNSEEDABLE.some(re => re.test(m))) return null;
+        if (kpiMeasureCount(m) >= 3) return null;
+        const mUnit = kpiMetricUnit(m);
         for (const b of KPI_BENCHMARKS) {
-            if (b.re.test(m)) {
-                return { target: `${b.target} (proposed)`, frequency: b.frequency, note: b.note };
-            }
+            if (!b.re.test(m)) continue;
+            const tUnit = kpiTargetUnit(b.target);
+            if (mUnit && tUnit && mUnit !== tUnit) return null;
+            return { target: `${b.target} (proposed)`, frequency: b.frequency, note: b.note };
         }
         return null;
     }

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -825,25 +825,54 @@
     // Adoption rate and incident rate are deliberately absent: widely
     // measured, but with no established value to propose. A family with no
     // real benchmark gets no seed.
+    // `basis` records where the number came from, which "(proposed)" cannot
+    // say on its own: the marker means "not agreed", not "nobody published
+    // it". A 'benchmark' entry cites a real published source; a 'house' entry
+    // is a starting point for the conversation and says so in its note. The
+    // two are counted separately rather than blended, so a house figure is
+    // never mistaken for an industry standard.
     const KPI_BENCHMARKS = [
-        { re: /\bchange failure\b/i,                                    target: '≤15%',             frequency: 'Monthly',   note: 'DORA' },
-        { re: /\bdeployment frequency\b/i,                              target: 'Weekly or better', frequency: 'Monthly',   note: 'DORA high performer' },
+        { re: /\bchange failure\b/i,                                    target: '≤15%',             frequency: 'Monthly',   basis: 'benchmark', note: 'DORA' },
+        { re: /\bdeployment frequency\b/i,                              target: 'Weekly or better', frequency: 'Monthly',   basis: 'benchmark', note: 'DORA high performer' },
         // Ahead of the MTTR rule: for a vulnerability, "time to remediate" is
         // governed by the remediation policy, not the P1 restore commitment.
-        { re: /\bvulnerab\w*\b[^|]*\b(remediat|resolv|closure)/i,       target: '≤30 days (critical)', frequency: 'Monthly', note: 'common remediation policy' },
+        { re: /\bvulnerab\w*\b[^|]*\b(remediat|resolv|closure)/i,       target: '≤30 days (critical)', frequency: 'Monthly', basis: 'benchmark', note: 'common remediation policy' },
         { re: /\b(mttr|mean time to (restore|repair|resolve|recover)\w*|time to restore)\b/i,
-                                                                        target: '≤4 hours',         frequency: 'Monthly',   note: 'common P1 restore commitment' },
-        { re: /\b(mttd|mean time to detect\w*|time to detect)\b/i,      target: '≤24 hours',        frequency: 'Monthly',   note: 'common detection target' },
-        { re: /\b(test|code)\s+coverage\b/i,                            target: '≥80%',             frequency: 'Monthly',   note: 'widely-used threshold' },
-        { re: /\b(backup|recovery|restore)\b[^|]*\b(success|rate|test)/i, target: '≥99%',           frequency: 'Monthly',   note: 'standard data-protection target' },
-        { re: /\bfirst[- ]contact\b/i,                                  target: '≥70%',             frequency: 'Monthly',   note: 'common service-desk target' },
-        { re: /\b(patch|compliance)\b[^|]*\b(coverage|complian)/i,      target: '≥95%',             frequency: 'Monthly',   note: 'common security baseline' },
-        { re: /\bSLA\b/,                                                target: '≥95%',             frequency: 'Monthly',   note: 'typical service commitment' },
-        { re: /\b(csat|satisfaction|nps)\b/i,                           target: '≥85%',             frequency: 'Quarterly', note: 'common enterprise IT service target' },
+                                                                        target: '≤4 hours',         frequency: 'Monthly',   basis: 'benchmark', note: 'common P1 restore commitment' },
+        { re: /\b(mttd|mean time to detect\w*|time to detect)\b/i,      target: '≤24 hours',        frequency: 'Monthly',   basis: 'benchmark', note: 'common detection target' },
+        // Anchored to "commit": the DORA figure is about change lead time, not
+        // any duration that happens to be called a lead time.
+        { re: /\blead time\b[^|]*\bcommit\b|\blead time for changes\b/i, target: '≤24 hours',       frequency: 'Monthly',   basis: 'benchmark', note: 'DORA high performer' },
+        { re: /\b(test|code)\s+coverage\b/i,                            target: '≥80%',             frequency: 'Monthly',   basis: 'benchmark', note: 'widely-used threshold' },
+        { re: /\b(backup|recovery|restore)\b[^|]*\b(success|rate|test)/i, target: '≥99%',           frequency: 'Monthly',   basis: 'benchmark', note: 'standard data-protection target' },
+        { re: /\bfirst[- ]contact\b/i,                                  target: '≥70%',             frequency: 'Monthly',   basis: 'benchmark', note: 'common service-desk target' },
+        { re: /\b(patch|compliance)\b[^|]*\b(coverage|complian)/i,      target: '≥95%',             frequency: 'Monthly',   basis: 'benchmark', note: 'common security baseline' },
+        { re: /\bcomplian\w*\b[^|]*\b(baseline|guardrail|landing[- ]zone)|\b(baseline|guardrail)s?\b[^|]*\bcomplian/i,
+                                                                        target: '≥95%',             frequency: 'Monthly',   basis: 'benchmark', note: 'common security baseline' },
+        // SLO alongside SLA: the same commitment, named differently by the
+        // teams that publish one rather than the other.
+        { re: /\bSL[AO]\b/,                                             target: '≥95%',             frequency: 'Monthly',   basis: 'benchmark', note: 'typical service commitment' },
+        { re: /\backnowledg\w*\b[^|]*\b(response|window)\b/i,           target: '≥95%',             frequency: 'Monthly',   basis: 'benchmark', note: 'common service-desk response commitment' },
+        { re: /\b(csat|satisfaction|nps)\b/i,                           target: '≥85%',             frequency: 'Quarterly', basis: 'benchmark', note: 'common enterprise IT service target' },
         // Anchored to the noun so "documentation available to teams" does not
         // match — only uptime/availability used as the metric itself.
         { re: /\b(uptime|availability)\b(?!\s+(to|for|of\s+(the\s+)?(team|staff|stakeholder)))/i,
-                                                                        target: '≥99.9%',           frequency: 'Monthly',   note: 'three-nines enterprise SLA' },
+                                                                        target: '≥99.9%',           frequency: 'Monthly',   basis: 'benchmark', note: 'three-nines enterprise SLA' },
+
+        // House starting points. These families are measured everywhere and
+        // standardised nowhere: no body publishes a documentation-currency,
+        // first-pass-approval or ramp-completion figure. Left alone they stay
+        // blank indefinitely, so they carry a defensible opening number and an
+        // explicit statement of where it came from. Dressing one of these up
+        // with a citation it does not have would be the worse outcome.
+        { re: /\bdocumentation\b[^|]*\b(reviewed and current|current within|currency)\b/i,
+                                                                        target: '≥95%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bwithout (post-deployment )?rework\b|\b(approved|accepted|passing)\b[^|]*\bat first\b/i,
+                                                                        target: '≥80%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\breaching independent delivery\b|\bagreed ramp period\b/i,
+                                                                        target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\b(delivered|completed) in the committed\b/i,            target: '≥80%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bdefinition of ready\b/i,                               target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
     ];
 
     // A metric that asks only for a direction of travel has no threshold to
@@ -893,7 +922,7 @@
             if (!b.re.test(m)) continue;
             const tUnit = kpiTargetUnit(b.target);
             if (mUnit && tUnit && mUnit !== tUnit) return null;
-            return { target: `${b.target} (proposed)`, frequency: b.frequency, note: b.note };
+            return { target: `${b.target} (proposed)`, frequency: b.frequency, basis: b.basis, note: b.note };
         }
         return null;
     }


### PR DESCRIPTION
Three commits, deliberately separate. The correction should not be invisible inside the extension.

**Stacked on [#166](https://github.com/JeanKadang/DOC-ITRoles/pull/166)** (release 1.13.0), which had not merged because GitHub Actions stopped scheduling runs. Branching from it avoids a CHANGELOG conflict at the top of the file; merging this merges that too.

Refs #140 — the issue stays open, 1,267 rows still have no target.

## 1. `fix(kpi)` — 16 targets that contradict their own metric

Auditing all 258 rows seeded in 1.12.0 found the benchmark keyword matching incidentally rather than as the thing being measured:

| Was | Metric |
|---|---|
| `≥99.9%` | Model deployment lead time (hours … to production endpoint **availability**, trending down) |
| `≤4 hours` | Vulnerability mean time to remediate (**MTTR**) → now `≤30 days (critical)` |
| `≥95%` | **Number of** ad hoc analysis requests completed within SLA per quarter |
| `≤15%` | DORA metrics **trend** (deployment frequency, lead time, change failure rate, MTTR) |

**A wrong proposal is worse than a blank.** The validator counts a blank as a gap and a `(proposed)` value as awaiting confirmation — so a target that does not fit its metric is the one state that reads as progress while being false.

Three guards, each derived from rows that defeated the first pass:

- **unit conflict** — no percentage on a metric counted in hours or in units of work, and vice versa
- **direction-only** — `trend`, `improvement`, `etc.` name a direction of travel, which has no threshold
- **composite** — counted by measure nouns, not commas

The guard was reconciled against all 258 rows before use, and refused two the hand audit had passed. Both were *product* lists rather than *measure* lists — `Microsoft 365 service availability (Exchange, Teams, SharePoint)` is one measure across three products. That is what moved the composite rule off comma counting.

## 2. `feat(kpi)` — 179 more proposed targets, marked by basis

| Basis | Rows | Examples |
|---|---|---|
| Published benchmark | **275** | DORA change lead time `≤24 hours`, SLO attainment and guardrail compliance `≥95%` |
| House starting point | **152** | documentation currency `≥95%`, first-review approval `≥80%`, ramp completion `≥90%` |

**The distinction `(proposed)` cannot carry** is whether anybody published the number. The three house families are the largest in the catalogue — documentation currency (33 rows), accepted without rework (85), ramp completion (32) — and are standardised nowhere. Each entry declares `basis: 'house'` with the note *"no industry standard; house starting point for discussion"*; a test asserts every entry declares a basis, so one cannot be added as published by omission.

The validator no longer calls proposals *"seeded from an industry benchmark"* — false for 152 of the 427.

**Known limit:** `basis` is not visible in the markdown. A house `≥95%` and a DORA `≤15%` are identical strings in the file; only the code and the changelog distinguish them. Surfacing it means changing the marker, the validator regex and 152 rows — a follow-up, not part of this.

## 3. `test(kpi)` — the audit becomes an assertion

The 16 bad rows were found by hand. Hand-kept state going stale is this repository's dominant bug class (#18, #46 and #141 were one miscount in three lists), so:

- every `(proposed)` value must equal what `proposedKpiTarget()` returns for its metric
- no untargeted row may be one the table could already fill
- re-running the seeder must change nothing

All three were confirmed to fail on a one-character edit to a seeded value before being kept, and the first asserts it examined 300+ rows so it cannot pass vacuously.

`scripts/seed-kpi-targets.js` ships as `npm run seed-kpi` (`--dry` to preview) — the transform was a throwaway script until the suite started requiring the files and the table to agree. A dry run against the committed catalogue reports zero changes.

## Still open, deliberately

**1,267 of 1,941 rows have no target** (from 1,436). The three largest remaining families are counts — engineers mentored (22), knowledge-sharing sessions delivered (20), contributions published (20). A target there depends on team size and on what the organisation asks of the role, so there is no defensible figure to propose and they stay blank.

## Test plan

- [x] `npm test` — 202 pass, 0 fail (190 → 202; every new benchmark test uses the real string from the file)
- [x] `npm run validate` — 0 errors · `npm run check-counts` — README matches
- [x] `markdownlint-cli2 CHANGELOG.md` — 0 issues
- [x] Metric cells verified unchanged across all 200 edited rows — only Target and Frequency moved
- [x] `index.html` confirmed not to call `proposedKpiTarget` — the seeder runs at authoring time only, so no house figure reaches the UI unlabelled by a path the file check would miss
- [x] Rendered in the viewer: `API Platform Senior Engineer` shows `≥80% (proposed)` and `≥90% (proposed)` in its KPI table, no console errors