### PR TITLE
fix: verify dependencies and record decisions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+This catalogue influences role design, career conversations, and operating-model decisions. A structurally valid Markdown file is not enough: consequential claims need evidence, ownership, and an honest confidence level.
+
+## Before changing the catalogue
+
+1. Search [GitHub Issues](https://github.com/JeanKadang/DOC-ITRoles/issues) for the change or decision.
+2. Create or update an issue before implementation. Issues are the backlog source of truth; do not add new backlog checklists to Markdown documents.
+3. Identify whether the proposal changes portable catalogue content, an organisation-specific commitment, generated output, or a durable taxonomy decision.
+4. For a durable decision, add or update a proposed [Architecture Decision Record](docs/adr/README.md) in the same pull request.
+
+## Evidence standards
+
+Prefer primary, authoritative sources. Link the exact page, standard, release, policy, or decision that supports a claim and record the date it was checked when the source can change.
+
+| Content | Required evidence |
+|---|---|
+| Role responsibility or accountability | Named domain owner or approved operating-model source; distinguish a portable recommendation from local policy |
+| Certification or credential | Official issuer page, exact credential name, credential type, lifecycle status, and verification date; do not present organisation programmes as individual credentials |
+| Technology or standard | Official product, project, or standards-body source; record version/status when material |
+| KPI target | Approved target source, frequency, and scope (`global`, `service-specific`, or `local`); never generate an authoritative-looking commitment |
+| Reporting or career relationship | Existing catalogue role or explicitly labelled external destination; do not guess a relationship from similar names |
+| Review provenance | Reviewer or accountable team, date, scope reviewed, and evidence/decision link where available |
+
+If evidence is unavailable, label the content as proposed or unresolved and link the issue that owns the decision. An unresolved value is preferable to a fabricated one.
+
+## What counts as substantive review
+
+A substantive reviewer checks meaning, boundaries, relationships, and source currency—not only spelling, formatting, or template compliance. Record which sections or claims were reviewed. Mechanical bulk edits and generated rebuilds must not reset subject-matter review dates or imply approval by a domain owner.
+
+Reviewers should explicitly check:
+
+- responsibilities do not duplicate or contradict adjacent roles;
+- organisation-specific policy is labelled instead of asserted as universal;
+- credentials and standards still exist under the recorded name and status;
+- KPI rows contain an approved target and cadence, or remain visibly unresolved;
+- reporting, interaction, and career destinations resolve or are marked external;
+- privacy-sensitive reviewer metadata uses durable team identifiers where appropriate.
+
+## Generated content
+
+Edit a generator's source data or script, not its generated Markdown. Regenerate the artefact and commit source and output together. The pull request must state the command used and must not hand-maintain counts that the repository derives from files.
+
+## Pull request checklist
+
+- Link the issue with `Closes #<number>` when the acceptance criteria are complete.
+- Explain the evidence and any organisation-specific assumptions.
+- Update an ADR when the change creates or reverses a durable taxonomy decision.
+- Run `npm test`, `npm run validate`, `npm run check-counts`, and any focused generator or verifier command affected by the change.
+- Keep generated output, documentation links, and the changelog consistent with the implementation.
+
+Security vulnerabilities and credentials must not be filed in a public issue; follow [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Each role file follows the canonical 14-section structure. See [`docs/role_templ
 
 | Document | Purpose |
 |---|---|
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Evidence standards, substantive review expectations, and contribution workflow |
+| [`docs/adr/README.md`](docs/adr/README.md) | Durable catalogue and architecture decisions, ADR lifecycle, and index |
 | [`docs/CROSS_DOMAIN_INTERACTIONS.md`](docs/CROSS_DOMAIN_INTERACTIONS.md) | Domain ownership boundaries, key relationships, escalation paths |
 | [`docs/SKILLS_PROGRESSION.md`](docs/SKILLS_PROGRESSION.md) | Engineer → Senior → Architect career ladder per domain |
 | [`docs/ONBOARDING_TEMPLATE.md`](docs/ONBOARDING_TEMPLATE.md) | 30/60/90 day plan template for new hires |
@@ -211,6 +213,7 @@ Each role file follows the canonical 14-section structure. See [`docs/role_templ
 | [`docs/improvements_and_recommendations.md`](docs/improvements_and_recommendations.md) | **Closed.** Narrative of the four 2026 review cycles. Open work is in [GitHub Issues](https://github.com/JeanKadang/DOC-ITRoles/issues); what shipped is in [CHANGELOG.md](CHANGELOG.md) |
 | [`CHANGELOG.md`](CHANGELOG.md) | Version history of the codebase (Keep a Changelog format) |
 | [`SECURITY.md`](SECURITY.md) | Security policy and how to report a vulnerability |
+| [`vendor/README.md`](vendor/README.md) | Vendored dependency provenance, licence notices, verification, and upgrade process |
 
 ## Development
 

--- a/docs/adr/0001-organise-domains-into-seven-capability-chapters.md
+++ b/docs/adr/0001-organise-domains-into-seven-capability-chapters.md
@@ -1,0 +1,24 @@
+# ADR-0001: Organise domains into seven capability chapters
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Issue/PR:** #192
+
+## Context
+
+The catalogue contains many technology domains. A flat domain list does not provide an accountable operating-model layer for shared standards, practitioner development, or cross-domain collaboration. Hand-maintained role and domain counts have also drifted in narrative documents.
+
+The established catalogue groups domains into Cloud, Platform & Infrastructure; DevOps & Delivery; Data & AI; Security & Identity; End User & Workplace; Service & Governance; and Leadership. The first six capability chapters have Chapter Lead roles; Leadership contains cross-cutting executive and chapter leadership roles.
+
+## Decision
+
+Keep the seven chapters as the catalogue's grouping layer above domains. Each domain belongs to one capability chapter, while leadership roles remain in the Leadership chapter. Chapter narratives describe purpose and collaboration, but role/domain counts are derived from the catalogue rather than copied into those narratives.
+
+Changing a chapter boundary, creating a chapter, or moving a domain between chapters is a taxonomy decision and requires an issue plus a superseding ADR or explicit amendment decision.
+
+## Consequences
+
+- Chapter ownership and cross-domain collaboration have a stable vocabulary.
+- Domain additions must update the chapter configuration and chapter narrative.
+- The viewer and generated documents should derive membership and counts from one configuration source; centralising that source remains tracked by #184.
+- Organisation-specific structures that do not fit these chapters require an explicit future overlay decision rather than silent edits to the portable base.

--- a/docs/adr/0002-separate-technical-product-and-people-leadership-tracks.md
+++ b/docs/adr/0002-separate-technical-product-and-people-leadership-tracks.md
@@ -1,0 +1,28 @@
+# ADR-0002: Separate technical, product, and people-leadership tracks
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Issue/PR:** #192
+
+## Context
+
+The catalogue needs to show growth without implying that every senior practitioner must become a people manager. It also includes Product Owners whose backlog, value, and roadmap accountability differs from both technical proficiency and line management.
+
+The established progression model describes Engineer through Principal Architect as a technical individual-contributor path, Chapter Lead through TAL/PAL as people/area leadership, and Product Owner as a domain product-accountability role.
+
+## Decision
+
+Model technical individual contribution, product accountability, and people leadership as distinct tracks:
+
+- Engineer, Senior Engineer, Architect, Lead Architect, and Principal Architect form the technical IC progression where present.
+- Product Owner is a domain role with product/backlog accountability, not an automatic promotion rung above Architect or Senior Engineer.
+- Chapter Lead, Technical Area Lead, and Product Area Lead form leadership paths with explicit people or area accountability.
+
+Career-path text may describe transitions between tracks, but must not present a cross-track move as a universal promotion or infer management authority from senior technical level alone.
+
+## Consequences
+
+- Senior technical progression can remain credible without mandatory line management.
+- Product Owner comparisons must focus on product accountability rather than technical seniority.
+- Role metadata, viewer ordering, skills progression, and onboarding supplements must preserve the distinction.
+- Local organisations may map grades differently, but such mappings are local policy rather than changes to the portable base taxonomy.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,20 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) preserve consequential catalogue, governance, and implementation decisions with the files they affect. GitHub Issues own decisions still to be made; an accepted ADR records the outcome.
+
+## Lifecycle
+
+1. Open an issue labelled `decision-needed` when a durable choice is unresolved.
+2. Copy [`template.md`](template.md) to the next four-digit filename and set its status to `Proposed`.
+3. Review the options and consequences in the pull request.
+4. Merge as `Accepted` and link the deciding issue/PR.
+5. Never rewrite an accepted decision to reverse it. Add a new ADR, set the old record to `Superseded by ADR-NNNN`, and link both records.
+
+Allowed statuses are `Proposed`, `Accepted`, `Deprecated`, and `Superseded by ADR-NNNN`.
+
+## Index
+
+| ADR | Status | Decision |
+|---|---|---|
+| [0001](0001-organise-domains-into-seven-capability-chapters.md) | Accepted | Organise domains into seven capability chapters |
+| [0002](0002-separate-technical-product-and-people-leadership-tracks.md) | Accepted | Separate technical, product, and people-leadership tracks |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,17 @@
+# ADR-NNNN: Decision title
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Issue/PR:** #NNN
+
+## Context
+
+Describe the problem, constraints, evidence, and alternatives that made a durable decision necessary.
+
+## Decision
+
+State the chosen rule precisely enough that future contributors can apply it consistently.
+
+## Consequences
+
+Record the benefits, costs, exclusions, follow-up work, and conditions that could justify superseding this decision.

--- a/docs/superpowers/plans/2026-08-07-contribution-evidence-adrs.md
+++ b/docs/superpowers/plans/2026-08-07-contribution-evidence-adrs.md
@@ -19,6 +19,7 @@
 ### Task 1: Evidence and decision guidance
 
 **Files:**
+
 - Create: `CONTRIBUTING.md`
 - Create: `docs/adr/README.md`
 - Create: `docs/adr/template.md`
@@ -27,6 +28,7 @@
 - Modify: `README.md`
 
 **Interfaces:**
+
 - Consumes: current role template, repository design notes, and retired recommendations workflow
 - Produces: contributor review rules and indexed, immutable decision records
 

--- a/docs/superpowers/plans/2026-08-07-contribution-evidence-adrs.md
+++ b/docs/superpowers/plans/2026-08-07-contribution-evidence-adrs.md
@@ -1,0 +1,37 @@
+# Contribution Evidence and ADRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add evidence-focused contribution guidance and a lightweight ADR system with two pilot decisions.
+
+**Architecture:** Keep contributor policy in one root document, keep immutable decisions as individually numbered files under `docs/adr/`, and make both discoverable from README. Record only decisions already evidenced by the repository.
+
+**Tech Stack:** Markdown, existing Markdown/link checks
+
+## Global Constraints
+
+- Do not invent organisational commitments, KPI values, reviewers, or credential authority.
+- GitHub Issues remain the backlog source of truth.
+- Accepted ADRs are superseded by new records rather than rewritten.
+
+---
+
+### Task 1: Evidence and decision guidance
+
+**Files:**
+- Create: `CONTRIBUTING.md`
+- Create: `docs/adr/README.md`
+- Create: `docs/adr/template.md`
+- Create: `docs/adr/0001-retain-portable-no-build-viewer.md`
+- Create: `docs/adr/0002-use-github-issues-as-backlog.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: current role template, repository design notes, and retired recommendations workflow
+- Produces: contributor review rules and indexed, immutable decision records
+
+- [ ] **Step 1: Write `CONTRIBUTING.md`** with evidence, review, credential, KPI, generated-content, and issue/PR standards.
+- [ ] **Step 2: Add the ADR guide, template, and two accepted pilot records** using Context / Decision / Consequences / Status.
+- [ ] **Step 3: Link the guidance from README's governance table.**
+- [ ] **Step 4: Run `npm test`, `npm run validate`, and the repository Markdown lint command** expecting zero failures.
+- [ ] **Step 5: Commit** with `docs: add contribution evidence and ADRs`.

--- a/docs/superpowers/plans/2026-08-07-vendored-dependency-verification.md
+++ b/docs/superpowers/plans/2026-08-07-vendored-dependency-verification.md
@@ -19,6 +19,7 @@
 ### Task 1: Vendor manifest verifier
 
 **Files:**
+
 - Create: `test/vendor-verification.test.js`
 - Create: `scripts/verify-vendor.js`
 - Create: `vendor/manifest.json`
@@ -26,6 +27,7 @@
 - Modify: `package.json`
 
 **Interfaces:**
+
 - Consumes: `{ assets: Array<{ file, package, version, source, license, sha256, verified, owner, reviewCadence }> }`
 - Produces: `verifyVendor(rootDir): string[]`, where an empty array means success
 

--- a/docs/superpowers/plans/2026-08-07-vendored-dependency-verification.md
+++ b/docs/superpowers/plans/2026-08-07-vendored-dependency-verification.md
@@ -1,0 +1,37 @@
+# Vendored Dependency Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add offline provenance and SHA-256 verification for every vendored browser asset.
+
+**Architecture:** Store review metadata in `vendor/manifest.json`, document the maintenance policy in `vendor/README.md`, and verify both schema and committed bytes through a dependency-free Node script. Exercise the verifier through `node:test` and expose it through npm.
+
+**Tech Stack:** Node.js built-ins, JSON, Markdown, `node:test`
+
+## Global Constraints
+
+- Preserve the zero-runtime-dependency and offline architecture.
+- Verification must not require network access.
+- Every JavaScript file directly under `vendor/` must have exactly one manifest entry.
+
+---
+
+### Task 1: Vendor manifest verifier
+
+**Files:**
+- Create: `test/vendor-verification.test.js`
+- Create: `scripts/verify-vendor.js`
+- Create: `vendor/manifest.json`
+- Create: `vendor/README.md`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: `{ assets: Array<{ file, package, version, source, license, sha256, verified, owner, reviewCadence }> }`
+- Produces: `verifyVendor(rootDir): string[]`, where an empty array means success
+
+- [ ] **Step 1: Write failing tests** for a valid temporary manifest, changed bytes, an untracked JavaScript file, and the committed repository manifest.
+- [ ] **Step 2: Run `node --test test/vendor-verification.test.js`** and confirm failure because `scripts/verify-vendor.js` does not exist.
+- [ ] **Step 3: Implement `verifyVendor(rootDir)`** using `node:crypto`, `node:fs`, and `node:path`, plus a CLI that prints errors and exits non-zero.
+- [ ] **Step 4: Add the manifest and maintenance README** using the four committed assets and their SHA-256 digests.
+- [ ] **Step 5: Add `verify-vendor` to `package.json` and run the focused test, `npm run verify-vendor`, and `npm test`** expecting zero failures.
+- [ ] **Step 6: Commit** with `fix: verify vendored dependencies`.

--- a/docs/superpowers/specs/2026-08-07-contribution-evidence-adrs-design.md
+++ b/docs/superpowers/specs/2026-08-07-contribution-evidence-adrs-design.md
@@ -1,0 +1,13 @@
+# Contribution Evidence and ADRs Design
+
+## Goal
+
+Give content contributors a concise evidence standard and preserve consequential catalogue decisions in versioned decision records.
+
+## Design
+
+Root-level `CONTRIBUTING.md` focuses on substantive content review rather than repeating Git mechanics. It distinguishes evidence-backed facts, organisation-specific commitments, generated content, and unresolved proposals; it also covers credentials, KPI targets, review provenance, and issue-first workflow.
+
+`docs/adr/README.md` defines the immutable ADR lifecycle and indexes records. A reusable template records Status, Context, Decision, and Consequences. Two pilot accepted ADRs capture already-established decisions: retaining the portable no-build/offline viewer architecture and keeping GitHub Issues as the active backlog rather than Markdown checklists.
+
+The repository README links to both guides. Markdown lint and link checks provide verification.

--- a/docs/superpowers/specs/2026-08-07-vendored-dependency-verification-design.md
+++ b/docs/superpowers/specs/2026-08-07-vendored-dependency-verification-design.md
@@ -1,0 +1,15 @@
+# Vendored Dependency Verification Design
+
+## Goal
+
+Make every browser asset in `vendor/` traceable and mechanically verifiable without adding a runtime dependency or network requirement.
+
+## Design
+
+`vendor/manifest.json` is the machine-readable source for filename, package, version, upstream release URL, licence, SHA-256 checksum, verification date, owner, and review cadence. `vendor/README.md` explains the project licensing position and the offline upgrade/security-review procedure.
+
+`scripts/verify-vendor.js` validates the manifest schema, requires an entry for every committed JavaScript asset, rejects missing or unexpected files, and compares each file's SHA-256 digest. It performs no network access. `npm run verify-vendor` exposes the check locally and in CI through the existing `npm test` suite.
+
+## Error handling and tests
+
+The verifier returns actionable errors for malformed metadata, missing assets, unexpected assets, and checksum drift. Unit tests use temporary directories to prove a valid manifest succeeds and tampering fails before the committed repository assets are checked.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:browser": "node scripts/run-browser-tests.js",
     "validate": "node validate-roles.js",
     "check-counts": "node scripts/check-counts.js",
+    "verify-vendor": "node scripts/verify-vendor.js",
     "seed-kpi": "node scripts/seed-kpi-targets.js",
     "build-radar": "node scripts/build-radar.js",
     "build-skills-matrix": "node scripts/build-skills-matrix.js"

--- a/scripts/verify-vendor.js
+++ b/scripts/verify-vendor.js
@@ -1,0 +1,109 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REQUIRED_FIELDS = [
+  'file',
+  'package',
+  'version',
+  'source',
+  'license',
+  'sha256',
+  'verified',
+  'owner',
+  'reviewCadence',
+];
+
+function digest(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function verifyVendor(rootDir) {
+  const vendorDir = path.join(rootDir, 'vendor');
+  const manifestPath = path.join(vendorDir, 'manifest.json');
+  const errors = [];
+  let manifest;
+
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    return [`Unable to read vendor/manifest.json: ${error.message}`];
+  }
+
+  if (manifest.schemaVersion !== 1) {
+    errors.push('vendor/manifest.json: schemaVersion must be 1');
+  }
+  if (!Array.isArray(manifest.assets)) {
+    return [...errors, 'vendor/manifest.json: assets must be an array'];
+  }
+
+  const tracked = new Set();
+  for (const [index, asset] of manifest.assets.entries()) {
+    const label = `vendor/manifest.json assets[${index}]`;
+    if (!asset || typeof asset !== 'object' || Array.isArray(asset)) {
+      errors.push(`${label}: must be an object`);
+      continue;
+    }
+    for (const field of REQUIRED_FIELDS) {
+      if (typeof asset[field] !== 'string' || asset[field].trim() === '') {
+        errors.push(`${label}: ${field} must be a non-empty string`);
+      }
+    }
+    if (typeof asset.file !== 'string') continue;
+    if (path.basename(asset.file) !== asset.file || !asset.file.endsWith('.js')) {
+      errors.push(`${label}: file must be a JavaScript filename directly under vendor/`);
+      continue;
+    }
+    if (tracked.has(asset.file)) {
+      errors.push(`${label}: duplicate asset ${asset.file}`);
+      continue;
+    }
+    tracked.add(asset.file);
+
+    if (typeof asset.source === 'string' && !asset.source.startsWith('https://')) {
+      errors.push(`${label}: source must be an HTTPS URL`);
+    }
+    if (typeof asset.sha256 === 'string' && !/^[a-f0-9]{64}$/i.test(asset.sha256)) {
+      errors.push(`${label}: sha256 must contain 64 hexadecimal characters`);
+    }
+    if (typeof asset.verified === 'string' && !/^\d{4}-\d{2}-\d{2}$/.test(asset.verified)) {
+      errors.push(`${label}: verified must use YYYY-MM-DD`);
+    }
+
+    const assetPath = path.join(vendorDir, asset.file);
+    if (!fs.existsSync(assetPath)) {
+      errors.push(`Missing vendored asset: ${asset.file}`);
+    } else if (/^[a-f0-9]{64}$/i.test(asset.sha256 || '') && digest(assetPath) !== asset.sha256.toLowerCase()) {
+      errors.push(`Checksum mismatch for ${asset.file}`);
+    }
+  }
+
+  let vendorFiles = [];
+  try {
+    vendorFiles = fs.readdirSync(vendorDir)
+      .filter(file => file.endsWith('.js'))
+      .sort();
+  } catch (error) {
+    errors.push(`Unable to enumerate vendor/: ${error.message}`);
+  }
+  for (const file of vendorFiles) {
+    if (!tracked.has(file)) errors.push(`Untracked asset: ${file}`);
+  }
+
+  return errors;
+}
+
+if (require.main === module) {
+  const rootDir = process.argv[2]
+    ? path.resolve(process.argv[2])
+    : path.resolve(__dirname, '..');
+  const errors = verifyVendor(rootDir);
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+  } else {
+    console.log('Vendored dependency manifest and checksums verified.');
+  }
+}
+
+module.exports = { verifyVendor };

--- a/scripts/verify-vendor.js
+++ b/scripts/verify-vendor.js
@@ -70,6 +70,22 @@ function verifyVendor(rootDir) {
     if (typeof asset.verified === 'string' && !/^\d{4}-\d{2}-\d{2}$/.test(asset.verified)) {
       errors.push(`${label}: verified must use YYYY-MM-DD`);
     }
+    if (!Array.isArray(asset.licenseFiles) || asset.licenseFiles.length === 0) {
+      errors.push(`${label}: licenseFiles must be a non-empty array`);
+    } else {
+      for (const licenseFile of asset.licenseFiles) {
+        if (typeof licenseFile !== 'string' || licenseFile.trim() === '') {
+          errors.push(`${label}: licenseFiles entries must be non-empty strings`);
+          continue;
+        }
+        const licensePath = path.resolve(vendorDir, licenseFile);
+        if (!licensePath.startsWith(`${path.resolve(vendorDir)}${path.sep}`)) {
+          errors.push(`${label}: licence file must stay inside vendor/: ${licenseFile}`);
+        } else if (!fs.existsSync(licensePath)) {
+          errors.push(`Missing licence file: ${licenseFile}`);
+        }
+      }
+    }
 
     const assetPath = path.join(vendorDir, asset.file);
     if (!fs.existsSync(assetPath)) {

--- a/scripts/verify-vendor.js
+++ b/scripts/verify-vendor.js
@@ -15,7 +15,8 @@ const REQUIRED_FIELDS = [
 ];
 
 function digest(filePath) {
-  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  const normalized = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+  return crypto.createHash('sha256').update(normalized).digest('hex');
 }
 
 function verifyVendor(rootDir) {

--- a/test/vendor-verification.test.js
+++ b/test/vendor-verification.test.js
@@ -15,8 +15,10 @@ function createFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vendor-verification-'));
   const vendorDir = path.join(root, 'vendor');
   fs.mkdirSync(vendorDir);
+  fs.mkdirSync(path.join(vendorDir, 'licenses'));
   const content = '/* Example 1.0.0 */\n';
   fs.writeFileSync(path.join(vendorDir, 'example.min.js'), content);
+  fs.writeFileSync(path.join(vendorDir, 'licenses', 'MIT.txt'), 'MIT licence\n');
   fs.writeFileSync(path.join(vendorDir, 'manifest.json'), JSON.stringify({
     schemaVersion: 1,
     assets: [{
@@ -25,6 +27,7 @@ function createFixture() {
       version: '1.0.0',
       source: 'https://example.com/example/releases/tag/v1.0.0',
       license: 'MIT',
+      licenseFiles: ['licenses/MIT.txt'],
       sha256: sha256(content),
       verified: '2026-08-07',
       owner: 'repository maintainer',
@@ -59,6 +62,13 @@ test('reports JavaScript assets missing from the manifest', t => {
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   fs.writeFileSync(path.join(root, 'vendor', 'untracked.min.js'), '// untracked\n');
   assert.match(verifyVendor(root).join('\n'), /untracked asset.*untracked\.min\.js/i);
+});
+
+test('reports a retained licence file that is missing', t => {
+  const root = createFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.unlinkSync(path.join(root, 'vendor', 'licenses', 'MIT.txt'));
+  assert.match(verifyVendor(root).join('\n'), /missing licence file.*licenses[/\\]MIT\.txt/i);
 });
 
 test('the committed vendor directory passes verification', () => {

--- a/test/vendor-verification.test.js
+++ b/test/vendor-verification.test.js
@@ -47,6 +47,13 @@ test('reports checksum drift after an asset changes', t => {
   assert.match(verifyVendor(root).join('\n'), /checksum mismatch.*example\.min\.js/i);
 });
 
+test('uses LF-normalized text checksums across Git checkout settings', t => {
+  const root = createFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(root, 'vendor', 'example.min.js'), '/* Example 1.0.0 */\r\n');
+  assert.deepEqual(verifyVendor(root), []);
+});
+
 test('reports JavaScript assets missing from the manifest', t => {
   const root = createFixture();
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/test/vendor-verification.test.js
+++ b/test/vendor-verification.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { verifyVendor } = require('../scripts/verify-vendor');
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vendor-verification-'));
+  const vendorDir = path.join(root, 'vendor');
+  fs.mkdirSync(vendorDir);
+  const content = '/* Example 1.0.0 */\n';
+  fs.writeFileSync(path.join(vendorDir, 'example.min.js'), content);
+  fs.writeFileSync(path.join(vendorDir, 'manifest.json'), JSON.stringify({
+    schemaVersion: 1,
+    assets: [{
+      file: 'example.min.js',
+      package: 'example',
+      version: '1.0.0',
+      source: 'https://example.com/example/releases/tag/v1.0.0',
+      license: 'MIT',
+      sha256: sha256(content),
+      verified: '2026-08-07',
+      owner: 'repository maintainer',
+      reviewCadence: 'quarterly',
+    }],
+  }));
+  return root;
+}
+
+test('accepts a complete manifest whose checksums match', t => {
+  const root = createFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  assert.deepEqual(verifyVendor(root), []);
+});
+
+test('reports checksum drift after an asset changes', t => {
+  const root = createFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.appendFileSync(path.join(root, 'vendor', 'example.min.js'), '// changed\n');
+  assert.match(verifyVendor(root).join('\n'), /checksum mismatch.*example\.min\.js/i);
+});
+
+test('reports JavaScript assets missing from the manifest', t => {
+  const root = createFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(root, 'vendor', 'untracked.min.js'), '// untracked\n');
+  assert.match(verifyVendor(root).join('\n'), /untracked asset.*untracked\.min\.js/i);
+});
+
+test('the committed vendor directory passes verification', () => {
+  assert.deepEqual(verifyVendor(path.join(__dirname, '..')), []);
+});

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -14,7 +14,7 @@ The command performs no network access. It fails when manifest metadata is incom
 
 ## Licence and notice retention
 
-The original licence/copyright headers remain embedded in every minified asset. The manifest links to the complete licence text in the exact upstream tag from which each version came. `THIRD_PARTY_NOTICES.md` retains package-specific copyright and attribution notices, including the Apache ECharts NOTICE text and the additional Markdown notice shipped by marked.
+The original licence/copyright headers remain embedded in every minified asset. The manifest names the retained local licence files and links to the complete licence text in the exact upstream tag from which each version came. `THIRD_PARTY_NOTICES.md` retains package-specific copyright and attribution notices, including the Apache ECharts NOTICE text and the additional Markdown notice shipped by marked.
 
 The repository itself is private and `UNLICENSED`, as declared in `package.json`. Vendored third-party code remains governed by its own upstream licence; its presence does not license the rest of this repository.
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -10,7 +10,7 @@ Run:
 npm run verify-vendor
 ```
 
-The command performs no network access. It fails when manifest metadata is incomplete, a JavaScript asset is missing or untracked, or committed bytes no longer match their SHA-256 checksum.
+The command performs no network access. It fails when manifest metadata is incomplete, a JavaScript asset is missing or untracked, or committed content no longer matches its SHA-256 checksum. Checksums use UTF-8 text with LF line endings so Git's Windows checkout conversion cannot produce false failures.
 
 ## Licence and notice retention
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,32 @@
+# Vendored browser dependencies
+
+The viewer keeps these browser libraries in the repository so it works offline and does not depend on a public CDN. `manifest.json` is the source of truth for versions, immutable upstream release pages, licence sources, checksums, verification dates, ownership, and review cadence.
+
+## Verification
+
+Run:
+
+```powershell
+npm run verify-vendor
+```
+
+The command performs no network access. It fails when manifest metadata is incomplete, a JavaScript asset is missing or untracked, or committed bytes no longer match their SHA-256 checksum.
+
+## Licence and notice retention
+
+The original licence/copyright headers remain embedded in every minified asset. The manifest links to the complete licence text in the exact upstream tag from which each version came. `THIRD_PARTY_NOTICES.md` retains package-specific copyright and attribution notices, including the Apache ECharts NOTICE text and the additional Markdown notice shipped by marked.
+
+The repository itself is private and `UNLICENSED`, as declared in `package.json`. Vendored third-party code remains governed by its own upstream licence; its presence does not license the rest of this repository.
+
+## Upgrade and security review
+
+The repository maintainer reviews upstream release and security pages quarterly and when an upstream advisory is received.
+
+1. Open the immutable release and licence links recorded in `manifest.json`.
+2. Review release notes and upstream security advisories between the current and proposed versions.
+3. Download the official minified distribution for the selected release.
+4. Preserve its embedded licence header and update applicable notices.
+5. Replace only the relevant asset, then update its version, release URL, licence URL, SHA-256 digest, and verification date.
+6. Run `npm run verify-vendor` and `npm test` before opening an issue-linked pull request.
+
+Dependabot cannot update these copied browser files. Any available update or advisory that is not applied immediately must be recorded as a GitHub issue so the manual dependency backlog remains visible.

--- a/vendor/THIRD_PARTY_NOTICES.md
+++ b/vendor/THIRD_PARTY_NOTICES.md
@@ -1,10 +1,16 @@
 # Third-party notices
 
-Complete licence texts are linked by immutable upstream tag in `manifest.json`. The notices below are retained alongside the vendored distributions; the original headers are also retained inside each JavaScript file.
+Complete licence texts are retained here or under `licenses/` and linked by immutable upstream tag in `manifest.json`. The original headers are also retained inside each JavaScript file.
 
 ## Chart.js 4.5.1
 
 Copyright (c) 2014-2024 Chart.js Contributors. Released under the MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Apache ECharts 5.6.0
 
@@ -22,9 +28,23 @@ Copyright (c) 2018+, MarkedJS (<https://github.com/markedjs/>).
 
 Copyright (c) 2011-2018, Christopher Jeffrey (<https://github.com/chjj/>).
 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 The tagged licence also retains the notice for Markdown:
 
 Copyright (c) 2004, John Gruber. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+- Neither the name "Markdown" nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## DOMPurify 3.2.7
 

--- a/vendor/THIRD_PARTY_NOTICES.md
+++ b/vendor/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,31 @@
+# Third-party notices
+
+Complete licence texts are linked by immutable upstream tag in `manifest.json`. The notices below are retained alongside the vendored distributions; the original headers are also retained inside each JavaScript file.
+
+## Chart.js 4.5.1
+
+Copyright (c) 2014-2024 Chart.js Contributors. Released under the MIT License.
+
+## Apache ECharts 5.6.0
+
+Apache ECharts
+
+Copyright 2017-2024 The Apache Software Foundation
+
+This product includes software developed at the Apache Software Foundation (<https://www.apache.org/>).
+
+Apache ECharts also identifies d3.js-derived subcomponents under the BSD 3-Clause licence in its tagged `LICENSE` file.
+
+## marked 12.0.2
+
+Copyright (c) 2018+, MarkedJS (<https://github.com/markedjs/>).
+
+Copyright (c) 2011-2018, Christopher Jeffrey (<https://github.com/chjj/>).
+
+The tagged licence also retains the notice for Markdown:
+
+Copyright (c) 2004, John Gruber. All rights reserved.
+
+## DOMPurify 3.2.7
+
+Copyright 2025 Dr.-Ing. Mario Heiderich, Cure53. Distributed under Apache-2.0 or MPL-2.0.

--- a/vendor/licenses/APACHE-2.0.txt
+++ b/vendor/licenses/APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/licenses/BSD-3-Clause-d3.txt
+++ b/vendor/licenses/BSD-3-Clause-d3.txt
@@ -1,0 +1,27 @@
+Copyright 2010-2016 Mike Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/manifest.json
+++ b/vendor/manifest.json
@@ -8,6 +8,7 @@
       "source": "https://github.com/chartjs/Chart.js/releases/tag/v4.5.1",
       "license": "MIT",
       "licenseSource": "https://github.com/chartjs/Chart.js/blob/v4.5.1/LICENSE.md",
+      "licenseFiles": ["THIRD_PARTY_NOTICES.md"],
       "sha256": "48444a82d4edcb5bec0f1965faacdde18d9c17db3063d042abada2f705c9f54a",
       "verified": "2026-08-07",
       "owner": "repository maintainer",
@@ -21,6 +22,11 @@
       "license": "Apache-2.0",
       "licenseSource": "https://github.com/apache/echarts/blob/5.6.0/LICENSE",
       "noticeSource": "https://github.com/apache/echarts/blob/5.6.0/NOTICE",
+      "licenseFiles": [
+        "licenses/APACHE-2.0.txt",
+        "licenses/BSD-3-Clause-d3.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
       "sha256": "bf4a223524e40b77c304bec67e1222cf551f14880cf42c69dc046558e11c07b1",
       "verified": "2026-08-07",
       "owner": "repository maintainer",
@@ -33,6 +39,7 @@
       "source": "https://github.com/markedjs/marked/releases/tag/v12.0.2",
       "license": "MIT with bundled Markdown notices",
       "licenseSource": "https://github.com/markedjs/marked/blob/v12.0.2/LICENSE.md",
+      "licenseFiles": ["THIRD_PARTY_NOTICES.md"],
       "sha256": "15fabce5b65898b32b03f5ed25e9f891a729ad4c0d6d877110a7744aa847a894",
       "verified": "2026-08-07",
       "owner": "repository maintainer",
@@ -45,6 +52,10 @@
       "source": "https://github.com/cure53/DOMPurify/releases/tag/3.2.7",
       "license": "Apache-2.0 OR MPL-2.0",
       "licenseSource": "https://github.com/cure53/DOMPurify/blob/3.2.7/LICENSE",
+      "licenseFiles": [
+        "licenses/APACHE-2.0.txt",
+        "THIRD_PARTY_NOTICES.md"
+      ],
       "sha256": "40cff492b54353a55cdf9ffb369786539ffb7d54d25f97dd4a1e8975b309c35d",
       "verified": "2026-08-07",
       "owner": "repository maintainer",

--- a/vendor/manifest.json
+++ b/vendor/manifest.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "assets": [
+    {
+      "file": "chart.umd.min.js",
+      "package": "Chart.js",
+      "version": "4.5.1",
+      "source": "https://github.com/chartjs/Chart.js/releases/tag/v4.5.1",
+      "license": "MIT",
+      "licenseSource": "https://github.com/chartjs/Chart.js/blob/v4.5.1/LICENSE.md",
+      "sha256": "48444a82d4edcb5bec0f1965faacdde18d9c17db3063d042abada2f705c9f54a",
+      "verified": "2026-08-07",
+      "owner": "repository maintainer",
+      "reviewCadence": "quarterly"
+    },
+    {
+      "file": "echarts.min.js",
+      "package": "Apache ECharts",
+      "version": "5.6.0",
+      "source": "https://github.com/apache/echarts/releases/tag/5.6.0",
+      "license": "Apache-2.0",
+      "licenseSource": "https://github.com/apache/echarts/blob/5.6.0/LICENSE",
+      "noticeSource": "https://github.com/apache/echarts/blob/5.6.0/NOTICE",
+      "sha256": "bf4a223524e40b77c304bec67e1222cf551f14880cf42c69dc046558e11c07b1",
+      "verified": "2026-08-07",
+      "owner": "repository maintainer",
+      "reviewCadence": "quarterly"
+    },
+    {
+      "file": "marked.min.js",
+      "package": "marked",
+      "version": "12.0.2",
+      "source": "https://github.com/markedjs/marked/releases/tag/v12.0.2",
+      "license": "MIT with bundled Markdown notices",
+      "licenseSource": "https://github.com/markedjs/marked/blob/v12.0.2/LICENSE.md",
+      "sha256": "15fabce5b65898b32b03f5ed25e9f891a729ad4c0d6d877110a7744aa847a894",
+      "verified": "2026-08-07",
+      "owner": "repository maintainer",
+      "reviewCadence": "quarterly"
+    },
+    {
+      "file": "purify.min.js",
+      "package": "DOMPurify",
+      "version": "3.2.7",
+      "source": "https://github.com/cure53/DOMPurify/releases/tag/3.2.7",
+      "license": "Apache-2.0 OR MPL-2.0",
+      "licenseSource": "https://github.com/cure53/DOMPurify/blob/3.2.7/LICENSE",
+      "sha256": "9bc53493b7b0cfc39267a3b97e807b0d05a278b9f7552a6d1178c2240905682d",
+      "verified": "2026-08-07",
+      "owner": "repository maintainer",
+      "reviewCadence": "quarterly"
+    }
+  ]
+}

--- a/vendor/manifest.json
+++ b/vendor/manifest.json
@@ -45,7 +45,7 @@
       "source": "https://github.com/cure53/DOMPurify/releases/tag/3.2.7",
       "license": "Apache-2.0 OR MPL-2.0",
       "licenseSource": "https://github.com/cure53/DOMPurify/blob/3.2.7/LICENSE",
-      "sha256": "9bc53493b7b0cfc39267a3b97e807b0d05a278b9f7552a6d1178c2240905682d",
+      "sha256": "40cff492b54353a55cdf9ffb369786539ffb7d54d25f97dd4a1e8975b309c35d",
       "verified": "2026-08-07",
       "owner": "repository maintainer",
       "reviewCadence": "quarterly"


### PR DESCRIPTION
## Summary

- add a machine-readable manifest and SHA-256 verifier for all vendored browser assets
- document third-party notices, ownership, review cadence, upgrade and security intake
- add contribution evidence standards and substantive-review guidance
- introduce an ADR lifecycle with two accepted taxonomy decisions

## Verification

- `npm test` - 237/237 pass
- `npm run validate` - 0 errors (existing KPI warnings remain)
- `npm run check-counts` - README counts match
- `npm run verify-vendor` - manifest and checksums verified
- Markdown lint - 0 errors

Closes #185
Closes #192