### PR TITLE
docs: link the documents these files name, instead of naming them

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The 34 domains are grouped into 7 chapters, each led by a Chapter Lead:
 | 6 | 🎯 Service & Governance | ITSM, configuration management, service management, enterprise architecture |
 | 7 | 👑 Leadership | C-Suite, SVP, CISO, Chapter Leads, TAL, PAL, cross-cutting leadership |
 
-See `docs/CHAPTERS_OVERVIEW.md` for the full breakdown and `docs/chapters/*.md` for each chapter's detail. Domain and role counts are computed live from `Roles/` — never hand-maintained — to prevent drift.
+See [`docs/CHAPTERS_OVERVIEW.md`](docs/CHAPTERS_OVERVIEW.md) for the full breakdown and `docs/chapters/*.md` for each chapter's detail. Domain and role counts are computed live from `Roles/` — never hand-maintained — to prevent drift.
 
 ## Role hierarchy
 
@@ -148,11 +148,11 @@ roles_master/
 
 ## Adding a new role
 
-1. Copy `docs/role_template.md` into the appropriate folder under `Roles/`.
+1. Copy [`docs/role_template.md`](docs/role_template.md) into the appropriate folder under `Roles/`.
 2. Name the file using the pattern: `<technology>_<level>.md`
    - Standard levels: `architect`, `senior_engineer`, `engineer`, `product_owner`
    - Special levels: `product_area_lead`, `technical_area_lead`, `cloud_lead_architect`, `cloud_principal_architect`
-   - Example: `Roles/kubernetes/kubernetes_platform_engineer.md`
+   - Example: [`Roles/kubernetes/kubernetes_senior_engineer.md`](Roles/kubernetes/kubernetes_senior_engineer.md)
 3. Fill in all 14 sections following the template.
 4. Run `npm run validate` to confirm the file has all required sections and metadata.
 5. Restart the server — new roles are picked up automatically on each request.
@@ -166,7 +166,7 @@ roles_master/
 
 ## Role file format
 
-Each role file follows the canonical 14-section structure. See `docs/role_template.md` for full guidance.
+Each role file follows the canonical 14-section structure. See [`docs/role_template.md`](docs/role_template.md) for full guidance.
 
 ```markdown
 # Role Title
@@ -200,15 +200,15 @@ Each role file follows the canonical 14-section structure. See `docs/role_templa
 
 | Document | Purpose |
 |---|---|
-| `docs/CROSS_DOMAIN_INTERACTIONS.md` | Domain ownership boundaries, key relationships, escalation paths |
-| `docs/SKILLS_PROGRESSION.md` | Engineer → Senior → Architect career ladder per domain |
-| `docs/ONBOARDING_TEMPLATE.md` | 30/60/90 day plan template for new hires |
+| [`docs/CROSS_DOMAIN_INTERACTIONS.md`](docs/CROSS_DOMAIN_INTERACTIONS.md) | Domain ownership boundaries, key relationships, escalation paths |
+| [`docs/SKILLS_PROGRESSION.md`](docs/SKILLS_PROGRESSION.md) | Engineer → Senior → Architect career ladder per domain |
+| [`docs/ONBOARDING_TEMPLATE.md`](docs/ONBOARDING_TEMPLATE.md) | 30/60/90 day plan template for new hires |
 | `docs/onboarding_*_supplement.md` | Level overlays (Engineer, Senior Engineer, Architect, Product Owner) — used **alongside** the base template, adding only what differs by level |
