### PR TITLE
feat(kpi): indicative numbers for every untargeted row that states a unit

### DIFF
--- a/Roles/FinOps/finops_engineer.md
+++ b/Roles/FinOps/finops_engineer.md
@@ -151,7 +151,7 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 | Quality of cost optimization implementations | — | — |
 | Effectiveness of monitoring and alerting setup | — | — |
 | Resource tagging compliance percentage | — | — |
-| Eligible spend covered by reserved or committed capacity (%) | — | — |
+| Eligible spend covered by reserved or committed capacity (%) | 70–80% (proposed) | Quarterly |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with cost management tools | ≥85% (proposed) | Quarterly |
 | Problem resolution time for billing issues | — | — |

--- a/Roles/FinOps/finops_product_owner.md
+++ b/Roles/FinOps/finops_product_owner.md
@@ -157,7 +157,7 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 | Adoption of FinOps practices across teams | — | — |
 | Quality of backlog management | — | — |
 | Unit economics improvement metrics | — | — |
-| Eligible spend covered by reserved or committed capacity (%) | — | — |
+| Eligible spend covered by reserved or committed capacity (%) | 70–80% (proposed) | Quarterly |
 | FinOps maturity progression | — | — |
 
 ## Remote Work Considerations

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -142,8 +142,8 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 | Reduction in API architectural risks and technical debt | — | — |
 | Median lead time from commit to production for teams on the standard (hours) | ≤24 hours (proposed) | Monthly |
 | Innovation in API architectural approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -133,14 +133,14 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
 | .NET designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
-| Application transactions meeting their response-time budget (%) | — | — |
+| Application transactions meeting their response-time budget (%) | ≥95% (proposed) | Monthly |
 | Security posture of .NET applications | — | — |
 | Adoption of .NET reference architectures and patterns | — | — |
-| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Median lead time from commit to production for teams on the standard (hours) | ≤24 hours (proposed) | Monthly |
 | Innovation in .NET architectural approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -133,16 +133,16 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Code quality gate pass rate on the main branch (%) | — | — |
+| Code quality gate pass rate on the main branch (%) | ≥90% (proposed) | Monthly |
 | Timely completion of development tasks | — | — |
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Work conforming to .NET coding standards (%) | — | — |
+| Work conforming to .NET coding standards (%) | ≥95% (proposed) | Quarterly |
 | Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Support requests acknowledged within the agreed response window (%) | ≥95% (proposed) | Monthly |
-| Application transactions meeting their response-time budget (%) | — | — |
+| Application transactions meeting their response-time budget (%) | ≥95% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -138,7 +138,7 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 | Platform services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Security vulnerability reduction in .NET applications | — | — |
 | Platform roadmap items delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
