### PR TITLE
fix: improve dark-theme contrast

### DIFF
--- a/docs/superpowers/plans/2026-08-07-dark-theme-contrast.md
+++ b/docs/superpowers/plans/2026-08-07-dark-theme-contrast.md
@@ -1,0 +1,270 @@
+# Dark-Theme Contrast Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the serious axe color-contrast violations in the dark home and opened-role states while preserving the light theme, layout, and theme-toggle behavior.
+
+**Architecture:** Extend the existing Playwright accessibility suite with explicit dark-theme states, then correct contrast through the existing semantic CSS tokens. Keep the exceptional role-level badge colors as narrowly scoped component overrides; do not introduce a second theme system or centralize configuration as part of this issue.
+
+**Tech Stack:** Static HTML/CSS/JavaScript, Playwright, axe-core, Node.js test suite, markdownlint-cli2.
+
+## Global Constraints
+
+- Work only on issue #202 in branch `codex/202-dark-theme-contrast`.
+- Preserve all light-theme values and behavior.
+- Preserve the current `data-theme` and `aria-pressed` toggle contract.
+- Do not change layout, typography, content, generated role data, or configuration loading.
+- Do not weaken axe rules, exclude selectors, or lower the serious/critical threshold.
+- Run the accessibility tests in Chromium, Firefox, and WebKit before completion.
+- Keep all new tests deterministic by using the existing finite-animation wait in `scanForAccessibility`.
+
+---
+
+## Task 1: Cover and correct the dark home state
+
+**Files:**
+
+- Modify: `test/browser/accessibility.spec.js`
+- Modify: `index.html:41-55`
+
+**Interfaces:**
+
+- Reuse `scanForAccessibility(page, testInfo, stateName)` without changing its exclusions or severity threshold.
+- Add `activateDarkTheme(page)`, which proves both the document theme and toggle state before an axe scan.
+
+- [ ] **Step 1: Add a dark-theme activation helper**
+
+Add this helper immediately after `scanForAccessibility` in `test/browser/accessibility.spec.js`:
+
+```javascript
+async function activateDarkTheme(page) {
+  const themeButton = page.getByRole('button', { name: 'Toggle dark mode' });
+
+  await themeButton.click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await expect(themeButton).toHaveAttribute('aria-pressed', 'true');
+}
+```
+
+- [ ] **Step 2: Add the failing dark-home accessibility test**
+
+Add this test after the existing home-state accessibility test:
+
+```javascript
+test('dark home state has no serious or critical axe violations', async ({ page }, testInfo) => {
+  await activateDarkTheme(page);
+
+  await expect(page.getByRole('heading', { name: 'Select a role to view' })).toBeVisible();
+  await scanForAccessibility(page, testInfo, 'dark-home');
+});
+```
+
+- [ ] **Step 3: Prove that the new test catches the current defect**
+
+Run:
+
+```powershell
+npm run test:browser -- test/browser/accessibility.spec.js --project=chromium
+```
+
+Expected result: the two existing light-theme tests pass and the new dark-home test fails with serious `color-contrast` violations. The report should include the filter-chip variants, resource headings, and welcome paragraph documented in issue #202.
+
+- [ ] **Step 4: Refresh the semantic dark palette**
+
+Replace only the existing `[data-theme="dark"]` token block in `index.html` with:
+
+```css
+[data-theme="dark"] {
+  --bg-primary: #0b1220;
+  --bg-card: #111827;
+  --bg-card-hover: #1b2638;
+  --bg-input: #243044;
+  --text-primary: #f8fafc;
+  --text-secondary: #d6deea;
+  --text-muted: #b4c0d0;
+  --accent-blue: #6eb6ff;
+  --border-color: rgba(226, 232, 240, 0.18);
+  --border-hover: rgba(110, 182, 255, 0.72);
+  --gradient-card: linear-gradient(135deg, #172033 0%, #202c40 100%);
+}
+```
+
+This keeps the existing semantic token API intact while lifting muted text, links, and active-state boundaries above the WCAG AA contrast threshold.
+
+- [ ] **Step 5: Prove that the dark home state now passes**
+
+Run:
+
+```powershell
+npm run test:browser -- test/browser/accessibility.spec.js --project=chromium
+```
+
+Expected result: all three Chromium accessibility tests pass with no serious or critical violations.
+
+- [ ] **Step 6: Commit the independently verified home-state change**
+
+```powershell
+git add test/browser/accessibility.spec.js index.html
+git commit -m "fix: improve dark home contrast"
+```
+
+---
+
+## Task 2: Cover and correct the dark opened-role state
+
+**Files:**
+
+- Modify: `test/browser/accessibility.spec.js`
+- Modify: `index.html:375-390`
+
+**Interfaces:**
+
+- Reuse `activateDarkTheme(page)` from Task 1.
+- Continue using the accessible search and role-card names rather than CSS selectors to open a role.
+- Preserve the existing role-level class names (`b-ceo` through `b-tal`).
+
+- [ ] **Step 1: Add the failing dark opened-role accessibility test**
+
+Add this test after the existing opened-role accessibility test:
+
+```javascript
+test('dark opened role has no serious or critical axe violations', async ({ page }, testInfo) => {
+  await activateDarkTheme(page);
+
+  const search = page.getByRole('textbox', { name: 'Search roles' });
+  await search.fill('Kubernetes Architect');
+  await page.getByRole('button', { name: /Kubernetes Architect/ }).click();
+
+  await expect(
+    page.locator('#roleHeader').getByRole('heading', { name: 'Kubernetes Architect' }),
+  ).toBeVisible();
+  await scanForAccessibility(page, testInfo, 'dark-opened-role');
+});
+```
+
+- [ ] **Step 2: Prove that the opened-role test catches the remaining defect**
+
+Run:
+
+```powershell
+npm run test:browser -- test/browser/accessibility.spec.js --project=chromium
+```
+
+Expected result: the new dark opened-role test fails if any role badge or opened-role state still has a serious `color-contrast` violation. The attached axe report must name the remaining selectors; do not infer them from appearance alone.
+
+- [ ] **Step 3: Replace translucent dark badge overrides with accessible solid pairs**
+
+Replace the existing dark-theme role-badge override block in `index.html` with:
+
+```css
+[data-theme="dark"] .b-ceo { background: #3a2c0c; color: #fcd34d; }
+[data-theme="dark"] .b-cto { background: #26264f; color: #c7d2fe; }
+[data-theme="dark"] .b-cio { background: #11382d; color: #6ee7b7; }
+[data-theme="dark"] .b-cfo { background: #442039; color: #f9a8d4; }
+[data-theme="dark"] .b-svp { background: #2b3442; color: #f1f5f9; }
+[data-theme="dark"] .b-ciso { background: #48252b; color: #fecaca; }
+[data-theme="dark"] .b-arch { background: #342247; color: #e9d5ff; }
+[data-theme="dark"] .b-lead { background: #422b18; color: #fdba74; }
+[data-theme="dark"] .b-prin { background: #3b330f; color: #fde68a; }
+[data-theme="dark"] .b-cl { background: #103b34; color: #5eead4; }
+[data-theme="dark"] .b-sen { background: #163858; color: #93c5fd; }
+[data-theme="dark"] .b-eng { background: #173822; color: #86efac; }
+[data-theme="dark"] .b-po { background: #422a0b; color: #fdba74; }
+[data-theme="dark"] .b-standards { background: #123744; color: #67e8f9; }
+[data-theme="dark"] .b-pal { background: #1d3557; color: #bfdbfe; }
+[data-theme="dark"] .b-tal { background: #123b55; color: #bae6fd; }
+```
+
+The solid backgrounds make each foreground/background pair deterministic instead of depending on alpha blending with the surrounding card.
+
+- [ ] **Step 4: Prove both dark states pass in every supported browser**
+
+Run:
+
+```powershell
+npm run test:browser -- test/browser/accessibility.spec.js
+```
+
+Expected result: 12 accessibility tests pass: four states in each of Chromium, Firefox, and WebKit. No test may use an axe exclusion.
+
+- [ ] **Step 5: Commit the independently verified opened-role change**
+
+```powershell
+git add test/browser/accessibility.spec.js index.html
+git commit -m "test: cover dark opened-role contrast"
+```
+
+---
+
+## Task 3: Complete regression and visual verification
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-08-07-dark-theme-contrast-design.md`
+
+- [ ] **Step 1: Run the full automated verification set**
+
+Run each command separately:
+
+```powershell
+npm test
+npm run test:browser
+npm run validate
+npm run count
+npx markdownlint-cli2 "**/*.md" "#node_modules"
+```
+
+Expected results from the current baseline plus the two new browser tests:
+
+- `npm test`: 233 tests pass.
+- `npm run test:browser`: 27 tests pass across Chromium, Firefox, and WebKit.
+- `npm run validate`: zero errors; the existing warning baseline remains unchanged unless the generated data changed, which this plan forbids.
+- `npm run count`: 226 roles, 34 categories, and 7 tracks.
+- Markdown lint: zero errors.
+
+- [ ] **Step 2: Inspect the final UI at desktop and narrow widths**
+
+Start the local server:
+
+```powershell
+npm start
+```
+
+Inspect these four states with the browser developer tools at 1440×900 and 375×812:
+
+1. Light home: confirm it is visually unchanged.
+2. Dark home: confirm filter chips, resource headings, welcome text, borders, and focus indicators are readable.
+3. Light Kubernetes Architect: confirm it is visually unchanged.
+4. Dark Kubernetes Architect: confirm the Chapter Lead badge, metadata keys, career links, table-of-contents chips, and Role Overview text are readable.
+
+Also keyboard-tab through the theme button, search input, filter chips, role card, and opened-role table of contents. Confirm the 2px accent focus outline remains visible and no text disappears on hover or active states.
+
+- [ ] **Step 3: Record the verified result in the approved design**
+
+Change the design document status from `Approved` to `Implemented`, then append:
+
+```markdown
+## Implementation verification
+
+- Dark home and dark opened-role axe scans pass without exclusions in Chromium, Firefox, and WebKit.
+- The full Node and browser suites pass.
+- Repository validation and content counts remain at their pre-change baselines.
+- Desktop and narrow-width checks confirm that the light theme and layout remain unchanged.
+```
+
+Use the actual command results in place of any statement that did not pass exactly as written.
+
+- [ ] **Step 4: Commit the verification record**
+
+```powershell
+git add docs/superpowers/specs/2026-08-07-dark-theme-contrast-design.md
+git commit -m "docs: record dark-theme verification"
+```
+
+- [ ] **Step 5: Push the completed branch**
+
+```powershell
+git push
+```
+
+The branch is then ready for the GitHub hygiene checks, issue-linking pull request, and review workflow.

--- a/docs/superpowers/plans/2026-08-07-dark-theme-contrast.md
+++ b/docs/superpowers/plans/2026-08-07-dark-theme-contrast.md
@@ -210,7 +210,7 @@ Run each command separately:
 npm test
 npm run test:browser
 npm run validate
-npm run count
+npm run check-counts
 npx markdownlint-cli2 "**/*.md" "#node_modules"
 ```
 