-| `docs/onboarding_chapter_lead_template.md` | Onboarding variant for incoming Chapter Leads |
-| `docs/CHAPTERS_OVERVIEW.md` | The 7 chapters, their focus, and links to per-chapter detail |
-| `docs/improvements_and_recommendations.md` | **Closed.** Narrative of the four 2026 review cycles. Open work is in [GitHub Issues](https://github.com/JeanKadang/DOC-ITRoles/issues); what shipped is in [CHANGELOG.md](CHANGELOG.md) |
-| `CHANGELOG.md` | Version history of the codebase (Keep a Changelog format) |
-| `SECURITY.md` | Security policy and how to report a vulnerability |
+| [`docs/onboarding_chapter_lead_template.md`](docs/onboarding_chapter_lead_template.md) | Onboarding variant for incoming Chapter Leads |
+| [`docs/CHAPTERS_OVERVIEW.md`](docs/CHAPTERS_OVERVIEW.md) | The 7 chapters, their focus, and links to per-chapter detail |
+| [`docs/improvements_and_recommendations.md`](docs/improvements_and_recommendations.md) | **Closed.** Narrative of the four 2026 review cycles. Open work is in [GitHub Issues](https://github.com/JeanKadang/DOC-ITRoles/issues); what shipped is in [CHANGELOG.md](CHANGELOG.md) |
+| [`CHANGELOG.md`](CHANGELOG.md) | Version history of the codebase (Keep a Changelog format) |
+| [`SECURITY.md`](SECURITY.md) | Security policy and how to report a vulnerability |
 
 ## Development
 

--- a/Roles/c_suite/README.md
+++ b/Roles/c_suite/README.md
@@ -1,12 +1,12 @@
 # C-Suite domain
 
-This domain covers the top executive roles setting organisation-wide strategy and direction: CEO, CFO, CIO, and CTO. The Chief Information Security Officer (CISO) is also a C-suite-level role but is filed under `leadership/` — a cross-cutting chapter alongside the Chapter Lead and TAL/PAL roles — rather than here, since its reporting line (SVP of Technology, CTO/CIO, or directly to the CEO/Board) varies by governance model rather than sitting fixed in the standalone executive line. See `Roles/leadership/chief_information_security_officer.md`.
+This domain covers the top executive roles setting organisation-wide strategy and direction: CEO, CFO, CIO, and CTO. The Chief Information Security Officer (CISO) is also a C-suite-level role but is filed under `leadership/` — a cross-cutting chapter alongside the Chapter Lead and TAL/PAL roles — rather than here, since its reporting line (SVP of Technology, CTO/CIO, or directly to the CEO/Board) varies by governance model rather than sitting fixed in the standalone executive line. See [`Roles/leadership/chief_information_security_officer.md`](../leadership/chief_information_security_officer.md).
 
 ## Roles in this domain
 
-- `chief_executive_officer.md`
-- `chief_financial_officer.md`
-- `chief_information_officer.md`
-- `chief_technology_officer.md`
+- [`chief_executive_officer.md`](chief_executive_officer.md)
+- [`chief_financial_officer.md`](chief_financial_officer.md)
+- [`chief_information_officer.md`](chief_information_officer.md)
+- [`chief_technology_officer.md`](chief_technology_officer.md)
 
-For the CISO, see `Roles/leadership/chief_information_security_officer.md`.
+For the CISO, see [`Roles/leadership/chief_information_security_officer.md`](../leadership/chief_information_security_officer.md).

--- a/Roles/security/README.md
+++ b/Roles/security/README.md
@@ -4,9 +4,9 @@ This domain covers general security architecture across the organisation — thr
 
 ## Roles in this domain
 
-- `devsecops_architect.md`
-- `devsecops_engineer.md`
-- `security_architect.md`
-- `security_engineer.md`
-- `security_product_owner.md`
-- `security_senior_engineer.md`
+- [`devsecops_architect.md`](devsecops_architect.md)
+- [`devsecops_engineer.md`](devsecops_engineer.md)
+- [`security_architect.md`](security_architect.md)
+- [`security_engineer.md`](security_engineer.md)
+- [`security_product_owner.md`](security_product_owner.md)
+- [`security_senior_engineer.md`](security_senior_engineer.md)

--- a/Roles/security_cross_platform/README.md
+++ b/Roles/security_cross_platform/README.md
@@ -4,7 +4,7 @@ This domain covers security patterns and controls that apply across multiple tec
 
 ## Roles in this domain
 
-- `security_cross_platform_architect.md`
-- `security_cross_platform_engineer.md`
-- `security_cross_platform_product_owner.md`
-- `security_cross_platform_senior_engineer.md`
+- [`security_cross_platform_architect.md`](security_cross_platform_architect.md)
+- [`security_cross_platform_engineer.md`](security_cross_platform_engineer.md)
+- [`security_cross_platform_product_owner.md`](security_cross_platform_product_owner.md)
+- [`security_cross_platform_senior_engineer.md`](security_cross_platform_senior_engineer.md)

--- a/Roles/security_identity/README.md
+++ b/Roles/security_identity/README.md
@@ -4,13 +4,13 @@ This domain covers identity and access management (IAM) architecture across the 
 
 ## Roles in this domain
 
-- `access_management_architect.md`
-- `access_management_engineer.md`
-- `access_management_product_owner.md`
-- `access_management_senior_engineer.md`
-- `identity_management_architect.md`
-- `identity_management_engineer.md`
-- `identity_management_product_owner.md`
-- `identity_management_senior_engineer.md`
-- `privileged_access_management_architect.md`
-- `privileged_access_management_engineer.md`
+- [`access_management_architect.md`](access_management_architect.md)
+- [`access_management_engineer.md`](access_management_engineer.md)
+- [`access_management_product_owner.md`](access_management_product_owner.md)
+- [`access_management_senior_engineer.md`](access_management_senior_engineer.md)
+- [`identity_management_architect.md`](identity_management_architect.md)
+- [`identity_management_engineer.md`](identity_management_engineer.md)
+- [`identity_management_product_owner.md`](identity_management_product_owner.md)
+- [`identity_management_senior_engineer.md`](identity_management_senior_engineer.md)
+- [`privileged_access_management_architect.md`](privileged_access_management_architect.md)
+- [`privileged_access_management_engineer.md`](privileged_access_management_engineer.md)

--- a/docs/ONBOARDING_TEMPLATE.md
+++ b/docs/ONBOARDING_TEMPLATE.md
@@ -13,7 +13,7 @@
 | **Start date** | \<date\> |
 | **Hiring manager** | \<name\> |
 | **Assigned buddy** | \<name and role\> |
-| **Role definition** | Link to role file in this repository |
+| **Role definition** | \<link to the role definition\> |
 
 ---
 
@@ -46,7 +46,7 @@
 - [ ] Review existing architecture documentation, decision records (ADRs), and runbooks for the domain
 - [ ] Get hands-on access to key systems and environments (non-production first)
 - [ ] Shadow at least 2 live tasks or incidents to understand how the team operates
-- [ ] Review the `SKILLS_PROGRESSION.md` and `CROSS_DOMAIN_INTERACTIONS.md` in this repository
+- [ ] Review [Career Paths & Skills Progression](SKILLS_PROGRESSION.md) and [Domain Interactions](CROSS_DOMAIN_INTERACTIONS.md)
 
 ### Domain-specific orientation
 
@@ -130,9 +130,9 @@
 
 | Resource | Type | Priority |
 |---|---|---|
-| Role definition in this repository | Internal documentation | Day 1 |
-| `SKILLS_PROGRESSION.md` | Internal documentation | Week 1 |
-| `CROSS_DOMAIN_INTERACTIONS.md` | Internal documentation | Week 1 |
+| \<link to the role definition\> | Internal documentation | Day 1 |
+| [Career Paths & Skills Progression](SKILLS_PROGRESSION.md) | Internal documentation | Week 1 |
+| [Domain Interactions](CROSS_DOMAIN_INTERACTIONS.md) | Internal documentation | Week 1 |
 | \<Relevant certification path\> | Certification | First 90 days |
 | \<Internal wiki / Confluence space\> | Internal knowledge base | Week 1 |
 | \<Specific tool or platform training\> | Vendor training | By day 60 |

--- a/docs/onboarding_chapter_lead_template.md
+++ b/docs/onboarding_chapter_lead_template.md
@@ -56,7 +56,7 @@ Complete all items before the new Chapter Lead's first day. Items marked _(CL-sp
 - [ ] All domain role definitions for the chapter shared — new Chapter Lead asked to review before day 1 _(CL-specific)_
 - [ ] Existing chapter architecture standards documentation shared _(CL-specific)_
 - [ ] Current chapter technology radar shared _(CL-specific)_
-- [ ] `SKILLS_PROGRESSION.md` and `CROSS_DOMAIN_INTERACTIONS.md` shared
+- [ ] [Career Paths & Skills Progression](SKILLS_PROGRESSION.md) and [Domain Interactions](CROSS_DOMAIN_INTERACTIONS.md) shared
 
 ---
 
@@ -81,7 +81,7 @@ The first 30 days are for orientation. The new Chapter Lead should listen, read,
 - [ ] Review existing chapter architecture standards, technology radar, and any active Architecture Decision Records (ADRs) across all chapter domains
 - [ ] Attend and observe (do not chair) the chapter architecture review board in your first two weeks — understand the current decision-making process, quality bar, and recurring themes
 - [ ] Review the chapter roadmap, backlog, and any outstanding architecture or delivery commitments already in flight
-- [ ] Review `SKILLS_PROGRESSION.md` and `CROSS_DOMAIN_INTERACTIONS.md` with specific focus on your chapter's domains — understand how your domains interact with other chapters
+- [ ] Review [Career Paths & Skills Progression](SKILLS_PROGRESSION.md) and [Domain Interactions](CROSS_DOMAIN_INTERACTIONS.md) with specific focus on your chapter's domains — understand how your domains interact with other chapters
 - [ ] Review any active platform consolidation or rationalisation programmes affecting your chapter
 
 ### Stakeholder and context orientation
@@ -233,8 +233,8 @@ These tasks are specific to the Chapter Lead role and should be completed within
 |---|---|---|
 | Chapter Lead role definition (this repository) | Internal documentation | Day 1 |
 | All domain role definitions in your chapter (this repository) | Internal documentation | Week 1 |
-| `SKILLS_PROGRESSION.md` | Internal documentation | Week 1 |
-| `CROSS_DOMAIN_INTERACTIONS.md` | Internal documentation | Week 1 |
+| [Career Paths & Skills Progression](SKILLS_PROGRESSION.md) | Internal documentation | Week 1 |
+| [Domain Interactions](CROSS_DOMAIN_INTERACTIONS.md) | Internal documentation | Week 1 |
 | TOGAF Foundation or Practitioner | Certification | First 90 days |
 | ITIL 4 Managing Professional or Strategic Leader | Certification | First 90 days |
 | Relevant chapter domain certifications (see role definition) | Certification | By 6 months |

--- a/index.html
+++ b/index.html
@@ -3414,7 +3414,14 @@
                 openRole(clean, title, '', '');
             }
         } else if (clean.startsWith('docs/')) {
-            const title = clean.split('/').pop().replace(/_/g, ' ').replace('.md', '');
+            // Prefer the title the sidebar uses. Deriving one from the
+            // filename gave "SKILLS PROGRESSION" for a document listed as
+            // "Career Paths & Skills Progression", so following a link
+            // landed the reader somewhere that looked like a different page.
+            const listed = RESOURCES.find(r => r.file === clean);
+            const title = listed
+                ? listed.title
+                : clean.split('/').pop().replace(/_/g, ' ').replace('.md', '');
             openDoc(clean, title);
         }
     });