-| Delivery teams onboarded to a platform capability (count per quarter) | — | — |
+| Delivery teams onboarded to a platform capability (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in .NET capabilities | — | — |
 

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -132,13 +132,13 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 | Metric | Target | Frequency |
 |---|---|---|
 | .NET platform reliability and performance metrics | — | — |
-| Code quality gate pass rate on the main branch (%) | — | — |
+| Code quality gate pass rate on the main branch (%) | ≥90% (proposed) | Monthly |
 | .NET implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex .NET issues | — | — |
 | Junior developers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | .NET security posture improvement | — | — |
 | Successful implementation of .NET standards | — | — |
-| Recorded technical debt items closed (count per quarter) | — | — |
+| Recorded technical debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Innovation in .NET platform capabilities | — | — |
 | Median lead time from commit to production for teams on the framework (hours) | ≤24 hours (proposed) | Monthly |
 

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -133,14 +133,14 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
 | Java designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
-| Application transactions meeting their response-time budget (%) | — | — |
+| Application transactions meeting their response-time budget (%) | ≥95% (proposed) | Monthly |
 | Security posture of Java applications | — | — |
 | Adoption of Java reference architectures and patterns | — | — |
-| Recorded architectural risks and debt items closed (count per quarter) | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Median lead time from commit to production for teams on the standard (hours) | ≤24 hours (proposed) | Monthly |
 | Innovation in Java architectural approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -133,16 +133,16 @@ The Java Engineer implements and maintains Java-based applications and platform 
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Code quality gate pass rate on the main branch (%) | — | — |
+| Code quality gate pass rate on the main branch (%) | ≥90% (proposed) | Monthly |
 | Timely completion of development tasks | — | — |
 | Unit test coverage percentage | ≥80% (proposed) | Monthly |
 | Number of defects in delivered code | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Work conforming to Java coding standards (%) | — | — |
+| Work conforming to Java coding standards (%) | ≥95% (proposed) | Quarterly |
 | Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Support requests acknowledged within the agreed response window (%) | ≥95% (proposed) | Monthly |
-| Application transactions meeting their response-time budget (%) | — | — |
+| Application transactions meeting their response-time budget (%) | ≥95% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -139,7 +139,7 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 | Platform services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Security vulnerability reduction in Java applications | — | — |
 | Platform roadmap items delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
-| Delivery teams onboarded to a platform capability (count per quarter) | — | — |
+| Delivery teams onboarded to a platform capability (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in Java capabilities | — | — |
 

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -133,13 +133,13 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 | Metric | Target | Frequency |
 |---|---|---|
 | Java platform reliability and performance metrics | — | — |
-| Code quality gate pass rate on the main branch (%) | — | — |
+| Code quality gate pass rate on the main branch (%) | ≥90% (proposed) | Monthly |
 | Java implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex Java issues | — | — |
 | Junior developers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Java security posture improvement | — | — |
 | Successful implementation of Java standards | — | — |
-| Recorded technical debt items closed (count per quarter) | — | — |
+| Recorded technical debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Innovation in Java platform capabilities | — | — |
 | Median lead time from commit to production for teams on the framework (hours) | ≤24 hours (proposed) | Monthly |
 

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -147,10 +147,10 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 | Cost efficiency of designed cloud solutions | — | — |
 | Cloud designs passing security review at first submission (%) | ≥80% (proposed) | Quarterly |
 | Adoption of cloud reference architectures and patterns | — | — |
-| Recorded architectural risks and debt items closed (count per quarter) | — | — |
-| New cloud patterns adopted into the reference architecture (count per year) | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
+| New cloud patterns adopted into the reference architecture (count per year) | ≥2 per year (proposed) | Annually |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -136,10 +136,10 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 | AWS cost management effectiveness | — | — |
 | Security compliance in AWS environments | — | — |
 | Documentation quality for AWS configurations | — | — |
-| Deployments using an approved reference pattern (%) | — | — |
+| Deployments using an approved reference pattern (%) | ≥90% (proposed) | Quarterly |
 | AWS resource utilization efficiency | — | — |
 | User satisfaction with AWS services | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -134,7 +134,7 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 | AWS service adoption rates | — | — |
 | Cloud migration project success rates | — | — |
 | AWS platform feature delivery against roadmap | — | — |
-| Cloud platform requests fulfilled without manual intervention (%) | — | — |
+| Cloud platform requests fulfilled without manual intervention (%) | ≥80% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -138,7 +138,7 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of AWS standards and patterns | — | — |
 | Projects delivered in the committed period without post-go-live defects (%) | ≥80% (proposed) | Quarterly |
-| New patterns or tooling adopted into the standard (count per year) | — | — |
+| New patterns or tooling adopted into the standard (count per year) | ≥2 per year (proposed) | Annually |
 | Customer satisfaction with AWS services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -141,10 +141,10 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 | Cost efficiency of designed cloud solutions | — | — |
 | Cloud designs passing security review at first submission (%) | ≥80% (proposed) | Quarterly |
 | Adoption of cloud reference architectures and patterns | — | — |
-| Recorded architectural risks and debt items closed (count per quarter) | — | — |
-| New cloud patterns adopted into the reference architecture (count per year) | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
+| New cloud patterns adopted into the reference architecture (count per year) | ≥2 per year (proposed) | Annually |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -132,7 +132,7 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 | Quality of IaC implementation | — | — |
 | Security compliance in Azure deployments | — | — |
 | Documentation quality for Azure configurations | — | — |
-| Deployments using an approved reference pattern (%) | — | — |
+| Deployments using an approved reference pattern (%) | ≥90% (proposed) | Quarterly |
 | Azure service monitoring coverage | — | — |
 | Knowledge sharing with team members | — | — |
 

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -134,7 +134,7 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 | PaaS service adoption rates | — | — |
 | Migrations completed in the committed window without rollback (%) | ≥80% (proposed) | Quarterly |
 | Azure platform feature delivery against roadmap | — | — |
-| Cloud platform requests fulfilled without manual intervention (%) | — | — |
+| Cloud platform requests fulfilled without manual intervention (%) | ≥80% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -139,7 +139,7 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Timely delivery of Azure implementation projects | — | — |
 | Customer satisfaction scores for cloud services | ≥85% (proposed) | Quarterly |
-| Improvement items proposed and adopted (count per quarter) | — | — |
+| Improvement items proposed and adopted (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -141,10 +141,10 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 | Cost efficiency of designed cloud solutions | — | — |
 | Cloud designs passing security review at first submission (%) | ≥80% (proposed) | Quarterly |
 | Adoption of cloud reference architectures and patterns | — | — |
-| Recorded architectural risks and debt items closed (count per quarter) | — | — |
-| New cloud patterns adopted into the reference architecture (count per year) | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Recorded architectural risks and debt items closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
+| New cloud patterns adopted into the reference architecture (count per year) | ≥2 per year (proposed) | Annually |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -136,10 +136,10 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 | GCP cost management effectiveness | — | — |
 | Security compliance in GCP environments | — | — |
 | Documentation quality for GCP configurations | — | — |
-| Deployments using an approved reference pattern (%) | — | — |
+| Deployments using an approved reference pattern (%) | ≥90% (proposed) | Quarterly |
 | GCP resource utilization efficiency | — | — |
 | User satisfaction with GCP services | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -138,7 +138,7 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 | GCP service adoption rates | — | — |
 | Migrations completed in the committed window without rollback (%) | ≥80% (proposed) | Quarterly |
 | GCP platform feature delivery against roadmap | — | — |
-| Cloud platform requests fulfilled without manual intervention (%) | — | — |
+| Cloud platform requests fulfilled without manual intervention (%) | ≥80% (proposed) | Monthly |
 
 ## Remote Work Considerations
 

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -138,7 +138,7 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of GCP standards and patterns | — | — |
 | Projects delivered in the committed period without post-go-live defects (%) | ≥80% (proposed) | Quarterly |
-| New patterns or tooling adopted into the standard (count per year) | — | — |
+| New patterns or tooling adopted into the standard (count per year) | ≥2 per year (proposed) | Annually |
 | Customer satisfaction with GCP services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -136,10 +136,10 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 | Cost efficiency of designed solutions | — | — |
 | Storage performance and availability metrics | ≥99.9% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
-| Recorded architectural risks closed (count per quarter) | — | — |
+| Recorded architectural risks closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Innovation in storage approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -131,10 +131,10 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 | Resolution time for storage incidents | — | — |
 | File system performance optimization | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Planned maintenance completed in window without unplanned impact (%) | — | — |
+| Planned maintenance completed in window without unplanned impact (%) | ≥95% (proposed) | Quarterly |
 | Protected workloads passing their most recent recovery test (%) | ≥99% (proposed) | Monthly |
 | User satisfaction with file services | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Capacity utilization efficiency | — | — |
 
 ## Remote Work Considerations

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -158,7 +158,7 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 | Storage implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Cost optimization achievements | — | — |
 | Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
-| New storage capabilities released to consuming teams (count per year) | — | — |
+| New storage capabilities released to consuming teams (count per year) | ≥2 per year (proposed) | Annually |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -137,11 +137,11 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 | Resolution time for storage incidents | — | — |
 | Storage utilization efficiency | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Planned maintenance completed in window without unplanned impact (%) | — | — |
+| Planned maintenance completed in window without unplanned impact (%) | ≥95% (proposed) | Quarterly |
 | Storage performance consistency | — | — |
 | Protected workloads passing their most recent recovery test (%) | ≥99% (proposed) | Monthly |
 | User satisfaction with storage services | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -140,7 +140,7 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 | Storage implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Cost optimization achievements | — | — |
 | Backlog items meeting the definition of ready before sprint planning (%) | ≥90% (proposed) | Quarterly |
-| New storage capabilities released to consuming teams (count per year) | — | — |
+| New storage capabilities released to consuming teams (count per year) | ≥2 per year (proposed) | Annually |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -138,7 +138,7 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 | Automation level of reliability processes | — | — |
 | Accuracy of reliability metrics | — | — |
 | SLO/SLA achievement for backup services | ≥95% (proposed) | Monthly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -132,14 +132,14 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
 | Solution designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
-| Protected workloads within the supported backup architecture (%) | — | — |
+| Protected workloads within the supported backup architecture (%) | ≥95% (proposed) | Quarterly |
 | Cost efficiency of designed solutions | — | — |
 | Recovery tests meeting their stated RTO (%) | ≥99% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
-| Recorded architectural risks closed (count per quarter) | — | — |
+| Recorded architectural risks closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Innovation in data protection approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -149,13 +149,13 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 |---|---|---|
 | Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievements | — | — |
-| Protected workloads meeting their stated RPO (%) | — | — |
+| Protected workloads meeting their stated RPO (%) | ≥99% (proposed) | Monthly |
 | Stakeholder satisfaction with data protection services | ≥85% (proposed) | Quarterly |
 | Backup compliance and audit readiness | — | — |
 | Data protection cost efficiency | — | — |
 | Storage optimization metrics (deduplication ratios) | — | — |
 | Successful delivery of backup roadmap items | — | — |
-| Backup jobs running without manual intervention (%) | — | — |
+| Backup jobs running without manual intervention (%) | ≥80% (proposed) | Monthly |
 | Backup platform availability and reliability | ≥99.9% (proposed) | Monthly |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -131,12 +131,12 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 |---|---|---|
 | Backup success rate and reliability | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievement | — | — |
-| Protected workloads meeting their stated RPO (%) | — | — |
+| Protected workloads meeting their stated RPO (%) | ≥99% (proposed) | Monthly |
 | Backup window optimization | — | — |
 | Data protection implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex backup incidents | — | — |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
-| Backup operations performed without manual intervention (%) | — | — |
+| Backup operations performed without manual intervention (%) | ≥80% (proposed) | Monthly |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Storage efficiency metrics (deduplication, compression) | — | — |
 

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -131,14 +131,14 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
 | Solution designs accepted by the requesting business owner without rework (%) | ≥80% (proposed) | Quarterly |
-| Protected workloads within the supported backup architecture (%) | — | — |
+| Protected workloads within the supported backup architecture (%) | ≥95% (proposed) | Quarterly |
 | Cost efficiency of designed solutions | — | — |
 | Recovery tests meeting their stated RTO (%) | ≥99% (proposed) | Monthly |
 | Adoption of reference architectures and standards | — | — |
 | Reduction in data protection architectural risks | — | — |
 | Innovation in backup approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -131,7 +131,7 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Response time to backup failures | — | — |
 | Recovery testing success rates | ≥99% (proposed) | Monthly |
-| Work conforming to data retention requirements (%) | — | — |
+| Work conforming to data retention requirements (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with backup/recovery services | ≥85% (proposed) | Quarterly |
 | Efficiency of storage utilization for backups | — | — |
 

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -141,13 +141,13 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 |---|---|---|
 | Backup success rate percentage | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievements | — | — |
-| Protected workloads meeting their stated RPO (%) | — | — |
+| Protected workloads meeting their stated RPO (%) | ≥99% (proposed) | Monthly |
 | Stakeholder satisfaction with recovery capabilities | ≥85% (proposed) | Quarterly |
 | Data protection compliance scores | — | — |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Backup storage efficiency metrics | — | — |
 | Incident reduction in backup operations | — | — |
-| Backup jobs running without manual intervention (%) | — | — |
+| Backup jobs running without manual intervention (%) | ≥80% (proposed) | Monthly |
 | Cross-team deliverables completed in the committed period (%) | ≥80% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -127,12 +127,12 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 |---|---|---|
 | Backup success rate and reliability metrics | ≥99% (proposed) | Monthly |
 | Recovery time objective (RTO) achievement | — | — |
-| Protected workloads meeting their stated RPO (%) | — | — |
+| Protected workloads meeting their stated RPO (%) | ≥99% (proposed) | Monthly |
 | Backup storage efficiency (deduplication ratios) | — | — |
 | Data protection implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex backup incidents | — | — |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
-| Backup operations performed without manual intervention (%) | — | — |
+| Backup operations performed without manual intervention (%) | ≥80% (proposed) | Monthly |
 | Successful recovery testing completion rates | ≥99% (proposed) | Monthly |
 | Business continuity improvement metrics | — | — |
 

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -139,8 +139,8 @@ The Database Architect designs comprehensive data management strategies and arch
 | Reduction in data-related architectural risks | — | — |
 | Database modernization progress and benefits | — | — |
 | Innovation in data management approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -147,7 +147,7 @@ The Database Engineer implements and maintains database systems across the organ
 | User satisfaction with database services | ≥85% (proposed) | Quarterly |
 | Implementation quality of standard configurations | — | — |
 | Security compliance with database policies | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -148,7 +148,7 @@ The Database Product Owner manages the portfolio of database platforms and data 
 | Metric | Target | Frequency |
 |---|---|---|
 | Database platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Median query execution time for tuned workloads (ms) | — | — |
+| Median query execution time for tuned workloads (ms) | ≤200 ms (proposed) | Monthly |
 | Time to provision new database environments | — | — |
 | Database incident reduction trends | — | — |
 | Cost efficiency of database resources | — | — |

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -134,13 +134,13 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 | Database uptime and availability metrics | ≥99.9% (proposed) | Monthly |
 | Mean time to detect (MTTD) database issues | ≤24 hours (proposed) | Monthly |
 | Mean time to resolve (MTTR) database failures | ≤4 hours (proposed) | Monthly |
-| Median query execution time for tuned workloads (ms) | — | — |
+| Median query execution time for tuned workloads (ms) | ≤200 ms (proposed) | Monthly |
 | Successful automated recovery percentage | — | — |
 | Reduction in database incidents over time | — | — |
 | Database scaling effectiveness | — | — |
 | Automated operations percentage | — | — |
 | SLO/SLA achievement for database services | ≥95% (proposed) | Monthly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -136,7 +136,7 @@ The Database Senior Engineer leads the implementation and optimization of comple
 | Metric | Target | Frequency |
 |---|---|---|
 | Database availability and performance metrics | ≥99.9% (proposed) | Monthly |
-| Median query execution time for tuned workloads (ms) | — | — |
+| Median query execution time for tuned workloads (ms) | ≤200 ms (proposed) | Monthly |
 | Database implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Mean time to resolution for critical database issues | — | — |
 | Knowledge transfer effectiveness to database engineers | — | — |

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -141,8 +141,8 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 | Adoption of DevOps reference architectures and patterns | — | — |
 | Reduction in delivery-related incidents | — | — |
 | Number of novel pipeline patterns adopted and operationalized per quarter; percentage of teams using self-service golden path tooling | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Improvement in delivery metrics (lead time, MTTR, etc.) | — | Monthly |
 
 ## Remote Work Considerations

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -119,7 +119,7 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 | Improvements in deployment frequency and reliability | — | Monthly |
 | Quality of pipeline templates and reusable components | — | — |
 | Effectiveness of self-service DevOps capabilities | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
 | Contribution to DevOps standards and best practices | — | — |
 | Innovation in delivery automation approaches | — | — |
 

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -145,7 +145,7 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Issue resolution time for SCCM-related problems | — | — |
 | Endpoint inventory accuracy | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -136,11 +136,11 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 | Onboarding architecture scalability and flexibility | — | — |
 | Standardization level across infrastructure domains | — | — |
 | Time-to-provision improvements through architecture | — | — |
-| Recorded architectural risks closed (count per quarter) | — | — |
+| Recorded architectural risks closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Adoption of reference architectures and patterns | — | — |
 | Innovation in infrastructure provisioning approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -140,7 +140,7 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 | Time to resolve provisioning incidents | — | — |
 | Quality of service catalog items and descriptions | — | — |
 | Self-service adoption metrics | — | — |
-| Work conforming to infrastructure standards (%) | — | — |
+| Work conforming to infrastructure standards (%) | ≥95% (proposed) | Quarterly |
 | Process improvement contributions | — | — |
 
 ## Remote Work Considerations

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -138,9 +138,9 @@ The Application Configuration Management Architect designs comprehensive strateg
 | Adoption of configuration reference architectures | — | — |
 | Reduction in configuration-related incidents | — | — |
 | Configuration automation maturity improvement | — | — |
-| New configuration patterns adopted into the standard (count per year) | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| New configuration patterns adopted into the standard (count per year) | ≥2 per year (proposed) | Annually |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -141,7 +141,7 @@ The Application Configuration Management Engineer implements and maintains confi
 | Configuration management automation level | — | — |
 | Environment configuration consistency | — | — |
 | User satisfaction with configuration services | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -139,7 +139,7 @@ The Application Configuration Management Senior Engineer leads the implementatio
 | Resolution time for configuration incidents | — | — |
 | Engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Standardization level of configuration practices | — | — |
-| New configuration patterns adopted into the standard (count per year) | — | — |
+| New configuration patterns adopted into the standard (count per year) | ≥2 per year (proposed) | Annually |
 | Security compliance of configuration processes | — | — |
 | Stakeholder satisfaction with configuration services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -132,7 +132,7 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 
 | Metric | Target | Frequency |
 |---|---|---|
-| Committed sprint items delivered in the sprint (%) | — | — |
+| Committed sprint items delivered in the sprint (%) | ≥80% (proposed) | Monthly |
 | ITSM platform user satisfaction score (CSAT) | ≥85% (proposed) | Quarterly |
 | CMDB CI accuracy rate (target: >95% for in-scope CI classes) | >95% | — |
 | Service request self-service adoption rate (trend: increasing) | — | — |

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -138,7 +138,7 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 | Security compliance in Kubernetes environments | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Implementation quality of standard patterns | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Kubernetes automation implementation | — | — |
 | User satisfaction with container platform | ≥85% (proposed) | Quarterly |
 | Cluster resource utilization efficiency | — | — |

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -117,7 +117,7 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 | Deployment automation effectiveness | — | — |
 | Knowledge transfer metrics for mentored engineers | — | — |
 | Kubernetes platform security posture scores | — | — |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Contribution to platform standards adoption | — | — |
 | Implementation of innovative container solutions | — | — |
 | Reduced operational overhead through automation | — | — |

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -140,7 +140,7 @@ The Data & AI Chapter Lead is the most senior technical manager and people leade
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| New architect and senior engineer hires retained at 90 days (%) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | ≥95% (proposed) | Quarterly |
 | Chapter satisfaction score (internal survey results for the Data & AI chapter) | ≥85% (proposed) | Quarterly |
 | Data platform adoption and coverage across the organisation's data domains | — | — |
 | Data quality scores for critical business data domains | — | — |

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -139,7 +139,7 @@ The DevOps & Delivery Chapter Lead is the most senior technical manager and peop
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| New architect and senior engineer hires retained at 90 days (%) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | ≥95% (proposed) | Quarterly |
 | Chapter satisfaction score (internal survey results for the DevOps & Delivery chapter) | ≥85% (proposed) | Quarterly |
 | DORA metrics trend at chapter level (deployment frequency, lead time, change failure rate, MTTR) | — | Monthly |
 | IDP adoption rate across development teams | — | — |

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -141,7 +141,7 @@ The End User & Workplace Chapter Lead is the most senior technical manager and p
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| New architect and senior engineer hires retained at 90 days (%) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | ≥95% (proposed) | Quarterly |
 | Chapter satisfaction score (internal survey results for the End User & Workplace chapter) | ≥85% (proposed) | Quarterly |
 | Device management coverage and compliance rate across all managed endpoints | — | — |
 | Microsoft 365 governance compliance rate — adherence to tenant standards and Teams governance policies | — | — |

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -141,7 +141,7 @@ The Security & Identity Chapter Lead is the organisation's most senior security 
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| New architect and senior engineer hires retained at 90 days (%) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | ≥95% (proposed) | Quarterly |
 | Chapter satisfaction score (internal survey results for the Security & Identity chapter) | ≥85% (proposed) | Quarterly |
 | Security architecture standards adoption rate across all technology domains | — | — |
 | Zero trust roadmap milestone completion rate against agreed programme timeline | — | — |

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -140,7 +140,7 @@ The Service & Governance Chapter Lead is the most senior technical manager and p
 | Metric | Target | Frequency |
 |---|---|---|
 | Chapter practitioner retention rate and voluntary attrition trend | — | — |
-| New architect and senior engineer hires retained at 90 days (%) | — | — |
+| New architect and senior engineer hires retained at 90 days (%) | ≥95% (proposed) | Quarterly |
 | Chapter satisfaction score (internal survey results for the Service & Governance chapter) | ≥85% (proposed) | Quarterly |
 | ITSM process maturity level across all ITIL 4 processes (measured against ITIL 4 maturity model) | — | — |
 | CMDB accuracy and completeness rate for critical configuration item classes | — | — |

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -117,7 +117,7 @@ The Observability Senior Engineer leads advanced observability projects, focusin
 | Successful implementation of complex observability solutions | — | — |
 | Effectiveness of advanced alerting and detection mechanisms | — | — |
 | Platform scalability and performance improvements | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
 | Contribution to observability standards and patterns | — | — |
 | Implementation of innovative monitoring approaches | — | — |
 

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -146,10 +146,10 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 | Developer experience improvement through architecture | — | — |
 | Platform reliability and performance through design | — | — |
 | Adoption of reference architectures and golden paths | — | — |
-| Recorded architectural risks closed (count per quarter) | — | — |
+| Recorded architectural risks closed (count per quarter) | ≥2 per quarter (proposed) | Quarterly |
 | Innovation in platform approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Edge workload onboarding time: time from request to production-ready edge deployment | — | — |
 | Edge platform availability: uptime SLA for IDP golden paths and self-service tooling at edge locations | ≥95% (proposed) | Monthly |
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -144,7 +144,7 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 | Template and golden path usage rates | — | — |
 | Developer support responsiveness | — | — |
 | Platform deployment automation success rate | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -141,7 +141,7 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 | Reduction in developer toil through automation | — | — |
 | Platform services meeting their published SLO (%) | ≥95% (proposed) | Monthly |
 | Platform roadmap items delivered in the committed quarter (%) | ≥80% (proposed) | Quarterly |
-| Delivery teams onboarded to a platform capability (count per quarter) | — | — |
+| Delivery teams onboarded to a platform capability (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Engineering hours saved per quarter attributable to platform capabilities (hours) | — | — |
 | Innovation in developer experience | — | — |
 

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -137,7 +137,7 @@ The Modern Workplace Product Owner (PO) owns the vision, roadmap, and delivery b
 | Microsoft 365 Copilot adoption (active users / licensed) | — | — |
 | Licensing utilisation efficiency (active use / licensed seats) | — | — |
 | Employee satisfaction with digital workplace tools (annual survey) | ≥85% (proposed) | Annual |
-| Committed sprint items delivered in the sprint (%) | — | — |
+| Committed sprint items delivered in the sprint (%) | ≥80% (proposed) | Monthly |
 | Roadmap milestones delivered against plan | — | — |
 
 ## Remote Work Considerations

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -143,8 +143,8 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 | Reduction in network-related incidents | — | — |
 | Network simplification and standardization | — | — |
 | Innovation in network architectural approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | AIOps prediction accuracy for capacity forecasting and incident detection (target: >85% precision) | >85% | — |
 | Edge network availability: ≥99.9% connectivity SLA for business-critical edge PoPs and industrial edge sites | ≥99.9% | — |
 | Edge site deployment time: network provisioning lead time for new edge PoPs reduced via SD-WAN ZTP automation | — | — |

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -140,7 +140,7 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 | Network security policy compliance | — | — |
 | Network monitoring coverage | — | — |
 | Response time to service requests | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Successful implementation of standard designs | — | — |
 | Customer satisfaction with network services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -138,15 +138,15 @@ The Access Management Architect designs and oversees the organization's access m
 | Metric | Target | Frequency |
 |---|---|---|
 | Designs approved at first architecture review, without rework (%) | ≥80% (proposed) | Quarterly |
-| Access-related security incidents (count per quarter) | — | — |
+| Access-related security incidents (count per quarter) | 0 critical or high (proposed) | Quarterly |
 | Improvement in access governance metrics | — | — |
 | Timely delivery of access architecture artifacts | — | — |
 | Stakeholder satisfaction with access solutions | ≥85% (proposed) | Quarterly |
-| New access management patterns adopted into the standard (count per year) | — | — |
+| New access management patterns adopted into the standard (count per year) | ≥2 per year (proposed) | Annually |
 | Alignment with security and compliance requirements | — | — |
 | Successful adoption of access architecture patterns | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -165,7 +165,7 @@ The Access Management Product Owner manages the development and lifecycle of the
 | Access review campaign completion rates | — | — |
 | Stakeholder satisfaction with access processes | ≥85% (proposed) | Quarterly |
 | Privileged access security metrics | — | — |
-| Access-related security incidents (count per quarter) | — | — |
+| Access-related security incidents (count per quarter) | 0 critical or high (proposed) | Quarterly |
 | Successful delivery of access roadmap items | — | — |
 | Self-service access request adoption | — | — |
 | Access governance compliance scores | — | — |

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -142,7 +142,7 @@ The Access Management Senior Engineer leads the implementation and optimization 
 | Knowledge transfer to junior engineers | — | — |
 | Reduction in inappropriate access events | — | — |
 | Compliance with access governance frameworks | — | — |
-| New access management patterns adopted into the standard (count per year) | — | — |
+| New access management patterns adopted into the standard (count per year) | ≥2 per year (proposed) | Annually |
 
 ## Key Performance Indicators
 

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -138,10 +138,10 @@ The Identity Management Architect designs and oversees the organization's identi
 | User experience improvements through architecture | — | — |
 | Security posture improvement via identity controls | — | — |
 | Adoption of identity standards and patterns | — | — |
-| Identity-related security incidents (count per quarter) | — | — |
+| Identity-related security incidents (count per quarter) | 0 critical or high (proposed) | Quarterly |
 | Innovation in identity management approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -140,7 +140,7 @@ The Identity Management Senior Engineer leads the implementation and optimizatio
 | Automation level achieved for identity operations | — | — |
 | Security posture improvement in identity systems | — | — |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
-| Identity-related security incidents (count per quarter) | — | — |
+| Identity-related security incidents (count per quarter) | 0 critical or high (proposed) | Quarterly |
 | Successful implementation of identity standards | — | — |
 | User satisfaction with authentication experience | ≥85% (proposed) | Quarterly |
 

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -137,10 +137,10 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 | Data centre power usage effectiveness (PUE) | — | — |
 | Cost effectiveness of hardware architectures | — | — |
 | Adoption of reference architectures and standards | — | — |
-| Server estate within its supported lifecycle window (%) | — | — |
-| New server platform patterns adopted into the standard build (count per year) | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Server estate within its supported lifecycle window (%) | ≥95% (proposed) | Quarterly |
+| New server platform patterns adopted into the standard build (count per year) | ≥2 per year (proposed) | Annually |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -144,10 +144,10 @@ The Server Hardware Engineer implements and maintains the physical server infras
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Firmware compliance percentage | — | — |
 | Hardware inventory accuracy | — | — |
-| Planned hardware maintenance completed in window (%) | — | — |
-| Servers deployed from the approved standard build (%) | — | — |
+| Planned hardware maintenance completed in window (%) | ≥95% (proposed) | Quarterly |
+| Servers deployed from the approved standard build (%) | ≥90% (proposed) | Quarterly |
 | User satisfaction with hardware support | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -147,7 +147,7 @@ The Server Hardware Senior Engineer leads the implementation and optimization of
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Hardware standardization implementation success | — | — |
 | Success rate of hardware upgrades and refreshes | — | — |
-| New server platform patterns adopted into the standard build (count per year) | — | — |
+| New server platform patterns adopted into the standard build (count per year) | ≥2 per year (proposed) | Annually |
 | Stakeholder satisfaction with infrastructure services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -143,10 +143,10 @@ The HPE Server Hardware Architect designs and oversees the organization's server
 | Data centre power usage effectiveness (PUE) | — | — |
 | Cost effectiveness of hardware architectures | — | — |
 | Adoption of reference architectures and standards | — | — |
-| Server estate within its supported lifecycle window (%) | — | — |
-| New server platform patterns adopted into the standard build (count per year) | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Server estate within its supported lifecycle window (%) | ≥95% (proposed) | Quarterly |
+| New server platform patterns adopted into the standard build (count per year) | ≥2 per year (proposed) | Annually |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -168,10 +168,10 @@ The HPE Server Hardware Engineer implements and maintains server infrastructure 
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
 | Firmware compliance percentage | — | — |
 | Hardware inventory accuracy | — | — |
-| Planned hardware maintenance completed in window (%) | — | — |
-| Servers deployed from the approved standard build (%) | — | — |
+| Planned hardware maintenance completed in window (%) | ≥95% (proposed) | Quarterly |
+| Servers deployed from the approved standard build (%) | ≥90% (proposed) | Quarterly |
 | User satisfaction with hardware support | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -121,9 +121,9 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 | Implementation time for server infrastructure projects | — | — |
 | Server hardware incident resolution time | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Automation implementation success rate | — | — |
-| Servers meeting their performance baseline after tuning (%) | — | — |
+| Servers meeting their performance baseline after tuning (%) | ≥90% (proposed) | Quarterly |
 | Hardware standardization compliance | — | — |
 | Team technical capability development | — | — |
 | Server capacity utilization metrics | — | — |

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -135,9 +135,9 @@ The Linux Server Architect designs and defines the strategic direction for the o
 | Architectural standards adoption rate across Linux deployments | — | — |
 | Reduction in Linux infrastructure incidents due to architectural improvements | — | — |
 | Linux environment availability and performance metrics | ≥99.9% (proposed) | Monthly |
-| Architecture review recommendations implemented within the agreed period (%) | — | — |
+| Architecture review recommendations implemented within the agreed period (%) | ≥90% (proposed) | Quarterly |
 | Cost optimization of Linux infrastructure | — | — |
-| Architecture artefacts current within the agreed review cycle (%) | — | — |
+| Architecture artefacts current within the agreed review cycle (%) | ≥90% (proposed) | Quarterly |
 | Technical debt reduction in Linux environments | — | — |
 | Time-to-delivery for new Linux capabilities and services | — | — |
 | Linux security posture improvement | — | — |

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -147,8 +147,8 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 | Successful implementation of automation tasks | — | — |
 | Backup success rates and recovery capabilities | ≥99% (proposed) | Monthly |
 | User satisfaction with Linux support | ≥85% (proposed) | Quarterly |
-| Work conforming to Linux standards and procedures (%) | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Work conforming to Linux standards and procedures (%) | ≥95% (proposed) | Quarterly |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -134,9 +134,9 @@ The Windows Server Architect designs and defines the strategic direction for the
 | Architectural standards adoption rate across Windows deployments | — | — |
 | Reduction in Windows infrastructure incidents due to architectural improvements | — | — |
 | Windows environment availability and performance metrics | ≥99.9% (proposed) | Monthly |
-| Architecture review recommendations implemented within the agreed period (%) | — | — |
+| Architecture review recommendations implemented within the agreed period (%) | ≥90% (proposed) | Quarterly |
 | Cost optimization of Windows licensing and infrastructure | — | — |
-| Architecture artefacts current within the agreed review cycle (%) | — | — |
+| Architecture artefacts current within the agreed review cycle (%) | ≥90% (proposed) | Quarterly |
 | Technical debt reduction in Windows environments | — | — |
 | Time-to-delivery for new Windows capabilities and services | — | — |
 | Windows security posture improvement | — | — |

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -148,7 +148,7 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 | Group Policy implementation accuracy | — | — |
 | Backup success rate and recovery effectiveness | ≥99% (proposed) | Monthly |
 | Change implementation success rate | — | — |
-| Work conforming to security standards and best practices (%) | — | — |
+| Work conforming to security standards and best practices (%) | ≥95% (proposed) | Quarterly |
 | User satisfaction with server services | ≥85% (proposed) | Quarterly |
 
 ## Remote Work Considerations

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -149,7 +149,7 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 | Security compliance scores for Windows servers | — | — |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Successful implementation of Windows standards | — | — |
-| Servers meeting their performance baseline after tuning (%) | — | — |
+| Servers meeting their performance baseline after tuning (%) | ≥90% (proposed) | Quarterly |
 | Projects delivered in the committed period without post-go-live defects (%) | ≥80% (proposed) | Quarterly |
 | Innovation in Windows platform capabilities | — | — |
 

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -138,8 +138,8 @@ The Service Management Architect designs comprehensive strategies and architectu
 | Adoption of ITSM reference architectures | — | — |
 | Reduction in service-related incidents | — | — |
 | Innovation in service management approaches | — | — |
-| Engineers mentored who progress to the next competency level (count per year) | — | — |
-| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | — | — |
+| Engineers mentored who progress to the next competency level (count per year) | ≥1 per year (proposed) | Annually |
+| Knowledge-sharing sessions delivered to engineering teams (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Service management maturity improvement | — | — |
 
 ## Remote Work Considerations

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -140,7 +140,7 @@ The Service Management Engineer implements and maintains IT service management p
 | User satisfaction with ITSM tools | ≥85% (proposed) | Quarterly |
 | Reporting and dashboard utility | — | — |
 | Resolution time for ITSM platform issues | — | — |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 | Process automation efficiency | — | — |
 
 ## Remote Work Considerations

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -124,7 +124,7 @@ The Hyper-V Engineer implements and maintains Microsoft virtualization environme
 | Timely resolution of incidents and service requests | — | — |
 | Efficiency of virtual resource utilization | — | — |
 | Quality of documentation and operational procedures | — | — |
-| Work conforming to change management processes (%) | — | — |
+| Work conforming to change management processes (%) | ≥95% (proposed) | Quarterly |
 | Successful implementation of routine maintenance activities | — | — |
 | VM provisioning turnaround times | — | — |
 | Security compliance of virtualized environments | — | — |

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -129,7 +129,7 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 | Success rate of migrations and upgrades | — | — |
 | Resolution time for complex virtualization issues | — | — |
 | Automation coverage for routine administrative tasks | — | — |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Contribution to virtualization standards and best practices | — | — |
 | Security posture improvement in virtualized environments | — | — |

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -148,7 +148,7 @@ The Nutanix Architect designs and oversees the organization's hyperconverged inf
 | Adoption of standards and best practices | — | — |
 | Time-to-value for new Nutanix implementations | — | — |
 | Risk mitigation effectiveness | — | — |
-| Improvement items proposed and adopted (count per quarter) | — | — |
+| Improvement items proposed and adopted (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -143,11 +143,11 @@ The Nutanix Engineer implements and maintains hyperconverged infrastructure base
 | Time to resolve Nutanix-related incidents | — | — |
 | Successful completion of maintenance activities | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Patch compliance for Nutanix components | ≥95% (proposed) | Monthly |
 | Reduction in recurring incidents | — | — |
 | User satisfaction with infrastructure services | ≥85% (proposed) | Quarterly |
-| Knowledge-sharing contributions published or presented (count per quarter) | — | — |
+| Knowledge-sharing contributions published or presented (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -141,7 +141,7 @@ The Nutanix Product Owner manages the development and lifecycle of the organizat
 | Metric | Target | Frequency |
 |---|---|---|
 | Platform availability and reliability metrics | ≥99.9% (proposed) | Monthly |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Time-to-delivery for platform enhancements | — | — |
 | Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Cost efficiency metrics for HCI resources | — | — |

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -136,7 +136,7 @@ The Nutanix Senior Engineer leads the implementation and optimization of complex
 | HCI implementations accepted without post-deployment rework (%) | ≥80% (proposed) | Quarterly |
 | Time to resolution for complex Nutanix issues | — | — |
 | Automation coverage for Nutanix operations | — | — |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Success rate of migrations and upgrades | — | — |
 | Contribution to HCI standards and best practices | — | — |

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -140,10 +140,10 @@ The VMware Engineer implements and maintains virtualization infrastructure based
 | Virtual machine deployment time efficiency | — | — |
 | Resolution time for virtualization incidents | — | — |
 | Owned documentation reviewed and current within the agreed review cycle (%) | ≥95% (proposed) | Quarterly |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Patch compliance for VMware components | ≥95% (proposed) | Monthly |
 | Backup success rates for virtual machines | ≥99% (proposed) | Monthly |
-| Work conforming to VMware configuration standards (%) | — | — |
+| Work conforming to VMware configuration standards (%) | ≥95% (proposed) | Quarterly |
 | Number of automated processes implemented | — | — |
 | Customer satisfaction with virtualization services | ≥85% (proposed) | Quarterly |
 

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -162,7 +162,7 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 | Platform availability and SLA compliance | ≥95% (proposed) | Monthly |
 | Stakeholder satisfaction ratings | ≥85% (proposed) | Quarterly |
 | Business value delivered through platform enhancements | — | — |
-| Provisioned capacity actively utilised (%) | — | — |
+| Provisioned capacity actively utilised (%) | 70–85% (proposed) | Monthly |
 | Cost optimization achievements | — | — |
 | Feature adoption rates | — | — |
 | Backlog health and roadmap delivery | — | — |

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -145,7 +145,7 @@ The VMware Senior Engineer leads the implementation and optimization of complex 
 | Resolution time for complex incidents | — | — |
 | Junior engineers reaching independent delivery within the agreed ramp period (%) | ≥90% (proposed) | Quarterly |
 | Implementation of standards and best practices | — | — |
-| Improvement items proposed and adopted (count per quarter) | — | — |
+| Improvement items proposed and adopted (count per quarter) | ≥1 per quarter (proposed) | Quarterly |
 
 ## Remote Work Considerations
 

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -1379,3 +1379,22 @@ test('every KPI benchmark declares its basis and a note', () => {
         assert.ok(b.note && b.note.length > 0, `${b.re} needs a note`);
     }
 });
+
+test('proposedKpiTarget seeds counted improvement items but not improvement in a measure', () => {
+    // "Improvement in X" is a direction of travel; "Improvement items
+    // proposed and adopted" counts things. The first blanket rule refused
+    // both, which silently withheld a target from 3 rows that have a unit.
+    assert.match(proposedKpiTarget('Improvement items proposed and adopted (count per quarter)').target, /per quarter/);
+    assert.equal(proposedKpiTarget('Improvement in delivery metrics (lead time, MTTR, etc.)'), null);
+    assert.equal(proposedKpiTarget('Improvements in deployment frequency and reliability'), null);
+});
+
+test('count targets are floors, and stated per period', () => {
+    // A count depends on team size, so these say "the activity happens at
+    // all" rather than proposing a level of output.
+    for (const m of ['Engineers mentored who progress to the next competency level (count per year)',
+                     'Knowledge-sharing sessions delivered to engineering teams (count per quarter)']) {
+        assert.match(proposedKpiTarget(m).target, /^≥\d+ per (quarter|year) \(proposed\)$/, m);
+        assert.equal(proposedKpiTarget(m).basis, 'house');
+    }
+});

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -873,6 +873,48 @@
                                                                         target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
         { re: /\b(delivered|completed) in the committed\b/i,            target: '≥80%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
         { re: /\bdefinition of ready\b/i,                               target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+
+        // Conformance and estate hygiene. All of these ask "what share of the
+        // work followed the rule", where the rule is the organisation's own.
+        { re: /\bwork conforming to\b|\bconforms? to\b[^|]*\bstandards?\b/i,
+                                                                        target: '≥95%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bwithin its supported lifecycle\b|\bwithin the supported\b[^|]*\barchitecture\b/i,
+                                                                        target: '≥95%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bfrom the approved standard build\b|\bapproved reference pattern\b/i,
+                                                                        target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bartefacts current within\b|\brecommendations implemented within\b/i,
+                                                                        target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bmaintenance completed in window\b|\bcompleted in window\b/i,
+                                                                        target: '≥95%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bwithout manual intervention\b/i,                       target: '≥80%',            frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bcommitted sprint items delivered\b/i,                  target: '≥80%',            frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bresponse-time budget\b/i,                              target: '≥95%',            frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bquality gate pass rate\b/i,                            target: '≥90%',            frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bperformance baseline after tuning\b/i,                 target: '≥90%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bstated RPO\b/i,                                        target: '≥99%',            frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bhires retained at 90 days\b/i,                         target: '≥95%',            frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        // Both of these are bands rather than thresholds: under-use wastes the
+        // spend, over-use removes the headroom the capacity exists for.
+        { re: /\bcapacity actively utilised\b|\butilisation\b[^|]*\(%\)/i,
+                                                                        target: '70–85%',          frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\breserved or committed capacity\b/i,                    target: '70–80%',          frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bmedian query execution time\b/i,                       target: '≤200 ms',         frequency: 'Monthly',   basis: 'house', note: 'no industry standard; house starting point for discussion' },
+
+        // Counts. A count target depends on team size, so these are the
+        // weakest proposals in the table and deliberately the lowest: a floor
+        // worth clearing rather than a stretch. "At least one a quarter" is a
+        // statement that the activity happens at all.
+        { re: /\bmentored who progress\b/i,                             target: '≥1 per year',     frequency: 'Annually',  basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\bknowledge[- ]sharing\b[^|]*\(count per quarter\)/i,    target: '≥1 per quarter',  frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\b(risks|debt items|technical debt items)\b[^|]*\bclosed\b[^|]*\(count per quarter\)/i,
+                                                                        target: '≥2 per quarter',  frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\b(adopted into the|released to consuming teams)\b[^|]*\(count per year\)/i,
+                                                                        target: '≥2 per year',     frequency: 'Annually',  basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        { re: /\b(onboarded to a platform capability|improvement items proposed and adopted)\b/i,
+                                                                        target: '≥1 per quarter',  frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
+        // The one count where the right number is knowable: severe incidents
+        // in the estate this role owns.
+        { re: /\b(access|identity)-related security incidents\b/i,      target: '0 critical or high', frequency: 'Quarterly', basis: 'house', note: 'no industry standard; house starting point for discussion' },
     ];
 
     // A metric that asks only for a direction of travel has no threshold to
@@ -880,7 +922,10 @@
     // keyword matched in a sense the benchmark does not cover.
     const KPI_UNSEEDABLE = [
         /\btrend\w*\b/i,
-        /\bimprovement\w*\b|\bimprovements? in\b/i,
+        // "Improvement in X" is a direction; "Improvement items closed" is a
+        // count of things. Only the former is unseedable, so this is anchored
+        // to the preposition rather than to the word.
+        /\bimprovements? in\b/i,
         /\betc\.?\b/i,
     ];
 


### PR DESCRIPTION
You asked for indicative numbers. **162 more rows have one** — 589 of the 1,694 untargeted rows now carry an opening figure, up from 427. All 162 are house figures, marked `(proposed)` and counted apart by the validator.

Refs #140 — still open, 1,105 rows remain blank.

## What decided which rows got a number

**The metric already declares what it is counted in.** A row saying `(%)`, `(count per quarter)` or `(ms)` states what kind of answer it wants, so a proposed figure is reviewable on its face. 168 rows met that test; 162 now carry one.

### Percentages

| Target | Families |
|---|---|
| `≥95%` | conformance to a standard · estate within its supported lifecycle · maintenance completed in window · hires retained at 90 days · transactions meeting their response-time budget |
| `≥90%` | quality gate pass rate · deployed from the approved standard build · review recommendations implemented · artefacts current |
| `≥80%` | fulfilled without manual intervention · committed sprint items delivered |
| `≥99%` | protected workloads meeting their stated RPO |
| `70–85%` | provisioned capacity actively utilised |
| `70–80%` | eligible spend on reserved or committed capacity |

The last two are **bands, not thresholds** — under-use wastes the spend, over-use removes the headroom the capacity exists for. A `≥` target on either proposes the wrong shape of answer.

### Counts

| Target | Rows | Family |
|---|---|---|
| `≥1 per year` | 22 | engineers mentored who progress a level |
| `≥1 per quarter` | 43 | knowledge-sharing sessions and contributions |
| `≥2 per quarter` | 11 | recorded risks and debt items closed |
| `≥2 per year` | 14 | new patterns adopted into a standard |
| `0 critical or high` | 4 | access- and identity-related security incidents |

**These are the weakest proposals in the table and deliberately the lowest defensible figure** — a floor worth clearing, not a level of output. "At least one a quarter" asserts the activity happens at all, which is the only thing sayable without knowing team size. I said last round there was no defensible figure for these; a floor is defensible in a way that a level is not, and a floor beats a blank.

## Still blank on purpose

Nine rows that declare a unit: `Engineering hours saved per quarter attributable to platform capabilities (hours)` needs a baseline nobody has measured, and `Delivery teams consuming a shared component (count)` has no period to count over.

## One guard narrowed

The direction-only rule moves from `improvement` to `improvements in`. `Improvement in delivery metrics` is a direction and stays refused; `Improvement items proposed and adopted (count per quarter)` counts things, and the broader rule was withholding a target from it.

## Test plan

- [x] `npm test` — 204 pass, 0 fail (202 → 204)
- [x] `npm run validate` — 0 errors
- [x] `npm run seed-kpi --dry` — reproduces the committed state exactly
- [x] Metric cells verified unchanged across all 162 edits — only Target and Frequency moved
- [x] The drift test from #167 fired before the files were seeded and passes after, which is the guard working as intended