### PR TITLE
ci: stabilize cross-browser accessibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
   browser:
     name: Browser journeys (Chromium, Firefox, WebKit)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Fresh hosted runners may need to provision more than 100 MB of browser
+    # system dependencies. Keep a ceiling, but leave enough room for a slow
+    # Ubuntu mirror before the cross-browser tests begin (#206).
+    timeout-minutes: 30
     steps:
       # actions/checkout v7
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/test/browser/accessibility.spec.js
+++ b/test/browser/accessibility.spec.js
@@ -2,6 +2,16 @@ const { test, expect } = require('@playwright/test');
 const AxeBuilder = require('@axe-core/playwright').default;
 
 async function scanForAccessibility(page, testInfo, stateName) {
+  // Axe evaluates the pixels at the instant it runs. Wait for finite entrance
+  // animations so Firefox does not measure text while its parent is partially
+  // transparent; intentionally infinite decoration such as the header shimmer
+  // must not hold the scan open.
+  await page.evaluate(async () => {
+    const finiteAnimations = document.getAnimations().filter(animation =>
+      animation.effect?.getTiming().iterations !== Infinity);
+    await Promise.all(finiteAnimations.map(animation => animation.finished.catch(() => {})));
+  });
+
   const results = await new AxeBuilder({ page }).analyze();
 
   if (results.violations.length > 0) {


### PR DESCRIPTION
## Summary

- wait for finite entrance animations before axe evaluates rendered contrast
- ignore intentionally infinite decorative animation when waiting
- prevent Firefox from measuring partially transparent role content
- allow slow Playwright dependency provisioning up to a bounded 30-minute browser-job ceiling

## Evidence and verification

- targeted Firefox accessibility run: 2 passed
- local `npm test`: 233 passed
- local `npm run test:browser`: 21 passed across Chromium, Firefox, and WebKit
- initial GitHub run proved the Actions allowlist correction from #203; its browser installation was canceled at the former 10-minute job limit before tests began

Closes #201
Closes #206