--- a/test/doc-links.test.js
+++ b/test/doc-links.test.js
@@ -1,0 +1,86 @@
+// Guards against a document naming another document without linking to it
+// (#168, #169).
+//
+// The viewer intercepts in-body `.md` links and routes them, so a mention
+// written as a bare code span is a dead end for the reader — and the
+// onboarding templates were doing it precisely where they tell a new starter
+// to go and read something. This makes the omission fail rather than sit.
+//
+// It also catches a mention of a file that does not exist, which is how
+// README.md came to give `kubernetes_platform_engineer.md` as its naming
+// example: no such role, and a level the pattern above it does not list.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+// Files that send a reader to another document. Deliberately a list rather
+// than a glob: a role definition mentioning a filename in prose is not the
+// same act as a README pointing somewhere.
+const NAVIGATIONAL = [
+  'README.md',
+  'docs/ONBOARDING_TEMPLATE.md',
+  'docs/onboarding_chapter_lead_template.md',
+  'docs/onboarding_engineer_supplement.md',
+  'docs/onboarding_senior_engineer_supplement.md',
+  'docs/onboarding_architect_supplement.md',
+  'docs/onboarding_product_owner_supplement.md',
+  'Roles/c_suite/README.md',
+  'Roles/security/README.md',
+  'Roles/security_cross_platform/README.md',
+  'Roles/security_identity/README.md',
+];
+
+// `docs/onboarding_*_supplement.md` names a set, not a file.
+const isGlob = named => named.includes('*');
+
+function bareMentions(rel) {
+  const text = fs.readFileSync(path.join(ROOT, rel), 'utf8').replace(/^﻿/, '');
+  const out = [];
+  for (const m of text.matchAll(/`([A-Za-z_0-9./-]+\.md)`(\])?/g)) {
+    if (m[2]) continue;              // already the label of a link
+    if (isGlob(m[1])) continue;
+    out.push(m[1]);
+  }
+  return out;
+}
+
+test('a document that names another document links to it', () => {
+  const dead = [];
+  for (const rel of NAVIGATIONAL) {
+    for (const named of bareMentions(rel)) dead.push(`${rel} → ${named}`);
+  }
+  assert.deepEqual(dead, [],
+    `write these as markdown links so the viewer can open them: ${dead.join(', ')}`);
+});
+
+test('every linked .md target exists', () => {
+  const broken = [];
+  for (const rel of NAVIGATIONAL) {
+    const dir = path.posix.dirname(rel);
+    const text = fs.readFileSync(path.join(ROOT, rel), 'utf8').replace(/^﻿/, '');
+    for (const m of text.matchAll(/\]\(([^)]+\.md)\)/g)) {
+      const href = m[1];
+      if (/^https?:/.test(href)) continue;
+      const target = path.posix.normalize(path.posix.join(dir === '.' ? '' : dir, href));
+      if (!fs.existsSync(path.join(ROOT, target))) broken.push(`${rel} → ${href}`);
+    }
+  }
+  assert.deepEqual(broken, [], `broken links: ${broken.join(', ')}`);
+});
+
+test('the onboarding templates leave the role definition as a fillable placeholder', () => {
+  // It differs per hire, so it cannot be a fixed link — but "Link to role
+  // file in this repository" described a link instead of being one, and
+  // gave the manager nothing to fill in.
+  const text = fs.readFileSync(path.join(ROOT, 'docs/ONBOARDING_TEMPLATE.md'), 'utf8');
+  assert.ok(!/Link to role file in this repository/.test(text),
+    'the Role definition row should be a placeholder, not a description of a link');
+  assert.ok(!/\| Role definition in this repository \|/.test(text),
+    'the Day 1 learning resource should be a placeholder, not a phrase');
+  assert.match(text, /\\<link to the role definition\\>/,
+    'expected the template\'s own \\<…\\> placeholder style');
+});