@@ -219,7 +219,7 @@ Expected results from the current baseline plus the two new browser tests:
 - `npm test`: 233 tests pass.
 - `npm run test:browser`: 27 tests pass across Chromium, Firefox, and WebKit.
 - `npm run validate`: zero errors; the existing warning baseline remains unchanged unless the generated data changed, which this plan forbids.
-- `npm run count`: 226 roles, 34 categories, and 7 tracks.
+- `npm run check-counts`: 226 roles, 34 domains, and 7 chapters.
 - Markdown lint: zero errors.
 
 - [ ] **Step 2: Inspect the final UI at desktop and narrow widths**

--- a/docs/superpowers/specs/2026-08-07-dark-theme-contrast-design.md
+++ b/docs/superpowers/specs/2026-08-07-dark-theme-contrast-design.md
@@ -1,0 +1,130 @@
+# Dark-Theme Contrast Remediation Design
+
+**Issue:** #202  
+**Status:** Approved  
+**Date:** 2026-08-07
+
+## Context
+
+The viewer's default light theme passes the serious/critical axe accessibility
+gate introduced by #183 and completed in #201. The dark theme still produces
+serious `color-contrast` violations on the home screen and after opening a role.
+The failures cover muted copy, filter chips, resource headings, reporting
+metadata, career-path controls, section navigation, and some role-level badges.
+
+The existing dark theme is a compact override block in `index.html`. Theme
+selection sets `data-theme="dark"` on the root element, after which semantic CSS
+variables and a small set of badge overrides determine component colours.
+
+## Goals
+
+- Eliminate serious and critical axe violations in dark-mode home and opened-role states.
+- Refresh the dark palette so text hierarchy, surface depth, and interactive states remain clear.
+- Preserve visible focus, selected-state clarity, and role-level differentiation.
+- Add permanent dark-theme coverage across Chromium, Firefox, and WebKit.
+- Keep the light theme and viewer layout unchanged.
+
+## Non-goals
+
+- Reworking layout, typography, spacing, or component structure.
+- Moving theme configuration out of `index.html`; configuration centralisation remains #184.
+- Weakening axe severity, excluding selectors, or disabling the `color-contrast` rule.
+- Resolving unrelated accessibility findings below serious impact.
+
+## Considered Approaches
+
+### 1. Semantic token refresh with limited component overrides — selected
+
+Refresh the dark semantic variables first, then adjust only badge or state pairs
+whose meaning depends on their own hue. This fixes shared causes, keeps the theme
+coherent, and minimises selector-specific debt.
+
+### 2. Component-by-component overrides
+
+Add dark selectors for every failing element while retaining the existing token
+values. This would preserve more of the current appearance, but duplicate colour
+decisions and make future components easy to miss.
+
+### 3. Full visual redesign
+
+Redesign elevation, borders, spacing, and component treatments along with the
+palette. This offers the most freedom but expands a bounded accessibility fix
+into an unrelated UI project.
+
+## Palette and Component Design
+
+The refreshed theme uses cool charcoal/navy surfaces and brighter text:
+
+| Semantic role | Direction |
+|---|---|
+| Page background | Deep navy-charcoal, darker than every content surface |
+| Cards | Dark slate with a distinct but restrained elevation step |
+| Inputs and inactive chips | Lighter slate so their boundaries remain visible |
+| Primary text | Near-white |
+| Secondary text | Light cool grey |
+| Muted text | Brighter blue-grey that still passes 4.5:1 on every surface where it appears |
+| Interactive blue | Light blue suitable for text, links, borders, and focus on dark surfaces |
+| Borders | Higher-opacity light borders; interactive borders use the light blue accent |
+
+Role-level badges retain their established hue families. Each foreground and
+background pair must independently meet the normal-text contrast threshold.
+Active filter and navigation chips use three signals together: brighter text,
+a tinted surface, and a visible border. Focus remains a two-pixel accent outline
+with an offset and never relies on the selected-state background alone.
+
+Palette values will be implemented as semantic variables in the existing
+`[data-theme="dark"]` block. Component-specific dark overrides are permitted only
+for role-level badge pairs and interactive states that cannot inherit a shared
+semantic token without losing meaning.
+
+## Behaviour and Data Flow
+
+1. The existing theme button activates dark mode.
+2. The root `data-theme` attribute changes to `dark` and its pressed state updates.
+3. Dark semantic variables flow through existing component styles.
+4. Badge and active-state overrides refine the few semantic exceptions.
+5. No JavaScript theme-storage or rendering behaviour changes.
+
+## Automated Verification
+
+`test/browser/accessibility.spec.js` will gain dark-theme variants for:
+
+- the home state; and
+- an opened `Kubernetes Architect` role.
+
+Each dark test will:
+
+1. activate dark mode through the accessible theme button;
+2. assert the root theme attribute and button pressed state;
+3. wait for finite UI animations through the existing scan helper;
+4. run axe without exclusions; and
+5. fail on any serious or critical violation, attaching the complete violation JSON.
+
+The tests run in the existing Chromium, Firefox, and WebKit projects. The full
+browser suite must remain green so navigation, responsive behaviour, search,
+comparison, and light-theme accessibility are protected.
+
+## Manual Verification
+
+Inspect dark home and opened-role states at desktop and narrow widths. Confirm:
+
+- text hierarchy remains legible without appearing uniformly bright;
+- inactive, hover, active, and focus states are distinguishable;
+- every role-level badge remains recognisable by both label and colour;
+- links remain visually distinct from body text; and
+- surfaces retain clear depth without excessive border noise.
+
+## Failure Handling
+
+The accessibility helper already attaches complete axe details when violations
+exist. Theme activation assertions will fail before the scan if dark mode cannot
+be entered, preventing a false green result caused by scanning the light theme.
+No fallback palette or suppression path is introduced.
+
+## Delivery Boundaries
+
+The implementation belongs in one issue-linked branch and pull request for
+#202. It should modify only the dark palette/component overrides, browser
+accessibility tests, and this design/implementation documentation. Configuration
+centralisation (#184), stable role identity (#180), and vendored dependency
+verification (#185) remain separate changes.

--- a/docs/superpowers/specs/2026-08-07-dark-theme-contrast-design.md
+++ b/docs/superpowers/specs/2026-08-07-dark-theme-contrast-design.md
@@ -1,7 +1,7 @@
 # Dark-Theme Contrast Remediation Design
 
 **Issue:** #202  
-**Status:** Approved  
+**Status:** Implemented
 **Date:** 2026-08-07
 
 ## Context
@@ -128,3 +128,10 @@ The implementation belongs in one issue-linked branch and pull request for
 accessibility tests, and this design/implementation documentation. Configuration
 centralisation (#184), stable role identity (#180), and vendored dependency
 verification (#185) remain separate changes.
+
+## Implementation verification
+
+- Dark home and dark opened-role axe scans pass without exclusions in Chromium, Firefox, and WebKit.
+- The full Node and browser suites pass.
+- Repository validation and content counts remain at their pre-change baselines.
+- Desktop and narrow-width checks confirm that the light theme and layout remain unchanged.

--- a/index.html
+++ b/index.html
@@ -39,21 +39,17 @@
             --sidebar-w:  290px;
         }
         [data-theme="dark"] {
-            --bg-primary:     #0d1117;
-            --bg-card:        #161b22;
-            --bg-card-hover:  #1c2333;
-            --bg-input:       #21262d;
-            --text-primary:   #e6edf3;
-            --text-secondary: #b1bac4;
-            --text-muted:     #7d8590;
-            --accent-blue:    #0078D4;
-            --border-color:   rgba(255,255,255,0.1);
-            --border-hover:   rgba(0,120,212,0.4);
-            --shadow-sm:      0 1px 3px rgba(0,0,0,0.3);
-            --shadow-md:      0 4px 12px rgba(0,0,0,0.4);
-            --shadow-lg:      0 8px 30px rgba(0,0,0,0.5);
-            --shadow-xl:      0 20px 60px rgba(0,0,0,0.6);
-            --gradient-card:  linear-gradient(135deg, #1c2333 0%, #21262d 100%);
+            --bg-primary: #0b1220;
+            --bg-card: #111827;
+            --bg-card-hover: #1b2638;
+            --bg-input: #243044;
+            --text-primary: #f8fafc;
+            --text-secondary: #d6deea;
+            --text-muted: #b4c0d0;
+            --accent-blue: #6eb6ff;
+            --border-color: rgba(226, 232, 240, 0.18);
+            --border-hover: rgba(110, 182, 255, 0.72);
+            --gradient-card: linear-gradient(135deg, #172033 0%, #202c40 100%);
         }
 
         *, *::before, *::after { margin:0; padding:0; box-sizing:border-box; }

--- a/index.html
+++ b/index.html
@@ -368,22 +368,22 @@
         .b-pal   { background: rgba(30,58,95,0.14);   color: #1e3a5f; }
         .b-tal   { background: rgba(0,120,212,0.22);  color: #005a9e; font-weight: 700; }
 
-        [data-theme="dark"] .b-ceo  { background: rgba(251,191,36,0.25);  color: #fcd34d; font-weight: 700; }
-        [data-theme="dark"] .b-cto  { background: rgba(165,180,252,0.25); color: #a5b4fc; font-weight: 700; }
-        [data-theme="dark"] .b-cio  { background: rgba(52,211,153,0.25);  color: #34d399; font-weight: 700; }
-        [data-theme="dark"] .b-cfo  { background: rgba(244,114,182,0.25); color: #f472b6; font-weight: 700; }
-        [data-theme="dark"] .b-svp  { background: rgba(226,232,240,0.15); color: #e2e8f0; font-weight: 700; }
-        [data-theme="dark"] .b-ciso { background: rgba(254,202,202,0.2);  color: #fca5a5; font-weight: 700; }
-        [data-theme="dark"] .b-arch { background: rgba(118,75,162,0.28); color: #c09ee0; }
-        [data-theme="dark"] .b-lead { background: rgba(220,130,50,0.28); color: #f0a860; }
-        [data-theme="dark"] .b-prin { background: rgba(220,180,0,0.28);  color: #f0d060; font-weight: 700; }
-        [data-theme="dark"] .b-cl   { background: rgba(0,200,160,0.28);  color: #00d4a8; font-weight: 700; }
-        [data-theme="dark"] .b-sen  { background: rgba(0,120,212,0.28);  color: #60b4ff; }
-        [data-theme="dark"] .b-eng  { background: rgba(40,167,69,0.28);  color: #6bcf7f; }
-        [data-theme="dark"] .b-po   { background: rgba(255,152,0,0.28);  color: #ffb84d; }
-        [data-theme="dark"] .b-standards { background: rgba(23,162,184,0.25); color: #5fd3e8; }
-        [data-theme="dark"] .b-pal  { background: rgba(100,160,255,0.2); color: #a0c8ff; font-weight: 700; }
-        [data-theme="dark"] .b-tal  { background: rgba(0,120,212,0.35);  color: #90d0ff; font-weight: 700; }
+        [data-theme="dark"] .b-ceo { background: #3a2c0c; color: #fcd34d; }
+        [data-theme="dark"] .b-cto { background: #26264f; color: #c7d2fe; }
+        [data-theme="dark"] .b-cio { background: #11382d; color: #6ee7b7; }
+        [data-theme="dark"] .b-cfo { background: #442039; color: #f9a8d4; }
+        [data-theme="dark"] .b-svp { background: #2b3442; color: #f1f5f9; }
+        [data-theme="dark"] .b-ciso { background: #48252b; color: #fecaca; }
+        [data-theme="dark"] .b-arch { background: #342247; color: #e9d5ff; }
+        [data-theme="dark"] .b-lead { background: #422b18; color: #fdba74; }
+        [data-theme="dark"] .b-prin { background: #3b330f; color: #fde68a; }
+        [data-theme="dark"] .b-cl { background: #103b34; color: #5eead4; }
+        [data-theme="dark"] .b-sen { background: #163858; color: #93c5fd; }
+        [data-theme="dark"] .b-eng { background: #173822; color: #86efac; }
+        [data-theme="dark"] .b-po { background: #422a0b; color: #fdba74; }
+        [data-theme="dark"] .b-standards { background: #123744; color: #67e8f9; }
+        [data-theme="dark"] .b-pal { background: #1d3557; color: #bfdbfe; }
+        [data-theme="dark"] .b-tal { background: #123b55; color: #bae6fd; }
 
         /* ── MAIN CONTENT ────────────────────────────────────────────── */
         .main {
@@ -536,6 +536,11 @@
             color: #fff;
             font-weight: 700;
             white-space: nowrap;
+        }
+        [data-theme="dark"] .career-stepper .cs-current {
+            background: var(--bg-input);
+            color: var(--accent-blue);
+            box-shadow: inset 0 0 0 1px var(--border-hover);
         }
         .career-stepper .cs-arrow { color: var(--text-muted); font-weight: 700; }
         @media print { .career-stepper { display: none; } }

--- a/test/browser/accessibility.spec.js
+++ b/test/browser/accessibility.spec.js
@@ -65,3 +65,16 @@ test('opened role has no serious or critical axe violations', async ({ page }, t
 
   await scanForAccessibility(page, testInfo, 'opened-role');
 });
+
+test('dark opened role has no serious or critical axe violations', async ({ page }, testInfo) => {
+  await activateDarkTheme(page);
+
+  const search = page.getByRole('textbox', { name: 'Search roles' });
+  await search.fill('Kubernetes Architect');
+  await page.getByRole('button', { name: /Kubernetes Architect/ }).click();
+
+  await expect(
+    page.locator('#roleHeader').getByRole('heading', { name: 'Kubernetes Architect' }),
+  ).toBeVisible();
+  await scanForAccessibility(page, testInfo, 'dark-opened-role');
+});

--- a/test/browser/accessibility.spec.js
+++ b/test/browser/accessibility.spec.js
@@ -33,6 +33,14 @@ async function scanForAccessibility(page, testInfo, stateName) {
   expect(summary, `${stateName} has serious or critical axe violations`).toEqual([]);
 }
 
+async function activateDarkTheme(page) {
+  const themeButton = page.getByRole('button', { name: 'Toggle dark mode' });
+
+  await themeButton.click();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+  await expect(themeButton).toHaveAttribute('aria-pressed', 'true');
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
 });
@@ -40,6 +48,13 @@ test.beforeEach(async ({ page }) => {
 test('home state has no serious or critical axe violations', async ({ page }, testInfo) => {
   await expect(page.getByRole('heading', { name: 'Select a role to view' })).toBeVisible();
   await scanForAccessibility(page, testInfo, 'home');
+});
+
+test('dark home state has no serious or critical axe violations', async ({ page }, testInfo) => {
+  await activateDarkTheme(page);
+
+  await expect(page.getByRole('heading', { name: 'Select a role to view' })).toBeVisible();
+  await scanForAccessibility(page, testInfo, 'dark-home');
 });
 
 test('opened role has no serious or critical axe violations', async ({ page }, testInfo) => {


### PR DESCRIPTION
Closes #202

## Summary
- refresh semantic dark-theme colours for WCAG AA contrast
- add deterministic accessible badge and career-state pairs
- add axe coverage for dark home and opened-role states

## Verification
- npm test: 233/233 passed
- npm run test:browser: 27/27 passed across Chromium, Firefox, and WebKit
- npm run validate: 0 errors
- npm run check-counts: 226 roles, 34 domains, 7 chapters
- Markdown lint: 0 issues
- desktop and narrow light/dark states reviewed