### PR DESCRIPTION
Closes #168 · Closes #169

**47 filename mentions across 7 files were code spans**, so a reader told to go and read something had no way to get there. Now links, resolved relative to the mentioning file so they work on GitHub and in the viewer alike.

## The onboarding templates, which is why #168 was P2

They instruct a new starter to read two documents the viewer already carries as pages, and both were inert text. Prose now names each document **the way the sidebar names it** — someone told to read `SKILLS_PROGRESSION.md` will not find that string in the sidebar, where it is listed as *Career Paths & Skills Progression*.

Two rows were not mentions at all but instructions where a link should be:

| Before | After |
|---|---|
| `\| **Role definition** \| Link to role file in this repository \|` | `\| **Role definition** \| \<link to the role definition\> \|` |
| `\| Role definition in this repository \| Internal documentation \| Day 1 \|` | `\| \<link to the role definition\> \| Internal documentation \| Day 1 \|` |

The second names the **Day 1** learning resource. Both differ per hire, so they become fillable placeholders in the template's own style, matching `\<Relevant certification path\>` in the same table — the manager supplies the link, and the template stops implying one is already there.

## Two things found while doing it

**`README.md` gave a naming example for a file that does not exist** — `Roles/kubernetes/kubernetes_platform_engineer.md`, whose level also contradicts the rule stated one line above it. Now points at a role that exists.

**Following a link landed on a page headed `SKILLS PROGRESSION`**, derived from the filename, for a document the sidebar calls *Career Paths & Skills Progression* — so the destination looked like a different page from the one advertised. The route now prefers the registered title.

## The guard

`test/doc-links.test.js`: a navigational document may not name a `.md` file without linking it, every link target must exist, and the onboarding placeholders may not revert to prose.

Scoped to a **named list** of navigational files rather than a glob — a role definition mentioning a filename in passing is not the same act as a README pointing somewhere, and a glob would have made the rule fire where it does not belong.

## Test plan

- [x] `npm test` — 214 pass, 0 fail (211 → 214)
- [x] `npm run validate` — 0 errors · `npm run check-counts` — README matches
- [x] `markdownlint-cli2` across README, `docs/*.md` and every `Roles/**/README.md` — 0 issues in 17 files
- [x] In the viewer: opened the onboarding template, clicked the *Career Paths & Skills Progression* link, and it opened that document under its registered title — no console errors