### PR TITLE
feat: add credential registry and Kubernetes pilot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Prefer primary, authoritative sources. Link the exact page, standard, release, p
 | Content | Required evidence |
 |---|---|
 | Role responsibility or accountability | Named domain owner or approved operating-model source; distinguish a portable recommendation from local policy |
-| Certification or credential | Official issuer page, exact credential name, credential type, lifecycle status, and verification date; do not present organisation programmes as individual credentials |
+| Certification or credential | Follow the [Credential Registry](docs/CREDENTIAL_REGISTRY.md): issuer-controlled page, exact credential name, type, lifecycle status, verification date, and owner; do not present organisation programmes as individual credentials |
 | Technology or standard | Official product, project, or standards-body source; record version/status when material |
 | KPI target | Approved target source, frequency, and scope (`global`, `service-specific`, or `local`); never generate an authoritative-looking commitment |
 | Reporting or career relationship | Existing catalogue role or explicitly labelled external destination; do not guess a relationship from similar names |
@@ -45,6 +45,7 @@ Edit a generator's source data or script, not its generated Markdown. Regenerate
 
 - Link the issue with `Closes #<number>` when the acceptance criteria are complete.
 - Explain the evidence and any organisation-specific assumptions.
+- For a credential change, include the registry ID, authoritative issuer URL, verification date, and `npm run validate` output; use the canonical marker in every audited role recommendation.
 - Update an ADR when the change creates or reverses a durable taxonomy decision.
 - Run `npm test`, `npm run validate`, `npm run check-counts`, and any focused generator or verifier command affected by the change.
 - Keep generated output, documentation links, and the changelog consistent with the implementation.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Each role file follows the canonical 14-section structure. See [`docs/role_templ
 | Document | Purpose |
 |---|---|
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Evidence standards, substantive review expectations, and contribution workflow |
+| [`docs/CREDENTIAL_REGISTRY.md`](docs/CREDENTIAL_REGISTRY.md) | Audited credential evidence, ownership, lifecycle, contributor policy, and rollout tracking |
 | [`docs/adr/README.md`](docs/adr/README.md) | Durable catalogue and architecture decisions, ADR lifecycle, and index |
 | [`docs/CROSS_DOMAIN_INTERACTIONS.md`](docs/CROSS_DOMAIN_INTERACTIONS.md) | Domain ownership boundaries, key relationships, escalation paths |
 | [`docs/SKILLS_PROGRESSION.md`](docs/SKILLS_PROGRESSION.md) | Engineer → Senior → Architect career ladder per domain |
@@ -248,7 +249,7 @@ HTML report is written to `playwright-report/` in CI.
 npm run validate
 ```
 
-Checks every role file against the canonical 14-section template and required metadata fields (`Domain`, `Role Level`, `Reports To`, `Direct Reports`, `Last Reviewed`), and requires the Interactions table to carry an `Interaction Mode` column. Missing sections, metadata, or the mode column are reported as errors (exit code 1); non-canonical values (e.g. an unrecognized `Role Level`, or a `Domain` that doesn't match its folder's canonical label) are reported as warnings. Pass `--strict` to fail the build on warnings too.
+Checks every role file against the canonical 14-section template and required metadata fields (`Domain`, `Role Level`, `Reports To`, `Direct Reports`, `Last Reviewed`), and requires the Interactions table to carry an `Interaction Mode` column. It also validates credential-registry structure, rejects unknown or duplicate credential references, requires complete marker coverage for `audited_roles`, and warns when credential verification is stale. Missing sections, metadata, unknown references, or the mode column are reported as errors (exit code 1); non-canonical values (e.g. an unrecognized `Role Level`, or a `Domain` that doesn't match its folder's canonical label) and stale credential verification are reported as warnings. Pass `--strict` to fail the build on warnings too.
 
 Duplicate H1 role titles across the catalog are also errors — the same title appearing in two files is a content-integrity bug that shipped twice before this check existed.
 

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -183,22 +183,16 @@ The Kubernetes Architect is responsible for designing and evolving container orc
 
 **Core Certifications:**
 
-- Certified Kubernetes Administrator (CKA)
-- Certified Kubernetes Security Specialist (CKS)
-- CNCF Certified Kubernetes Service Provider
-- Red Hat OpenShift Architect certification
-- Advanced Kubernetes Networking certification
-- Multi-Cloud Kubernetes Architecture certification
-- Cloud Native Architecture certification
-- Service Mesh Architecture certification
-- GitOps Architecture certification
-- Container Platform Architecture certification
-- Kubernetes Patterns and Practices
-- Enterprise Architecture certification
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+- Certified Kubernetes Security Specialist (CKS) <!-- credential: cncf-cks -->
+- TOGAF Enterprise Architecture Practitioner <!-- credential: opengroup-togaf-ea-practitioner -->
 
 **Complementary Certifications:**
 
-- HashiCorp Certified: Terraform Associate (cluster IaC), TOGAF (enterprise architecture alignment), and cloud provider Kubernetes specialist tracks (AKS, EKS, GKE).
+- HashiCorp Certified: Terraform Associate <!-- credential: hashicorp-terraform-associate -->
+- Red Hat Certified System Administrator in OpenShift <!-- credential: redhat-openshift-administrator -->
+- Istio Certified Associate (ICA) <!-- credential: cncf-ica -->
+- GitOps Certified Associate (CGOA) <!-- credential: cncf-cgoa -->
 
 **Learning Resources and Communities:**
 

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -171,20 +171,17 @@ The Kubernetes Engineer implements and maintains Kubernetes environments, ensuri
 
 ## Recommended Certifications & Learning Paths
 
-- Certified Kubernetes Administrator (CKA)
-- Certified Kubernetes Application Developer (CKAD)
-- Docker Certified Associate
-- Linux Foundation Kubernetes Fundamentals
-- Cloud provider Kubernetes certifications (AKS, EKS, GKE)
-- Container Security Fundamentals
-- Helm certification
-- Cloud Native Associate certification
-- GitOps Fundamentals (ArgoCD, Flux)
-- Linux Administration certification
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+- Certified Kubernetes Application Developer (CKAD) <!-- credential: cncf-ckad -->
 
 **Complementary Certifications:**
 
-- CompTIA Linux+ (OS fundamentals), Prometheus Certified Associate (PCA), and cloud provider Kubernetes fundamentals tracks (AKS, EKS, GKE basics).
+- Kubernetes and Cloud Native Associate (KCNA) <!-- credential: cncf-kcna -->
+- Prometheus Certified Associate (PCA) <!-- credential: cncf-pca -->
+- Certified Argo Project Associate (CAPA) <!-- credential: cncf-capa -->
+- HashiCorp Certified: Terraform Associate <!-- credential: hashicorp-terraform-associate -->
 
 **Learning Resources and Communities:**
 

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -172,20 +172,14 @@ The Kubernetes Product Owner manages the container platform roadmap and service 
 
 ## Recommended Certifications & Learning Paths
 
-- Professional Scrum Product Owner (PSPO)
-- Kubernetes Foundation certification
-- Certified Kubernetes Application Developer (CKAD)
-- Cloud Native Associate certification
-- SAFe Product Owner/Product Manager
-- DevOps Product Owner certification
-- Container Platform Strategy certification
-- Platform Engineering Leadership certification
-- Cloud Platforms Business Professional
-- Digital Transformation certification
+**Core Certifications:**
+
+- Professional Scrum Product Owner I (PSPO I) <!-- credential: scrumorg-pspo-i -->
+- Kubernetes and Cloud Native Associate (KCNA) <!-- credential: cncf-kcna -->
 
 **Complementary Certifications:**
 
-- FinOps Certified Practitioner (Kubernetes cost management), ITIL 4 Foundation, and CNCF Kubernetes Associate (platform awareness).
+- FinOps Certified Practitioner <!-- credential: finops-certified-practitioner -->
 
 **Learning Resources and Communities:**
 

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -177,22 +177,20 @@ The Kubernetes Senior Engineer leads complex containerization initiatives and ad
 
 ## Recommended Certifications & Learning Paths
 
-- Certified Kubernetes Administrator (CKA)
-- Certified Kubernetes Application Developer (CKAD)
-- Certified Kubernetes Security Specialist (CKS)
-- Linux Foundation Kubernetes certifications
-- Red Hat OpenShift certification
-- AWS Certified Container Specialist
-- Microsoft Azure Kubernetes Service certification
-- Google Kubernetes Engine certification
-- GitOps certifications (ArgoCD, Flux)
-- Cloud Native certifications from CNCF
-- Advanced Networking with Kubernetes
-- Container Security certifications
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+- Certified Kubernetes Application Developer (CKAD) <!-- credential: cncf-ckad -->
+- Certified Kubernetes Security Specialist (CKS) <!-- credential: cncf-cks -->
 
 **Complementary Certifications:**
 
-- HashiCorp Certified: Terraform Associate (cluster IaC), Istio Associate certification, and Prometheus Certified Associate (PCA).
+- HashiCorp Certified: Terraform Associate <!-- credential: hashicorp-terraform-associate -->
+- Red Hat Certified System Administrator in OpenShift <!-- credential: redhat-openshift-administrator -->
+- Istio Certified Associate (ICA) <!-- credential: cncf-ica -->
+- Prometheus Certified Associate (PCA) <!-- credential: cncf-pca -->
+- Certified Argo Project Associate (CAPA) <!-- credential: cncf-capa -->
+- GitOps Certified Associate (CGOA) <!-- credential: cncf-cgoa -->
 
 **Learning Resources and Communities:**
 

--- a/credentialRegistry.js
+++ b/credentialRegistry.js
@@ -6,7 +6,7 @@ const CREDENTIAL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const ALLOWED_TYPES = new Set(['certification', 'certificate']);
 const ALLOWED_STATUSES = new Set(['active', 'retired', 'superseded']);
 const CREDENTIAL_MARKER = /<!-- credential: ([a-z0-9]+(?:-[a-z0-9]+)*) -->/g;
-const CREDENTIAL_LIKE_MARKER = /<!--\s*credential\s*:[^>]*-->/gi;
+const CREDENTIAL_LIKE_MARKER = /<!--(?=[^>]*\bcredential\b)[^>]*-->/gi;
 const REQUIRED_FIELDS = [
   'id', 'name', 'issuer', 'type', 'url', 'status',
   'verified_on', 'owner', 'review_months',

--- a/credentialRegistry.js
+++ b/credentialRegistry.js
@@ -5,6 +5,7 @@ const fs = require('node:fs');
 const CREDENTIAL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const ALLOWED_TYPES = new Set(['certification', 'certificate']);
 const ALLOWED_STATUSES = new Set(['active', 'retired', 'superseded']);
+const CREDENTIAL_MARKER = /<!--\s*credential:\s*([a-z0-9]+(?:-[a-z0-9]+)*)\s*-->/g;
 const REQUIRED_FIELDS = [
   'id', 'name', 'issuer', 'type', 'url', 'status',
   'verified_on', 'owner', 'review_months',
@@ -109,10 +110,69 @@ function loadCredentialRegistry(filePath, now = new Date()) {
   }
 }
 
+function certificationSection(markdown) {
+  const start = markdown.search(/^##\s+Recommended Certifications (?:&|and) Learning Paths\s*$/im);
+  if (start === -1) return '';
+  const rest = markdown.slice(start);
+  const next = rest.slice(1).search(/\n##\s+/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+function findCredentialReferences(markdown) {
+  const references = [];
+  CREDENTIAL_MARKER.lastIndex = 0;
+  for (const match of markdown.matchAll(CREDENTIAL_MARKER)) {
+    references.push({
+      id: match[1],
+      line: markdown.slice(0, match.index).split(/\r?\n/).length,
+      raw: match[0],
+    });
+  }
+  return references;
+}
+
+function recommendedCredentialBullets(markdown) {
+  const section = certificationSection(markdown);
+  const learningIndex = section.search(/^\*\*Learning Resources and Communities:\*\*\s*$/im);
+  const credentialPart = learningIndex === -1 ? section : section.slice(0, learningIndex);
+  return credentialPart.split(/\r?\n/)
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(item => /^\s*-\s+/.test(item.line));
+}
+
+function validateRoleCredentialReferences(markdown, credentialsById, { requireComplete = false } = {}) {
+  const errors = [];
+  const warnings = [];
+  const seen = new Set();
+  for (const reference of findCredentialReferences(markdown)) {
+    if (!credentialsById.has(reference.id)) {
+      errors.push(`Unknown credential reference "${reference.id}" on line ${reference.line}`);
+    }
+    if (seen.has(reference.id)) {
+      errors.push(`Duplicate credential reference "${reference.id}" in one role`);
+    }
+    seen.add(reference.id);
+  }
+  if (requireComplete) {
+    for (const bullet of recommendedCredentialBullets(markdown)) {
+      CREDENTIAL_MARKER.lastIndex = 0;
+      const matches = [...bullet.line.matchAll(CREDENTIAL_MARKER)];
+      if (matches.length === 0) {
+        errors.push(`Audited credential bullet is missing credential marker: ${bullet.line.trim()}`);
+      } else if (matches.length > 1) {
+        errors.push(`Audited credential bullet has multiple credential markers: ${bullet.line.trim()}`);
+      }
+    }
+  }
+  return { errors, warnings };
+}
+
 module.exports = {
   validateCredentialRegistry,
   loadCredentialRegistry,
   CREDENTIAL_ID_PATTERN,
   ALLOWED_TYPES,
   ALLOWED_STATUSES,
+  findCredentialReferences,
+  validateRoleCredentialReferences,
 };

--- a/credentialRegistry.js
+++ b/credentialRegistry.js
@@ -24,8 +24,19 @@ function isRealIsoDate(value) {
 
 function reviewDueDate(verifiedOn, months) {
   const date = new Date(`${verifiedOn}T00:00:00Z`);
+  const day = date.getUTCDate();
+  date.setUTCDate(1);
   date.setUTCMonth(date.getUTCMonth() + months);
+  const monthEnd = new Date(date);
+  monthEnd.setUTCMonth(monthEnd.getUTCMonth() + 1, 0);
+  date.setUTCDate(Math.min(day, monthEnd.getUTCDate()));
   return date;
+}
+
+function utcCalendarDate(date) {
+  const normalized = new Date(date);
+  normalized.setUTCHours(0, 0, 0, 0);
+  return normalized;
 }
 
 function validateCredentialRegistry(value, now = new Date()) {
@@ -96,7 +107,7 @@ function validateCredentialRegistry(value, now = new Date()) {
     }
     if (isRealIsoDate(credential.verified_on || '') &&
         Number.isInteger(credential.review_months) && credential.review_months > 0 &&
-        now > reviewDueDate(credential.verified_on, credential.review_months)) {
+        utcCalendarDate(now) > reviewDueDate(credential.verified_on, credential.review_months)) {
       result.warnings.push(`${credential.id || prefix} credential verification is stale`);
     }
   }
@@ -134,11 +145,11 @@ function findCredentialReferences(markdown) {
 
 function recommendedCredentialBullets(markdown) {
   const section = certificationSection(markdown);
-  const learningIndex = section.search(/^\*\*Learning Resources and Communities:\*\*\s*$/im);
+  const learningIndex = section.search(/^\*\*Learning Resources (?:&|and) Communities:\*\*\s*$/im);
   const credentialPart = learningIndex === -1 ? section : section.slice(0, learningIndex);
   return credentialPart.split(/\r?\n/)
     .map((line, index) => ({ line, number: index + 1 }))
-    .filter(item => /^\s*-\s+/.test(item.line));
+    .filter(item => /^\s*[-*+]\s+/.test(item.line));
 }
 
 function validateRoleCredentialReferences(markdown, credentialsById, { requireComplete = false } = {}) {

--- a/credentialRegistry.js
+++ b/credentialRegistry.js
@@ -5,7 +5,8 @@ const fs = require('node:fs');
 const CREDENTIAL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const ALLOWED_TYPES = new Set(['certification', 'certificate']);
 const ALLOWED_STATUSES = new Set(['active', 'retired', 'superseded']);
-const CREDENTIAL_MARKER = /<!--\s*credential:\s*([a-z0-9]+(?:-[a-z0-9]+)*)\s*-->/g;
+const CREDENTIAL_MARKER = /<!-- credential: ([a-z0-9]+(?:-[a-z0-9]+)*) -->/g;
+const CREDENTIAL_LIKE_MARKER = /<!--\s*credential\s*:[^>]*-->/gi;
 const REQUIRED_FIELDS = [
   'id', 'name', 'issuer', 'type', 'url', 'status',
   'verified_on', 'owner', 'review_months',
@@ -144,6 +145,14 @@ function validateRoleCredentialReferences(markdown, credentialsById, { requireCo
   const errors = [];
   const warnings = [];
   const seen = new Set();
+  CREDENTIAL_LIKE_MARKER.lastIndex = 0;
+  for (const match of markdown.matchAll(CREDENTIAL_LIKE_MARKER)) {
+    CREDENTIAL_MARKER.lastIndex = 0;
+    if (!CREDENTIAL_MARKER.test(match[0])) {
+      const line = markdown.slice(0, match.index).split(/\r?\n/).length;
+      errors.push(`Invalid credential marker on line ${line}: ${match[0]}`);
+    }
+  }
   for (const reference of findCredentialReferences(markdown)) {
     if (!credentialsById.has(reference.id)) {
       errors.push(`Unknown credential reference "${reference.id}" on line ${reference.line}`);

--- a/credentialRegistry.js
+++ b/credentialRegistry.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const fs = require('node:fs');
+
+const CREDENTIAL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const ALLOWED_TYPES = new Set(['certification', 'certificate']);
+const ALLOWED_STATUSES = new Set(['active', 'retired', 'superseded']);
+const REQUIRED_FIELDS = [
+  'id', 'name', 'issuer', 'type', 'url', 'status',
+  'verified_on', 'owner', 'review_months',
+];
+
+function emptyResult(errors = []) {
+  return { errors, warnings: [], credentialsById: new Map(), auditedRoles: new Set() };
+}
+
+function isRealIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value;
+}
+
+function reviewDueDate(verifiedOn, months) {
+  const date = new Date(`${verifiedOn}T00:00:00Z`);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  return date;
+}
+
+function validateCredentialRegistry(value, now = new Date()) {
+  const result = emptyResult();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    result.errors.push('Credential registry must be a JSON object');
+    return result;
+  }
+  if (value.schema_version !== 1) result.errors.push('schema_version must be 1');
+  if (!Array.isArray(value.audited_roles)) result.errors.push('audited_roles must be an array');
+  if (!Array.isArray(value.credentials)) {
+    result.errors.push('credentials must be an array');
+    return result;
+  }
+
+  for (const role of value.audited_roles || []) {
+    if (typeof role !== 'string' || !/^Roles\/[a-z0-9_/-]+\.md$/.test(role)) {
+      result.errors.push(`Invalid audited role path: ${String(role)}`);
+    } else if (result.auditedRoles.has(role)) {
+      result.errors.push(`Duplicate audited role path: ${role}`);
+    } else {
+      result.auditedRoles.add(role);
+    }
+  }
+
+  for (const [index, credential] of value.credentials.entries()) {
+    const prefix = `credentials[${index}]`;
+    if (!credential || typeof credential !== 'object' || Array.isArray(credential)) {
+      result.errors.push(`${prefix} must be an object`);
+      continue;
+    }
+    for (const field of REQUIRED_FIELDS) {
+      if (credential[field] === undefined || credential[field] === '') {
+        result.errors.push(`${prefix}.${field} is required`);
+      }
+    }
+    for (const field of ['name', 'issuer']) {
+      if (typeof credential[field] !== 'string' || !credential[field].trim()) {
+        result.errors.push(`${prefix}.${field} must be a non-empty string`);
+      }
+    }
+    if (!CREDENTIAL_ID_PATTERN.test(credential.id || '')) {
+      result.errors.push(`${prefix}.id must be lowercase kebab-case`);
+    } else if (result.credentialsById.has(credential.id)) {
+      result.errors.push(`Duplicate credential ID: ${credential.id}`);
+    } else {
+      result.credentialsById.set(credential.id, credential);
+    }
+    if (!ALLOWED_TYPES.has(credential.type)) result.errors.push(`${prefix}.type is unsupported`);
+    if (!ALLOWED_STATUSES.has(credential.status)) result.errors.push(`${prefix}.status is unsupported`);
+    try {
+      const url = new URL(credential.url);
+      if (url.protocol !== 'https:') result.errors.push(`${prefix}.url must use https`);
+    } catch {
+      result.errors.push(`${prefix}.url must be a valid https URL`);
+    }
+    if (!isRealIsoDate(credential.verified_on || '')) {
+      result.errors.push(`${prefix}.verified_on must be a real YYYY-MM-DD date`);
+    }
+    if (!Number.isInteger(credential.review_months) || credential.review_months < 1) {
+      result.errors.push(`${prefix}.review_months must be a positive integer`);
+    }
+    if (typeof credential.owner !== 'string' || !credential.owner.trim()) {
+      result.errors.push(`${prefix}.owner is required`);
+    }
+    if (credential.notes !== undefined && typeof credential.notes !== 'string') {
+      result.errors.push(`${prefix}.notes must be a string when present`);
+    }
+    if (isRealIsoDate(credential.verified_on || '') &&
+        Number.isInteger(credential.review_months) && credential.review_months > 0 &&
+        now > reviewDueDate(credential.verified_on, credential.review_months)) {
+      result.warnings.push(`${credential.id || prefix} credential verification is stale`);
+    }
+  }
+  return result;
+}
+
+function loadCredentialRegistry(filePath, now = new Date()) {
+  try {
+    return validateCredentialRegistry(JSON.parse(fs.readFileSync(filePath, 'utf8')), now);
+  } catch (error) {
+    return emptyResult([`Unable to read or parse credential registry: ${error.message}`]);
+  }
+}
+
+module.exports = {
+  validateCredentialRegistry,
+  loadCredentialRegistry,
+  CREDENTIAL_ID_PATTERN,
+  ALLOWED_TYPES,
+  ALLOWED_STATUSES,
+};

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "audited_roles": [],
+  "credentials": []
+}

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -1,5 +1,154 @@
 {
   "schema_version": 1,
-  "audited_roles": [],
-  "credentials": []
+  "audited_roles": [
+    "Roles/kubernetes/kubernetes_architect.md",
+    "Roles/kubernetes/kubernetes_engineer.md",
+    "Roles/kubernetes/kubernetes_product_owner.md",
+    "Roles/kubernetes/kubernetes_senior_engineer.md"
+  ],
+  "credentials": [
+    {
+      "id": "cncf-cka",
+      "name": "Certified Kubernetes Administrator (CKA)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/cka/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-ckad",
+      "name": "Certified Kubernetes Application Developer (CKAD)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/ckad/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-cks",
+      "name": "Certified Kubernetes Security Specialist (CKS)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/cks/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-kcna",
+      "name": "Kubernetes and Cloud Native Associate (KCNA)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/kcna/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-pca",
+      "name": "Prometheus Certified Associate (PCA)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/pca/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-ica",
+      "name": "Istio Certified Associate (ICA)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/ica/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-capa",
+      "name": "Certified Argo Project Associate (CAPA)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/capa/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "cncf-cgoa",
+      "name": "GitOps Certified Associate (CGOA)",
+      "issuer": "Cloud Native Computing Foundation and The Linux Foundation",
+      "type": "certification",
+      "url": "https://www.cncf.io/training/certification/cgoa/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "hashicorp-terraform-associate",
+      "name": "HashiCorp Certified: Terraform Associate",
+      "issuer": "HashiCorp",
+      "type": "certification",
+      "url": "https://developer.hashicorp.com/certifications/infrastructure-automation",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "scrumorg-pspo-i",
+      "name": "Professional Scrum Product Owner I (PSPO I)",
+      "issuer": "Scrum.org",
+      "type": "certification",
+      "url": "https://www.scrum.org/assessments/professional-scrum-product-owner-i-certification",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "finops-certified-practitioner",
+      "name": "FinOps Certified Practitioner",
+      "issuer": "FinOps Foundation",
+      "type": "certification",
+      "url": "https://www.finops.org/training-certification/recommended/practitioner/",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "opengroup-togaf-ea-practitioner",
+      "name": "TOGAF Enterprise Architecture Practitioner",
+      "issuer": "The Open Group",
+      "type": "certification",
+      "url": "https://www.opengroup.org/certifications/togaf",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    },
+    {
+      "id": "redhat-openshift-administrator",
+      "name": "Red Hat Certified System Administrator in OpenShift",
+      "issuer": "Red Hat",
+      "type": "certification",
+      "url": "https://www.redhat.com/en/services/certification/rhcs-paas",
+      "status": "active",
+      "verified_on": "2026-08-08",
+      "owner": "catalogue-maintainers",
+      "review_months": 12
+    }
+  ]
 }

--- a/docs/CREDENTIAL_REGISTRY.md
+++ b/docs/CREDENTIAL_REGISTRY.md
@@ -1,0 +1,81 @@
+# Credential Registry
+
+## Purpose and audit boundary
+
+[`data/credentials.json`](../data/credentials.json) is the authoritative, machine-readable catalogue of credential recommendations that have been audited against an issuer-controlled source. A role recommendation with a valid registry marker is registry-backed and verified as of its recorded `verified_on` date.
+
+Legacy credential text without a marker is not yet audited. It may remain visible while the catalogue is migrated, but it must not be represented as registry-backed or current verified evidence. The current Kubernetes pilot is the first audited domain; remaining domains are tracked in [issue #210](https://github.com/JeanKadang/DOC-ITRoles/issues/210).
+
+## Registry schema
+
+The registry root is a JSON object with these fields:
+
+| Field | Required value |
+|---|---|
+| `schema_version` | The supported schema version; currently `1`. |
+| `audited_roles` | An array of unique repository-relative role paths such as `Roles/kubernetes/kubernetes_engineer.md`. These roles require complete credential markers. |
+| `credentials` | An array of credential records. |
+
+Each credential record contains:
+
+| Field | Required value |
+|---|---|
+| `id` | Stable lowercase kebab-case identifier, for example `cncf-cka`. IDs are unique and are not renamed when the display name changes. |
+| `name` | Exact official credential name. |
+| `issuer` | Official issuing organisation. |
+| `type` | `certification` or `certificate`. |
+| `url` | HTTPS URL of an issuer-controlled authoritative page. |
+| `status` | `active`, `retired`, or `superseded`. |
+| `verified_on` | Real ISO date (`YYYY-MM-DD`) on which the authoritative page was checked. |
+| `owner` | Non-empty durable owner identifier responsible for review. |
+| `review_months` | Positive integer review interval. Use 12 months unless the credential warrants a shorter interval. |
+| `notes` | Optional concise lifecycle or scope clarification. |
+
+Use the marker directly after the official credential name in a certification bullet:
+
+```markdown
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+```
+
+The marker syntax is exactly `<!-- credential: stable-id -->`: one space after `<!--`, one after the colon, lowercase kebab-case ID, and one space before `-->`. Each certification bullet in an audited role needs exactly one marker; a role cannot repeat the same ID. Markers that name an unknown ID, or comments that resemble a credential marker but do not match this syntax, are validation errors.
+
+## Authoritative evidence and ownership
+
+Use only issuer-controlled pages as credential evidence. Third-party course providers, search snippets, community summaries, and copied marketing text are not authoritative. `verified_on` is the day a contributor or reviewer checked that issuer page, not a course date, publication date, or future review date.
+
+`catalogue-maintainers` owns registry freshness until a durable domain team is named in the record. The owner reviews source currency, official name, lifecycle status, and continued relevance before changing a recommendation or refreshing its verification date.
+
+## Adding or changing a credential
+
+Start with an issue before implementation. A credential pull request must include:
+
+- the authoritative issuer URL;
+- the exact official name, `type`, and lifecycle `status`;
+- a stable registry ID and its role marker, where the role is audited;
+- the date the issuer page was verified;
+- the accountable owner and review interval; and
+- validator output showing the registry and role references pass.
+
+Keep the text shown to readers aligned with `name`, but preserve the existing ID if a provider changes branding. Do not recycle an ID for a different credential. Add or update the marker in the same change as the registry entry so validation can resolve it.
+
+## Lifecycle and staleness
+
+Do not delete a `retired` or `superseded` record while a role still references it. Retain it to preserve an auditable explanation of historical recommendations, use `notes` for a concise replacement or lifecycle clarification, and deliberately update role recommendations when a replacement is appropriate.
+
+The validator starts a stale-warning period only after `verified_on + review_months`. A record due exactly on that date is not yet stale. Staleness is a warning, not a structural failure, and the validator makes no runtime network request in CI or normal validation; maintainers perform the source check during review.
+
+## Courses and organisation programmes
+
+Courses, training platforms, communities, and learning paths belong under **Learning Resources & Communities**, not as credentials in the registry. Do not represent an organisation-level programme, partnership, provider designation, or service status as an individual-held credential. For example, KCSP-like programmes are not individual certifications.
+
+## Rollout policy
+
+Migrate the remaining catalogue in bounded domain or role-family batches:
+
+1. Inventory unique legacy credential strings and group likely aliases.
+2. Select a bounded domain batch and audit each distinct recommendation against issuer evidence.
+3. Add or update records, then migrate unambiguous role bullets to stable markers.
+4. Move learning resources out of certification lists and remove or clarify organisation programmes, ambiguous claims, and unverifiable text.
+5. Add completed roles to `audited_roles` only when every certification bullet is deliberately covered, then run validation.
+
+Legacy prose stays unaudited until that work is complete. The durable tracker for unaudited domains and rollout batches is [issue #210](https://github.com/JeanKadang/DOC-ITRoles/issues/210); do not treat its open scope as verified merely because the text remains in a role file.

--- a/docs/role_template.md
+++ b/docs/role_template.md
@@ -168,6 +168,10 @@
 
 ## Recommended Certifications & Learning Paths
 
+> For a registry-audited role, use the official credential name followed by
+> `<!-- credential: stable-id -->`. Keep courses and communities under learning
+> resources. See [Credential Registry](CREDENTIAL_REGISTRY.md).
+
 **Core Certifications:**
 
 - [Core Certification 1]

--- a/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
@@ -834,7 +834,7 @@ markers, while credential review dates now use UTC date-only comparison and
 clamped calendar-month arithmetic. The scoped re-review found both findings
 addressed with no new Critical or Important breakage.
 
-- [ ] **Step 3: Commit the verification record and push**
+- [x] **Step 3: Commit the verification record and push**
 
 Update this plan's checkboxes and add the actual verification totals beneath this task. Then:
 
@@ -844,11 +844,14 @@ git commit -m "docs: record credential pilot verification"
 git push -u origin codex/178-credential-registry
 ```
 
-- [ ] **Step 4: Reconcile issue #178 acceptance criteria before closure**
+- [x] **Step 4: Reconcile issue #178 acceptance criteria before closure**
 
 Add a completion comment mapping each issue criterion to concrete evidence: registry documentation, four audited role paths, the KCSP removal test, all registry URLs/dates, validator tests/output, and the rollout issue.
 
 Use `gh issue edit 178 --body-file <newline-preserving-file>` to check a criterion only after its evidence is confirmed. If any criterion lacks evidence, leave it unchecked and keep the PR body at `Refs #178`.
+
+Issue #178 now has a criterion-level completion comment, six checked acceptance
+criteria, zero unchecked criteria, and remains open pending merge of PR #211.
 
 - [ ] **Step 5: Open the pull request without bypassing the closure gate**
 
@@ -862,3 +865,6 @@ Create a ready PR titled `feat: add credential registry and Kubernetes pilot`. I
 - `Closes #178` only if every acceptance criterion has already been evidenced and checked, otherwise `Refs #178`.
 
 Wait for every CI leg. Do not merge until the maintainer explicitly approves and `github-hygiene` confirms the issue closure gate still passes.
+
+Ready PR #211 was opened against `main` with the `enhancement` release-note
+label and `Closes #178`. This step remains unchecked until every CI leg passes.

--- a/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
@@ -50,7 +50,7 @@
 - Produces: `loadCredentialRegistry(filePath, now)` with the same return shape and parse/read errors converted to validation errors.
 - Produces: `CREDENTIAL_ID_PATTERN`, `ALLOWED_TYPES`, and `ALLOWED_STATUSES` for focused tests.
 
-- [ ] **Step 1: Write failing schema and staleness tests**
+- [x] **Step 1: Write failing schema and staleness tests**
 
 Create `test/credential-registry.test.js` with a reusable valid fixture and one-behaviour tests:
 
@@ -157,13 +157,13 @@ test('malformed JSON is returned as a registry error', () => {
 });
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run: `node --test test/credential-registry.test.js`
 
 Expected: FAIL with `Cannot find module '../credentialRegistry'`.
 
-- [ ] **Step 3: Implement the minimal registry validator**
+- [x] **Step 3: Implement the minimal registry validator**
 
 Create `credentialRegistry.js` using these exact rules:
 
@@ -299,7 +299,7 @@ integrated in Task 2 without leaving `npm run validate` broken between commits:
 }
 ```
 
-- [ ] **Step 4: Run focused and full Node tests**
+- [x] **Step 4: Run focused and full Node tests**
 
 Run: `node --test test/credential-registry.test.js`
 
@@ -309,7 +309,7 @@ Run: `npm test`
 
 Expected: all existing tests plus the new registry tests pass.
 
-- [ ] **Step 5: Commit Task 1**
+- [x] **Step 5: Commit Task 1**
 
 ```bash
 git add credentialRegistry.js data/credentials.json test/credential-registry.test.js
@@ -332,7 +332,7 @@ git commit -m "feat: validate credential registry"
 - Produces: `validateRoleCredentialReferences(markdown, credentialsById, { requireComplete })` returning `{ errors, warnings }`.
 - Changes: `validateFile(filePath, rolesDir, credentialContext = null)`; existing two-argument callers remain valid.
 
-- [ ] **Step 1: Write failing marker tests**
+- [x] **Step 1: Write failing marker tests**
 
 Append tests that prove known, unknown, duplicate, and unmarked audited bullets:
 
@@ -387,13 +387,13 @@ test('legacy unmarked recommendations remain allowed', () => {
 
 In `test/validate-roles.test.js`, add a fixture test passing an explicit credential context to `validateFile` and a CLI test using `CREDENTIALS_FILE` to prove an unknown marker exits 1.
 
-- [ ] **Step 2: Run the focused tests and verify RED**
+- [x] **Step 2: Run the focused tests and verify RED**
 
 Run: `node --test test/credential-registry.test.js test/validate-roles.test.js`
 
 Expected: FAIL because the marker functions and `credentialContext` integration do not exist.
 
-- [ ] **Step 3: Implement marker extraction and audited-section checks**
+- [x] **Step 3: Implement marker extraction and audited-section checks**
 
 Add to `credentialRegistry.js`:
 
@@ -458,7 +458,7 @@ function validateRoleCredentialReferences(markdown, credentialsById, { requireCo
 
 Export the three new functions. Reset `CREDENTIAL_MARKER.lastIndex = 0` before each scan if implementation testing shows the global regular expression retaining state between calls.
 
-- [ ] **Step 4: Integrate the registry into `validate-roles.js`**
+- [x] **Step 4: Integrate the registry into `validate-roles.js`**
 
 Import `loadCredentialRegistry` and `validateRoleCredentialReferences`. Add `CREDENTIALS_FILE`, honoring a `CREDENTIALS_FILE` environment override for CLI fixtures. Extend `validateFile` with an optional context and append marker errors/warnings after the existing structural checks:
 
@@ -480,7 +480,7 @@ function validateFile(filePath, rolesDir = ROLES_DIR, credentialContext = null) 
 
 In `main()`, load the registry once, print registry errors/warnings under `data/credentials.json`, pass the context to every `validateFile`, include registry warnings in the strict-mode decision, and include registry errors in exit code 1. Do not load the registry at module import time.
 
-- [ ] **Step 5: Run focused tests and verify GREEN**
+- [x] **Step 5: Run focused tests and verify GREEN**
 
 Run: `node --test test/credential-registry.test.js test/validate-roles.test.js`
 
@@ -494,7 +494,7 @@ Run: `npm run validate`
 
 Expected: exit 0 with the empty valid registry and unchanged legacy role files.
 
-- [ ] **Step 6: Commit Task 2**
+- [x] **Step 6: Commit Task 2**
 
 ```bash
 git add credentialRegistry.js validate-roles.js test/credential-registry.test.js test/validate-roles.test.js
@@ -517,7 +517,7 @@ git commit -m "feat: validate role credential references"
 - Consumes: the registry schema and role-reference validator from Tasks 1–2.
 - Produces: 13 stable credential IDs and four fully audited role files.
 
-- [ ] **Step 1: Write the failing Kubernetes pilot integration test**
+- [x] **Step 1: Write the failing Kubernetes pilot integration test**
 
 Create `test/kubernetes-credentials.test.js`:
 
@@ -567,13 +567,13 @@ test('KCSP is not presented as an individual credential', () => {
 });
 ```
 
-- [ ] **Step 2: Run the pilot test and verify RED**
+- [x] **Step 2: Run the pilot test and verify RED**
 
 Run: `node --test test/kubernetes-credentials.test.js`
 
 Expected: FAIL because the registry has no audited roles or credential records.
 
-- [ ] **Step 3: Add the verified registry records**
+- [x] **Step 3: Add the verified registry records**
 
 Create `data/credentials.json` with `schema_version: 1`, the exact four `audited_roles`, and these records. Every record uses `status: "active"`, `type: "certification"`, `verified_on: "2026-08-08"`, `owner: "catalogue-maintainers"`, and `review_months: 12`.
 
@@ -595,7 +595,7 @@ Create `data/credentials.json` with `schema_version: 1`, the exact four `audited
 
 This table contains 13 records; keep all 13 because each appears in at least one audited role. Do not add Docker Certified Associate, Kubernetes Fundamentals, generic cloud-provider tracks, or invented architecture/product credentials to the registry.
 
-- [ ] **Step 4: Replace the four certification sections with audited content**
+- [x] **Step 4: Replace the four certification sections with audited content**
 
 Use these exact credential sets, one bullet and one marker per credential:
 
@@ -666,7 +666,7 @@ Use these exact credential sets, one bullet and one marker per credential:
 
 Retain each existing `Learning Resources and Communities` subsection. Move only genuine courses or reading suggestions there when the existing text is specific and useful; remove generic pseudo-credentials rather than relabeling them as authoritative learning resources.
 
-- [ ] **Step 5: Run pilot, validator, and full tests**
+- [x] **Step 5: Run pilot, validator, and full tests**
 
 Run: `node --test test/kubernetes-credentials.test.js`
 
@@ -680,7 +680,7 @@ Run: `npm test`
 
 Expected: all tests pass.
 
-- [ ] **Step 6: Commit Task 3**
+- [x] **Step 6: Commit Task 3**
 
 ```bash
 git add data/credentials.json test/kubernetes-credentials.test.js Roles/kubernetes
@@ -701,7 +701,7 @@ git commit -m "docs: audit kubernetes credentials"
 - Consumes: schema and marker syntax from Tasks 1–3.
 - Produces: contributor-facing ownership and lifecycle policy plus a GitHub follow-up for the remaining domains.
 
-- [ ] **Step 1: Write the credential governance document**
+- [x] **Step 1: Write the credential governance document**
 
 Create `docs/CREDENTIAL_REGISTRY.md` with these sections and decisions:
 
@@ -715,7 +715,7 @@ Create `docs/CREDENTIAL_REGISTRY.md` with these sections and decisions:
 - **Courses and organisation programmes:** keep courses under learning resources; never represent KCSP-like programmes as individual credentials.
 - **Rollout:** inventory strings, group aliases, audit by bounded domain batches, migrate markers, and track unaudited domains in GitHub.
 
-- [ ] **Step 2: Link the policy from contributor and repository guidance**
+- [x] **Step 2: Link the policy from contributor and repository guidance**
 
 In `CONTRIBUTING.md`, link `docs/CREDENTIAL_REGISTRY.md` from the credential evidence row and require registry ID, authoritative URL, verification date, and validator output in credential PRs.
 
@@ -729,7 +729,7 @@ In `docs/role_template.md`, add a concise note above the certification example:
 > resources. See [Credential Registry](CREDENTIAL_REGISTRY.md).
 ```
 
-- [ ] **Step 3: Create the catalogue rollout follow-up issue**
+- [x] **Step 3: Create the catalogue rollout follow-up issue**
 
 Create one assigned, milestone-bound issue titled `Roll out credential registry references across the remaining role domains` with labels `documentation`, `maintenance`, and `P2`, milestone `Catalogue Trust & Adoption`, and this acceptance contract:
 
@@ -747,9 +747,9 @@ Create one assigned, milestone-bound issue titled `Roll out credential registry 
 
 Reference issue #178 as the completed Kubernetes pilot. Do not close this rollout issue until its own criteria pass.
 
-- [ ] **Step 4: Verify documentation and links**
+- [x] **Step 4: Verify documentation and links**
 
-Run: `npx --yes markdownlint-cli2@0.18.1 "**/*.md"`
+Run: `npx --yes markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#.superpowers/sdd"`
 
 Expected: zero Markdown lint errors.
 
@@ -757,7 +757,7 @@ Run: `rg -n "CREDENTIAL_REGISTRY|credential: stable-id|catalogue-maintainers" RE
 
 Expected: all four files contain the intended policy link or example.
 
-- [ ] **Step 5: Commit Task 4**
+- [x] **Step 5: Commit Task 4**
 
 ```bash
 git add docs/CREDENTIAL_REGISTRY.md CONTRIBUTING.md README.md docs/role_template.md
@@ -775,7 +775,7 @@ git commit -m "docs: govern credential recommendations"
 - Consumes: every deliverable and test from Tasks 1–4.
 - Produces: a pushed branch, reviewable PR, and criterion-level completion evidence for issue #178.
 
-- [ ] **Step 1: Run the complete local verification gate**
+- [x] **Step 1: Run the complete local verification gate**
 
 Run each command separately and retain its exact result:
 
@@ -785,13 +785,13 @@ npm test
 npm run validate
 npm run check-counts
 npm run verify-vendor
-npx --yes markdownlint-cli2@0.18.1 "**/*.md"
+npx --yes markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#.superpowers/sdd"
 git diff --check
 ```
 
 Expected: every command exits 0. `npm run validate` may report pre-existing non-credential warnings but reports zero errors, zero stale credential warnings, and no audited-role marker gaps.
 
-- [ ] **Step 2: Review the complete diff against the approved design**
+- [x] **Step 2: Review the complete diff against the approved design**
 
 Confirm explicitly:
 
@@ -802,6 +802,30 @@ Confirm explicitly:
 - legacy domains remain allowed and visibly unaudited;
 - stale references warn and unknown references fail;
 - documentation names ownership and the remaining-domain rollout issue exists.
+
+#### Task 5 local verification evidence (2026-08-08)
+
+All commands were run separately on `codex/178-credential-registry` and exited 0:
+
+- `node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js`: 67 tests, 67 passed, 0 failed, 0 skipped, 0 todo.
+- `npm test`: 267 tests, 267 passed, 0 failed, 0 skipped, 0 todo.
+- `npm run validate`: checked 227 role files, skipped 1 reference document, found 0 files with errors, 199 files with pre-existing KPI warnings, and 0 duplicate titles. No stale credential warnings or audited-role marker gaps were reported.
+- `npm run check-counts`: 226 roles, 34 domains, and 7 chapters; README counts match.
+- `npm run verify-vendor`: vendored dependency manifest and checksums verified.
+- `npx --yes markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#.superpowers/sdd"`: linted 275 CI-visible Markdown files with 0 errors.
+- `git diff --check`: no whitespace errors.
+
+The original local lint glob also traversed git-ignored `node_modules/` and self-ignored `.superpowers/sdd/` orchestration artifacts, which are absent from CI. The corrected command excludes both ignored trees and matches the 275-file CI-visible scope.
+
+The design review confirmed:
+
+- `audited_roles` contains exactly the four Kubernetes architect, engineer, product owner, and senior engineer paths.
+- All 13 registry records use HTTPS issuer-controlled domains, carry `verified_on: 2026-08-08`, and are owned by `catalogue-maintainers`.
+- The four audited recommendation sections contain no KCSP or other organisation-programme recommendations.
+- Architect, engineer, product owner, and senior engineer contain 7, 6, 3, and 9 markers respectively; every recommendation bullet has exactly one known marker and all four files validate with zero credential errors.
+- Legacy unmarked recommendations remain allowed by validation and are explicitly described as unaudited in `docs/CREDENTIAL_REGISTRY.md`.
+- Focused tests prove stale entries warn, unknown references fail, and malformed marker syntax fails.
+- `docs/CREDENTIAL_REGISTRY.md` names `catalogue-maintainers` ownership and links the remaining-domain rollout tracker, issue #210, in both the audit-boundary and rollout sections. The controller separately verified the external issue state.
 
 - [ ] **Step 3: Commit the verification record and push**
 

--- a/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
@@ -1,0 +1,833 @@
+# Credential Registry and Kubernetes Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a source-backed credential registry, validate role references and review age, and complete a fully audited Kubernetes pilot for issue #178.
+
+**Architecture:** `credentialRegistry.js` owns registry parsing, schema checks, staleness calculation, and Markdown reference validation. `validate-roles.js` consumes that module so `npm run validate` remains the single content-validation entry point. `data/credentials.json` names the audited role files explicitly, allowing the four Kubernetes roles to require complete registry markers while legacy domains remain valid until later rollout batches.
+
+**Tech Stack:** Node.js 18+, CommonJS, `node:test`, JSON, Markdown, existing zero-runtime-dependency validation workflow.
+
+## Global Constraints
+
+- Keep runtime dependencies at zero; validation must use Node built-ins only.
+- Do not perform network requests in tests, `npm run validate`, or CI.
+- Use stable hidden markers in the exact form `<!-- credential: <id> -->`.
+- Use lowercase kebab-case credential IDs and never rename an ID merely because the official display name changes.
+- Treat unknown references and invalid registry records as errors.
+- Treat stale verification dates as warnings; the normal validator still exits zero when only warnings exist.
+- Default credential review cadence is 12 months.
+- Only the four Kubernetes role files are audited in this pilot; unmarked legacy recommendations elsewhere remain allowed.
+- Organisation programmes, courses, vague families, and provider marketing tracks are not individual credentials.
+- Use issuer-controlled sources checked on `2026-08-08`; do not substitute search snippets or training resellers.
+- Keep issue #178 open until every acceptance criterion has criterion-level evidence and is checked.
+
+---
+
+## File Structure
+
+- Create `credentialRegistry.js`: pure registry and Markdown-reference validation functions plus file loading.
+- Create `data/credentials.json`: versioned registry, audited-role list, and verified credential records.
+- Create `test/credential-registry.test.js`: schema, lifecycle, date, staleness, and reference unit tests.
+- Create `test/kubernetes-credentials.test.js`: integration guard for all four audited Kubernetes roles.
+- Modify `validate-roles.js`: load registry once, validate it, and apply its context to each role.
+- Modify `test/validate-roles.test.js`: prove CLI errors/warnings and audited-role integration.
+- Modify four files under `Roles/kubernetes/`: replace free-text claims with verified credentials and markers.
+- Create `docs/CREDENTIAL_REGISTRY.md`: schema, ownership, evidence, lifecycle, and rollout policy.
+- Modify `CONTRIBUTING.md`, `README.md`, and `docs/role_template.md`: link and apply the registry rules.
+
+### Task 1: Registry schema, loading, and staleness
+
+**Files:**
+
+- Create: `credentialRegistry.js`
+- Create: `data/credentials.json`
+- Create: `test/credential-registry.test.js`
+
+**Interfaces:**
+
+- Produces: `validateCredentialRegistry(value, now)` returning `{ errors, warnings, credentialsById, auditedRoles }`.
+- Produces: `loadCredentialRegistry(filePath, now)` with the same return shape and parse/read errors converted to validation errors.
+- Produces: `CREDENTIAL_ID_PATTERN`, `ALLOWED_TYPES`, and `ALLOWED_STATUSES` for focused tests.
+
+- [ ] **Step 1: Write failing schema and staleness tests**
+
+Create `test/credential-registry.test.js` with a reusable valid fixture and one-behaviour tests:
+
+```javascript
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  validateCredentialRegistry,
+  loadCredentialRegistry,
+} = require('../credentialRegistry');
+
+const NOW = new Date('2026-08-08T00:00:00Z');
+
+function validRegistry() {
+  return {
+    schema_version: 1,
+    audited_roles: ['Roles/kubernetes/kubernetes_engineer.md'],
+    credentials: [{
+      id: 'cncf-cka',
+      name: 'Certified Kubernetes Administrator (CKA)',
+      issuer: 'Cloud Native Computing Foundation and The Linux Foundation',
+      type: 'certification',
+      url: 'https://www.cncf.io/training/certification/cka/',
+      status: 'active',
+      verified_on: '2026-08-08',
+      owner: 'catalogue-maintainers',
+      review_months: 12,
+    }],
+  };
+}
+
+test('a valid registry builds ID and audited-role indexes', () => {
+  const result = validateCredentialRegistry(validRegistry(), NOW);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.warnings, []);
+  assert.equal(result.credentialsById.get('cncf-cka').name,
+    'Certified Kubernetes Administrator (CKA)');
+  assert.ok(result.auditedRoles.has('Roles/kubernetes/kubernetes_engineer.md'));
+});
+
+test('duplicate credential IDs are errors', () => {
+  const registry = validRegistry();
+  registry.credentials.push({ ...registry.credentials[0] });
+  assert.ok(validateCredentialRegistry(registry, NOW).errors
+    .some(error => /duplicate.*cncf-cka/i.test(error)));
+});
+
+test('missing required credential fields are errors', () => {
+  const registry = validRegistry();
+  delete registry.credentials[0].issuer;
+  assert.ok(validateCredentialRegistry(registry, NOW).errors
+    .some(error => /issuer/i.test(error)));
+});
+
+test('credential names and issuers must be non-empty strings', () => {
+  const registry = validRegistry();
+  registry.credentials[0].name = 42;
+  assert.ok(validateCredentialRegistry(registry, NOW).errors
+    .some(error => /name.*string/i.test(error)));
+});
+
+for (const [field, value, pattern] of [
+  ['id', 'CKA', /id/i],
+  ['type', 'badge', /type/i],
+  ['url', 'http://example.com/cka', /https/i],
+  ['status', 'maybe', /status/i],
+  ['verified_on', '2026-02-30', /verified_on/i],
+  ['review_months', 0, /review_months/i],
+]) {
+  test(`invalid ${field} is an error`, () => {
+    const registry = validRegistry();
+    registry.credentials[0][field] = value;
+    assert.ok(validateCredentialRegistry(registry, NOW).errors.some(error => pattern.test(error)));
+  });
+}
+
+test('an entry becomes stale only after its review interval', () => {
+  const registry = validRegistry();
+  registry.credentials[0].verified_on = '2025-08-07';
+  const result = validateCredentialRegistry(registry, NOW);
+  assert.deepEqual(result.errors, []);
+  assert.ok(result.warnings.some(warning => /cncf-cka.*stale/i.test(warning)));
+});
+
+test('a review due on the reference date is not stale', () => {
+  const registry = validRegistry();
+  registry.credentials[0].verified_on = '2025-08-08';
+  assert.deepEqual(validateCredentialRegistry(registry, NOW).warnings, []);
+});
+
+test('malformed JSON is returned as a registry error', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-registry-'));
+  const file = path.join(dir, 'credentials.json');
+  fs.writeFileSync(file, '{ invalid json');
+  const result = loadCredentialRegistry(file, NOW);
+  assert.ok(result.errors.some(error => /parse/i.test(error)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `node --test test/credential-registry.test.js`
+
+Expected: FAIL with `Cannot find module '../credentialRegistry'`.
+
+- [ ] **Step 3: Implement the minimal registry validator**
+
+Create `credentialRegistry.js` using these exact rules:
+
+```javascript
+'use strict';
+
+const fs = require('node:fs');
+
+const CREDENTIAL_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const ALLOWED_TYPES = new Set(['certification', 'certificate']);
+const ALLOWED_STATUSES = new Set(['active', 'retired', 'superseded']);
+const REQUIRED_FIELDS = [
+  'id', 'name', 'issuer', 'type', 'url', 'status',
+  'verified_on', 'owner', 'review_months',
+];
+
+function emptyResult(errors = []) {
+  return { errors, warnings: [], credentialsById: new Map(), auditedRoles: new Set() };
+}
+
+function isRealIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value;
+}
+
+function reviewDueDate(verifiedOn, months) {
+  const date = new Date(`${verifiedOn}T00:00:00Z`);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  return date;
+}
+
+function validateCredentialRegistry(value, now = new Date()) {
+  const result = emptyResult();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    result.errors.push('Credential registry must be a JSON object');
+    return result;
+  }
+  if (value.schema_version !== 1) result.errors.push('schema_version must be 1');
+  if (!Array.isArray(value.audited_roles)) result.errors.push('audited_roles must be an array');
+  if (!Array.isArray(value.credentials)) {
+    result.errors.push('credentials must be an array');
+    return result;
+  }
+
+  for (const role of value.audited_roles || []) {
+    if (typeof role !== 'string' || !/^Roles\/[a-z0-9_/-]+\.md$/.test(role)) {
+      result.errors.push(`Invalid audited role path: ${String(role)}`);
+    } else if (result.auditedRoles.has(role)) {
+      result.errors.push(`Duplicate audited role path: ${role}`);
+    } else {
+      result.auditedRoles.add(role);
+    }
+  }
+
+  for (const [index, credential] of value.credentials.entries()) {
+    const prefix = `credentials[${index}]`;
+    if (!credential || typeof credential !== 'object' || Array.isArray(credential)) {
+      result.errors.push(`${prefix} must be an object`);
+      continue;
+    }
+    for (const field of REQUIRED_FIELDS) {
+      if (credential[field] === undefined || credential[field] === '') {
+        result.errors.push(`${prefix}.${field} is required`);
+      }
+    }
+    for (const field of ['name', 'issuer']) {
+      if (typeof credential[field] !== 'string' || !credential[field].trim()) {
+        result.errors.push(`${prefix}.${field} must be a non-empty string`);
+      }
+    }
+    if (!CREDENTIAL_ID_PATTERN.test(credential.id || '')) {
+      result.errors.push(`${prefix}.id must be lowercase kebab-case`);
+    } else if (result.credentialsById.has(credential.id)) {
+      result.errors.push(`Duplicate credential ID: ${credential.id}`);
+    } else {
+      result.credentialsById.set(credential.id, credential);
+    }
+    if (!ALLOWED_TYPES.has(credential.type)) result.errors.push(`${prefix}.type is unsupported`);
+    if (!ALLOWED_STATUSES.has(credential.status)) result.errors.push(`${prefix}.status is unsupported`);
+    try {
+      const url = new URL(credential.url);
+      if (url.protocol !== 'https:') result.errors.push(`${prefix}.url must use https`);
+    } catch {
+      result.errors.push(`${prefix}.url must be a valid https URL`);
+    }
+    if (!isRealIsoDate(credential.verified_on || '')) {
+      result.errors.push(`${prefix}.verified_on must be a real YYYY-MM-DD date`);
+    }
+    if (!Number.isInteger(credential.review_months) || credential.review_months < 1) {
+      result.errors.push(`${prefix}.review_months must be a positive integer`);
+    }
+    if (typeof credential.owner !== 'string' || !credential.owner.trim()) {
+      result.errors.push(`${prefix}.owner is required`);
+    }
+    if (credential.notes !== undefined && typeof credential.notes !== 'string') {
+      result.errors.push(`${prefix}.notes must be a string when present`);
+    }
+    if (isRealIsoDate(credential.verified_on || '') &&
+        Number.isInteger(credential.review_months) && credential.review_months > 0 &&
+        now > reviewDueDate(credential.verified_on, credential.review_months)) {
+      result.warnings.push(`${credential.id || prefix} credential verification is stale`);
+    }
+  }
+  return result;
+}
+
+function loadCredentialRegistry(filePath, now = new Date()) {
+  try {
+    return validateCredentialRegistry(JSON.parse(fs.readFileSync(filePath, 'utf8')), now);
+  } catch (error) {
+    return emptyResult([`Unable to read or parse credential registry: ${error.message}`]);
+  }
+}
+
+module.exports = {
+  validateCredentialRegistry,
+  loadCredentialRegistry,
+  CREDENTIAL_ID_PATTERN,
+  ALLOWED_TYPES,
+  ALLOWED_STATUSES,
+};
+```
+
+Create the initially empty but valid `data/credentials.json` so the CLI can be
+integrated in Task 2 without leaving `npm run validate` broken between commits:
+
+```json
+{
+  "schema_version": 1,
+  "audited_roles": [],
+  "credentials": []
+}
+```
+
+- [ ] **Step 4: Run focused and full Node tests**
+
+Run: `node --test test/credential-registry.test.js`
+
+Expected: PASS with zero failures.
+
+Run: `npm test`
+
+Expected: all existing tests plus the new registry tests pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add credentialRegistry.js data/credentials.json test/credential-registry.test.js
+git commit -m "feat: validate credential registry"
+```
+
+### Task 2: Role-marker validation and CLI integration
+
+**Files:**
+
+- Modify: `credentialRegistry.js`
+- Modify: `test/credential-registry.test.js`
+- Modify: `validate-roles.js`
+- Modify: `test/validate-roles.test.js`
+
+**Interfaces:**
+
+- Consumes: `credentialsById` and `auditedRoles` from Task 1.
+- Produces: `findCredentialReferences(markdown)` returning `{ id, line, raw }[]`.
+- Produces: `validateRoleCredentialReferences(markdown, credentialsById, { requireComplete })` returning `{ errors, warnings }`.
+- Changes: `validateFile(filePath, rolesDir, credentialContext = null)`; existing two-argument callers remain valid.
+
+- [ ] **Step 1: Write failing marker tests**
+
+Append tests that prove known, unknown, duplicate, and unmarked audited bullets:
+
+```javascript
+const {
+  findCredentialReferences,
+  validateRoleCredentialReferences,
+} = require('../credentialRegistry');
+
+const known = new Map([['cncf-cka', { id: 'cncf-cka' }]]);
+
+test('a known credential marker passes', () => {
+  const markdown = '## Recommended Certifications & Learning Paths\n\n- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->\n';
+  assert.deepEqual(validateRoleCredentialReferences(markdown, known, { requireComplete: true }),
+    { errors: [], warnings: [] });
+});
+
+test('an unknown credential marker is an error', () => {
+  const markdown = '- Imaginary Credential <!-- credential: invented-one -->\n';
+  assert.ok(validateRoleCredentialReferences(markdown, known, { requireComplete: false })
+    .errors.some(error => /unknown.*invented-one/i.test(error)));
+});
+
+test('a duplicate marker in one role is an error', () => {
+  const markdown = '- CKA <!-- credential: cncf-cka -->\n- CKA again <!-- credential: cncf-cka -->\n';
+  assert.ok(validateRoleCredentialReferences(markdown, known, { requireComplete: false })
+    .errors.some(error => /duplicate.*cncf-cka/i.test(error)));
+});
+
+test('audited recommendation bullets require exactly one marker', () => {
+  const markdown = `## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA)
+
+**Learning Resources and Communities:**
+
+- Kubernetes documentation
+`;
+  const result = validateRoleCredentialReferences(markdown, known, { requireComplete: true });
+  assert.ok(result.errors.some(error => /missing credential marker/i.test(error)));
+  assert.equal(result.errors.filter(error => /Kubernetes documentation/.test(error)).length, 0);
+});
+
+test('legacy unmarked recommendations remain allowed', () => {
+  const markdown = '## Recommended Certifications & Learning Paths\n\n- Legacy free text\n';
+  assert.deepEqual(validateRoleCredentialReferences(markdown, known, { requireComplete: false }),
+    { errors: [], warnings: [] });
+});
+```
+
+In `test/validate-roles.test.js`, add a fixture test passing an explicit credential context to `validateFile` and a CLI test using `CREDENTIALS_FILE` to prove an unknown marker exits 1.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `node --test test/credential-registry.test.js test/validate-roles.test.js`
+
+Expected: FAIL because the marker functions and `credentialContext` integration do not exist.
+
+- [ ] **Step 3: Implement marker extraction and audited-section checks**
+
+Add to `credentialRegistry.js`:
+
+```javascript
+const CREDENTIAL_MARKER = /<!--\s*credential:\s*([a-z0-9]+(?:-[a-z0-9]+)*)\s*-->/g;
+
+function certificationSection(markdown) {
+  const start = markdown.search(/^##\s+Recommended Certifications (?:&|and) Learning Paths\s*$/im);
+  if (start === -1) return '';
+  const rest = markdown.slice(start);
+  const next = rest.slice(1).search(/\n##\s+/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+function findCredentialReferences(markdown) {
+  const references = [];
+  for (const match of markdown.matchAll(CREDENTIAL_MARKER)) {
+    references.push({
+      id: match[1],
+      line: markdown.slice(0, match.index).split(/\r?\n/).length,
+      raw: match[0],
+    });
+  }
+  return references;
+}
+
+function recommendedCredentialBullets(markdown) {
+  const section = certificationSection(markdown);
+  const learningIndex = section.search(/^\*\*Learning Resources and Communities:\*\*\s*$/im);
+  const credentialPart = learningIndex === -1 ? section : section.slice(0, learningIndex);
+  return credentialPart.split(/\r?\n/)
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(item => /^\s*-\s+/.test(item.line));
+}
+
+function validateRoleCredentialReferences(markdown, credentialsById, { requireComplete = false } = {}) {
+  const errors = [];
+  const warnings = [];
+  const seen = new Set();
+  for (const reference of findCredentialReferences(markdown)) {
+    if (!credentialsById.has(reference.id)) {
+      errors.push(`Unknown credential reference "${reference.id}" on line ${reference.line}`);
+    }
+    if (seen.has(reference.id)) {
+      errors.push(`Duplicate credential reference "${reference.id}" in one role`);
+    }
+    seen.add(reference.id);
+  }
+  if (requireComplete) {
+    for (const bullet of recommendedCredentialBullets(markdown)) {
+      const matches = [...bullet.line.matchAll(CREDENTIAL_MARKER)];
+      if (matches.length === 0) {
+        errors.push(`Audited credential bullet is missing credential marker: ${bullet.line.trim()}`);
+      } else if (matches.length > 1) {
+        errors.push(`Audited credential bullet has multiple credential markers: ${bullet.line.trim()}`);
+      }
+    }
+  }
+  return { errors, warnings };
+}
+```
+
+Export the three new functions. Reset `CREDENTIAL_MARKER.lastIndex = 0` before each scan if implementation testing shows the global regular expression retaining state between calls.
+
+- [ ] **Step 4: Integrate the registry into `validate-roles.js`**
+
+Import `loadCredentialRegistry` and `validateRoleCredentialReferences`. Add `CREDENTIALS_FILE`, honoring a `CREDENTIALS_FILE` environment override for CLI fixtures. Extend `validateFile` with an optional context and append marker errors/warnings after the existing structural checks:
+
+```javascript
+function validateFile(filePath, rolesDir = ROLES_DIR, credentialContext = null) {
+  // existing implementation
+  if (credentialContext) {
+    const credentialResult = validateRoleCredentialReferences(
+      content,
+      credentialContext.credentialsById,
+      { requireComplete: credentialContext.auditedRoles.has(rel) },
+    );
+    errors.push(...credentialResult.errors);
+    warnings.push(...credentialResult.warnings);
+  }
+  return { rel, errors, warnings, skipped: false };
+}
+```
+
+In `main()`, load the registry once, print registry errors/warnings under `data/credentials.json`, pass the context to every `validateFile`, include registry warnings in the strict-mode decision, and include registry errors in exit code 1. Do not load the registry at module import time.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run: `node --test test/credential-registry.test.js test/validate-roles.test.js`
+
+Expected: PASS with zero failures.
+
+Run: `npm test`
+
+Expected: all tests pass.
+
+Run: `npm run validate`
+
+Expected: exit 0 with the empty valid registry and unchanged legacy role files.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add credentialRegistry.js validate-roles.js test/credential-registry.test.js test/validate-roles.test.js
+git commit -m "feat: validate role credential references"
+```
+
+### Task 3: Source-backed registry data and Kubernetes audit
+
+**Files:**
+
+- Modify: `data/credentials.json`
+- Create: `test/kubernetes-credentials.test.js`
+- Modify: `Roles/kubernetes/kubernetes_architect.md`
+- Modify: `Roles/kubernetes/kubernetes_engineer.md`
+- Modify: `Roles/kubernetes/kubernetes_product_owner.md`
+- Modify: `Roles/kubernetes/kubernetes_senior_engineer.md`
+
+**Interfaces:**
+
+- Consumes: the registry schema and role-reference validator from Tasks 1–2.
+- Produces: 13 stable credential IDs and four fully audited role files.
+
+- [ ] **Step 1: Write the failing Kubernetes pilot integration test**
+
+Create `test/kubernetes-credentials.test.js`:
+
+```javascript
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { loadCredentialRegistry, validateRoleCredentialReferences } = require('../credentialRegistry');
+
+const ROOT = path.join(__dirname, '..');
+const REGISTRY = path.join(ROOT, 'data', 'credentials.json');
+const EXPECTED_ROLES = [
+  'Roles/kubernetes/kubernetes_architect.md',
+  'Roles/kubernetes/kubernetes_engineer.md',
+  'Roles/kubernetes/kubernetes_product_owner.md',
+  'Roles/kubernetes/kubernetes_senior_engineer.md',
+];
+
+test('the Kubernetes pilot contains exactly the four audited roles', () => {
+  const result = loadCredentialRegistry(REGISTRY, new Date('2026-08-08T00:00:00Z'));
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual([...result.auditedRoles].sort(), EXPECTED_ROLES);
+});
+
+test('every Kubernetes pilot recommendation references a known credential', () => {
+  const registry = loadCredentialRegistry(REGISTRY, new Date('2026-08-08T00:00:00Z'));
+  for (const relativePath of EXPECTED_ROLES) {
+    const markdown = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+    const result = validateRoleCredentialReferences(
+      markdown,
+      registry.credentialsById,
+      { requireComplete: true },
+    );
+    assert.deepEqual(result.errors, [], `${relativePath}: ${result.errors.join('; ')}`);
+  }
+});
+
+test('KCSP is not presented as an individual credential', () => {
+  for (const relativePath of EXPECTED_ROLES) {
+    const markdown = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+    assert.doesNotMatch(markdown, /Certified Kubernetes Service Provider|\bKCSP\b/i);
+  }
+});
+```
+
+- [ ] **Step 2: Run the pilot test and verify RED**
+
+Run: `node --test test/kubernetes-credentials.test.js`
+
+Expected: FAIL because the registry has no audited roles or credential records.
+
+- [ ] **Step 3: Add the verified registry records**
+
+Create `data/credentials.json` with `schema_version: 1`, the exact four `audited_roles`, and these records. Every record uses `status: "active"`, `type: "certification"`, `verified_on: "2026-08-08"`, `owner: "catalogue-maintainers"`, and `review_months: 12`.
+
+| ID | Official name | Issuer | Authoritative URL |
+|---|---|---|---|
+| `cncf-cka` | Certified Kubernetes Administrator (CKA) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/cka/` |
+| `cncf-ckad` | Certified Kubernetes Application Developer (CKAD) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/ckad/` |
+| `cncf-cks` | Certified Kubernetes Security Specialist (CKS) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/cks/` |
+| `cncf-kcna` | Kubernetes and Cloud Native Associate (KCNA) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/kcna/` |
+| `cncf-pca` | Prometheus Certified Associate (PCA) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/pca/` |
+| `cncf-ica` | Istio Certified Associate (ICA) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/ica/` |
+| `cncf-capa` | Certified Argo Project Associate (CAPA) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/capa/` |
+| `cncf-cgoa` | GitOps Certified Associate (CGOA) | Cloud Native Computing Foundation and The Linux Foundation | `https://www.cncf.io/training/certification/cgoa/` |
+| `hashicorp-terraform-associate` | HashiCorp Certified: Terraform Associate | HashiCorp | `https://developer.hashicorp.com/certifications/infrastructure-automation` |
+| `scrumorg-pspo-i` | Professional Scrum Product Owner I (PSPO I) | Scrum.org | `https://www.scrum.org/assessments/professional-scrum-product-owner-i-certification` |
+| `finops-certified-practitioner` | FinOps Certified Practitioner | FinOps Foundation | `https://www.finops.org/training-certification/recommended/practitioner/` |
+| `opengroup-togaf-ea-practitioner` | TOGAF Enterprise Architecture Practitioner | The Open Group | `https://www.opengroup.org/certifications/togaf` |
+| `redhat-openshift-administrator` | Red Hat Certified System Administrator in OpenShift | Red Hat | `https://www.redhat.com/en/services/certification/rhcs-paas` |
+
+This table contains 13 records; keep all 13 because each appears in at least one audited role. Do not add Docker Certified Associate, Kubernetes Fundamentals, generic cloud-provider tracks, or invented architecture/product credentials to the registry.
+
+- [ ] **Step 4: Replace the four certification sections with audited content**
+
+Use these exact credential sets, one bullet and one marker per credential:
+
+`kubernetes_architect.md`:
+
+```markdown
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+- Certified Kubernetes Security Specialist (CKS) <!-- credential: cncf-cks -->
+- TOGAF Enterprise Architecture Practitioner <!-- credential: opengroup-togaf-ea-practitioner -->
+
+**Complementary Certifications:**
+
+- HashiCorp Certified: Terraform Associate <!-- credential: hashicorp-terraform-associate -->
+- Red Hat Certified System Administrator in OpenShift <!-- credential: redhat-openshift-administrator -->
+- Istio Certified Associate (ICA) <!-- credential: cncf-ica -->
+- GitOps Certified Associate (CGOA) <!-- credential: cncf-cgoa -->
+```
+
+`kubernetes_engineer.md`:
+
+```markdown
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+- Certified Kubernetes Application Developer (CKAD) <!-- credential: cncf-ckad -->
+
+**Complementary Certifications:**
+
+- Kubernetes and Cloud Native Associate (KCNA) <!-- credential: cncf-kcna -->
+- Prometheus Certified Associate (PCA) <!-- credential: cncf-pca -->
+- Certified Argo Project Associate (CAPA) <!-- credential: cncf-capa -->
+- HashiCorp Certified: Terraform Associate <!-- credential: hashicorp-terraform-associate -->
+```
+
+`kubernetes_product_owner.md`:
+
+```markdown
+**Core Certifications:**
+
+- Professional Scrum Product Owner I (PSPO I) <!-- credential: scrumorg-pspo-i -->
+- Kubernetes and Cloud Native Associate (KCNA) <!-- credential: cncf-kcna -->
+
+**Complementary Certifications:**
+
+- FinOps Certified Practitioner <!-- credential: finops-certified-practitioner -->
+```
+
+`kubernetes_senior_engineer.md`:
+
+```markdown
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+- Certified Kubernetes Application Developer (CKAD) <!-- credential: cncf-ckad -->
+- Certified Kubernetes Security Specialist (CKS) <!-- credential: cncf-cks -->
+
+**Complementary Certifications:**
+
+- HashiCorp Certified: Terraform Associate <!-- credential: hashicorp-terraform-associate -->
+- Red Hat Certified System Administrator in OpenShift <!-- credential: redhat-openshift-administrator -->
+- Istio Certified Associate (ICA) <!-- credential: cncf-ica -->
+- Prometheus Certified Associate (PCA) <!-- credential: cncf-pca -->
+- Certified Argo Project Associate (CAPA) <!-- credential: cncf-capa -->
+- GitOps Certified Associate (CGOA) <!-- credential: cncf-cgoa -->
+```
+
+Retain each existing `Learning Resources and Communities` subsection. Move only genuine courses or reading suggestions there when the existing text is specific and useful; remove generic pseudo-credentials rather than relabeling them as authoritative learning resources.
+
+- [ ] **Step 5: Run pilot, validator, and full tests**
+
+Run: `node --test test/kubernetes-credentials.test.js`
+
+Expected: PASS with zero failures.
+
+Run: `npm run validate`
+
+Expected: exit 0; registry has zero errors and no stale warnings; all four audited roles have zero credential-reference errors.
+
+Run: `npm test`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add data/credentials.json test/kubernetes-credentials.test.js Roles/kubernetes
+git commit -m "docs: audit kubernetes credentials"
+```
+
+### Task 4: Ownership, contribution guidance, and rollout tracking
+
+**Files:**
+
+- Create: `docs/CREDENTIAL_REGISTRY.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `README.md`
+- Modify: `docs/role_template.md`
+
+**Interfaces:**
+
+- Consumes: schema and marker syntax from Tasks 1–3.
+- Produces: contributor-facing ownership and lifecycle policy plus a GitHub follow-up for the remaining domains.
+
+- [ ] **Step 1: Write the credential governance document**
+
+Create `docs/CREDENTIAL_REGISTRY.md` with these sections and decisions:
+
+- **Purpose and audit boundary:** registry-backed items are verified; unmarked legacy text is not yet audited.
+- **Schema:** document every top-level and credential field, allowed values, the 12-month default, and stable-ID policy.
+- **Authoritative evidence:** issuer-controlled pages only; verification date is the day the page was checked.
+- **Ownership:** `catalogue-maintainers` owns registry freshness until a durable domain team is named.
+- **Adding or changing a credential:** issue-first, source link, exact official name/type/status, marker, tests, and verification date.
+- **Lifecycle:** retain retired/superseded records while references exist; update role recommendations deliberately.
+- **Staleness:** warnings begin after `verified_on + review_months`; no runtime network request.
+- **Courses and organisation programmes:** keep courses under learning resources; never represent KCSP-like programmes as individual credentials.
+- **Rollout:** inventory strings, group aliases, audit by bounded domain batches, migrate markers, and track unaudited domains in GitHub.
+
+- [ ] **Step 2: Link the policy from contributor and repository guidance**
+
+In `CONTRIBUTING.md`, link `docs/CREDENTIAL_REGISTRY.md` from the credential evidence row and require registry ID, authoritative URL, verification date, and validator output in credential PRs.
+
+In `README.md`, add the credential registry to the governance table and expand the validation description to include registry structure, unknown/duplicate references, audited-role completeness, and stale warnings.
+
+In `docs/role_template.md`, add a concise note above the certification example:
+
+```markdown
+> For a registry-audited role, use the official credential name followed by
+> `<!-- credential: stable-id -->`. Keep courses and communities under learning
+> resources. See [Credential Registry](CREDENTIAL_REGISTRY.md).
+```
+
+- [ ] **Step 3: Create the catalogue rollout follow-up issue**
+
+Create one assigned, milestone-bound issue titled `Roll out credential registry references across the remaining role domains` with labels `documentation`, `maintenance`, and `P2`, milestone `Catalogue Trust & Adoption`, and this acceptance contract:
+
+```markdown
+## Acceptance criteria
+
+- [ ] Unique legacy credential strings are inventoried and grouped into aliases.
+- [ ] Remaining domains are split into bounded native sub-issues before migration.
+- [ ] Every migrated credential has an issuer-controlled source and verification date.
+- [ ] Every migrated role recommendation uses a known registry ID.
+- [ ] Courses and organisation programmes are not presented as individual credentials.
+- [ ] `audited_roles` lists each completed role and validation rejects new unmarked recommendations in it.
+- [ ] `npm test` and `npm run validate` pass after every batch.
+```
+
+Reference issue #178 as the completed Kubernetes pilot. Do not close this rollout issue until its own criteria pass.
+
+- [ ] **Step 4: Verify documentation and links**
+
+Run: `npx --yes markdownlint-cli2@0.18.1 "**/*.md"`
+
+Expected: zero Markdown lint errors.
+
+Run: `rg -n "CREDENTIAL_REGISTRY|credential: stable-id|catalogue-maintainers" README.md CONTRIBUTING.md docs/role_template.md docs/CREDENTIAL_REGISTRY.md`
+
+Expected: all four files contain the intended policy link or example.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add docs/CREDENTIAL_REGISTRY.md CONTRIBUTING.md README.md docs/role_template.md
+git commit -m "docs: govern credential recommendations"
+```
+
+### Task 5: Full verification, issue evidence, and publication
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md` only to check completed execution steps and record actual command results.
+
+**Interfaces:**
+
+- Consumes: every deliverable and test from Tasks 1–4.
+- Produces: a pushed branch, reviewable PR, and criterion-level completion evidence for issue #178.
+
+- [ ] **Step 1: Run the complete local verification gate**
+
+Run each command separately and retain its exact result:
+
+```bash
+node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js
+npm test
+npm run validate
+npm run check-counts
+npm run verify-vendor
+npx --yes markdownlint-cli2@0.18.1 "**/*.md"
+git diff --check
+```
+
+Expected: every command exits 0. `npm run validate` may report pre-existing non-credential warnings but reports zero errors, zero stale credential warnings, and no audited-role marker gaps.
+
+- [ ] **Step 2: Review the complete diff against the approved design**
+
+Confirm explicitly:
+
+- all four and only the four Kubernetes roles are in `audited_roles`;
+- all 13 registry records have issuer-controlled HTTPS sources and `2026-08-08` verification dates;
+- KCSP and every other organisation programme are absent from individual recommendations;
+- all audited recommendation bullets contain exactly one known marker;
+- legacy domains remain allowed and visibly unaudited;
+- stale references warn and unknown references fail;
+- documentation names ownership and the remaining-domain rollout issue exists.
+
+- [ ] **Step 3: Commit the verification record and push**
+
+Update this plan's checkboxes and add the actual verification totals beneath this task. Then:
+
+```bash
+git add docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
+git commit -m "docs: record credential pilot verification"
+git push -u origin codex/178-credential-registry
+```
+
+- [ ] **Step 4: Reconcile issue #178 acceptance criteria before closure**
+
+Add a completion comment mapping each issue criterion to concrete evidence: registry documentation, four audited role paths, the KCSP removal test, all registry URLs/dates, validator tests/output, and the rollout issue.
+
+Use `gh issue edit 178 --body-file <newline-preserving-file>` to check a criterion only after its evidence is confirmed. If any criterion lacks evidence, leave it unchecked and keep the PR body at `Refs #178`.
+
+- [ ] **Step 5: Open the pull request without bypassing the closure gate**
+
+Create a ready PR titled `feat: add credential registry and Kubernetes pilot`. Its body includes:
+
+- summary of registry, validation, audited roles, and governance;
+- authoritative source list;
+- removed/reclassified recommendation summary;
+- exact verification commands and results;
+- rollout issue link; and
+- `Closes #178` only if every acceptance criterion has already been evidenced and checked, otherwise `Refs #178`.
+
+Wait for every CI leg. Do not merge until the maintainer explicitly approves and `github-hygiene` confirms the issue closure gate still passes.

--- a/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
@@ -853,7 +853,7 @@ Use `gh issue edit 178 --body-file <newline-preserving-file>` to check a criteri
 Issue #178 now has a criterion-level completion comment, six checked acceptance
 criteria, zero unchecked criteria, and remains open pending merge of PR #211.
 
-- [ ] **Step 5: Open the pull request without bypassing the closure gate**
+- [x] **Step 5: Open the pull request without bypassing the closure gate**
 
 Create a ready PR titled `feat: add credential registry and Kubernetes pilot`. Its body includes:
 
@@ -867,4 +867,7 @@ Create a ready PR titled `feat: add credential registry and Kubernetes pilot`. I
 Wait for every CI leg. Do not merge until the maintainer explicitly approves and `github-hygiene` confirms the issue closure gate still passes.
 
 Ready PR #211 was opened against `main` with the `enhancement` release-note
-label and `Closes #178`. This step remains unchecked until every CI leg passes.
+label and `Closes #178`. GitHub Actions run `31232382326` passed the Node 18,
+Node 22, role-validation, Markdown-lint, and hosted Chromium/Firefox/WebKit
+jobs; both CodeQL analyses also passed. The PR remains unmerged pending the
+maintainer's explicit approval.

--- a/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-kubernetes-pilot.md
@@ -807,8 +807,8 @@ Confirm explicitly:
 
 All commands were run separately on `codex/178-credential-registry` and exited 0:
 
-- `node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js`: 67 tests, 67 passed, 0 failed, 0 skipped, 0 todo.
-- `npm test`: 267 tests, 267 passed, 0 failed, 0 skipped, 0 todo.
+- `node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js`: 72 tests, 72 passed, 0 failed, 0 skipped, 0 todo after the final review fixes.
+- `npm test`: 272 tests, 272 passed, 0 failed, 0 skipped, 0 todo after the final review fixes.
 - `npm run validate`: checked 227 role files, skipped 1 reference document, found 0 files with errors, 199 files with pre-existing KPI warnings, and 0 duplicate titles. No stale credential warnings or audited-role marker gaps were reported.
 - `npm run check-counts`: 226 roles, 34 domains, and 7 chapters; README counts match.
 - `npm run verify-vendor`: vendored dependency manifest and checksums verified.
@@ -826,6 +826,13 @@ The design review confirmed:
 - Legacy unmarked recommendations remain allowed by validation and are explicitly described as unaudited in `docs/CREDENTIAL_REGISTRY.md`.
 - Focused tests prove stale entries warn, unknown references fail, and malformed marker syntax fails.
 - `docs/CREDENTIAL_REGISTRY.md` names `catalogue-maintainers` ownership and links the remaining-domain rollout tracker, issue #210, in both the audit-boundary and rollout sections. The controller separately verified the external issue state.
+
+The final whole-branch review found two boundary defects. Commit `91ed3db`
+fixed both with RED/GREEN regression coverage: audited completeness now accepts
+the canonical ampersand learning heading and all Markdown unordered-list
+markers, while credential review dates now use UTC date-only comparison and
+clamped calendar-month arithmetic. The scoped re-review found both findings
+addressed with no new Critical or Important breakage.
 
 - [ ] **Step 3: Commit the verification record and push**
 

--- a/docs/superpowers/specs/2026-08-08-credential-registry-kubernetes-pilot-design.md
+++ b/docs/superpowers/specs/2026-08-08-credential-registry-kubernetes-pilot-design.md
@@ -1,0 +1,128 @@
+# Credential Registry and Kubernetes Pilot Design
+
+## Goal
+
+Make certification recommendations trustworthy and maintainable by linking each audited role recommendation to a centrally governed credential record backed by an authoritative source.
+
+Issue #178 will establish the registry and validation model, then prove it across the four Kubernetes roles before a catalogue-wide rollout.
+
+## Scope
+
+The pilot covers:
+
+- `Roles/kubernetes/kubernetes_architect.md`
+- `Roles/kubernetes/kubernetes_engineer.md`
+- `Roles/kubernetes/kubernetes_product_owner.md`
+- `Roles/kubernetes/kubernetes_senior_engineer.md`
+
+It includes the credential registry, role-to-registry references, automated validation, tests, ownership documentation, and a rollout plan.
+
+Learning resources that do not award a credential remain ordinary prose and are not added to the registry. Organisation-level programmes, partnerships, and provider designations are not presented as credentials held by an individual.
+
+## Registry
+
+`data/credentials.json` is the authoritative machine-readable registry. Each entry contains:
+
+- `id`: stable, lowercase identifier used by role references;
+- `name`: official credential name;
+- `issuer`: official issuing organisation;
+- `type`: credential classification, such as certification or certificate;
+- `url`: authoritative issuer page;
+- `status`: lifecycle state, initially `active`, `retired`, or `superseded`;
+- `verified_on`: the date the official source was last checked;
+- `owner`: repository owner responsible for review;
+- `review_months`: review interval, defaulting to 12 months;
+- `notes`: optional concise lifecycle or scope clarification.
+
+The registry records only credentials confirmed from an issuer-controlled source. Marketing names, course titles, vague certification families, and programmes for organisations are excluded unless they can be represented accurately as a distinct credential.
+
+Stable IDs are not renamed when display names change. A superseded entry remains available long enough to explain and validate existing references, with its replacement identified in `notes` until the schema needs a dedicated relationship field.
+
+## Role References
+
+Certification sections remain readable Markdown. A registry reference is attached to each audited credential using an HTML comment:
+
+```markdown
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+```
+
+This keeps rendered role pages clean while giving validation a deterministic identifier. Each credential gets its own bullet and marker; combined or ambiguous bullets are split or rewritten.
+
+The Kubernetes pilot will audit every item currently presented as a certification. For each item, the implementation will:
+
+1. confirm the current official name, issuer, lifecycle, and URL from an authoritative provider source;
+2. add a registry entry and stable marker when it is a valid individual credential;
+3. replace or clarify a recommendation when the existing wording inaccurately describes a valid credential;
+4. move genuine non-credential learning guidance out of the certification list; or
+5. remove invented, unverifiable, retired-without-value, ambiguous, or organisation-only recommendations.
+
+In particular, CNCF Certified Kubernetes Service Provider (KCSP) must not remain framed as an individual certification because it is an organisation-level programme.
+
+## Validation
+
+Credential validation will live in a focused module used by `validate-roles.js`, so `npm run validate` remains the single repository validation entry point. The module will inspect credential markers in Markdown and the registry itself, and expose testable functions without executing the full catalogue scan on import.
+
+Validation errors will cover:
+
+- malformed registry data;
+- duplicate or invalid IDs;
+- markers referencing unknown IDs;
+- duplicate credential IDs within one role section;
+- missing required metadata;
+- invalid authoritative URLs;
+- unsupported lifecycle values; and
+- invalid verification dates or review intervals.
+
+Staleness is reported as a warning when `verified_on` plus `review_months` is older than the current date. This makes review debt visible without causing an otherwise unchanged repository to fail on the anniversary date. Unknown references and structurally invalid records remain hard failures.
+
+The validator does not make network requests during normal tests or CI. Source authority is established during the human audit and preserved as registry metadata; automated checks validate structure, references, and review age deterministically.
+
+## Tests
+
+Tests will demonstrate:
+
+- a valid registry and known marker pass;
+- an unknown marker fails;
+- duplicate IDs and missing required fields fail;
+- invalid URL, date, status, and review interval values fail;
+- duplicate role references fail;
+- stale entries warn without failing;
+- all four Kubernetes roles reference only known registry entries; and
+- the repository's existing role and count checks continue to pass.
+
+Fixture dates will be injected or compared against a controlled reference date so staleness tests remain deterministic.
+
+## Ownership and Review Policy
+
+The repository documentation will identify who owns registry review, how a contributor proposes a credential, what counts as an authoritative source, and how lifecycle changes are handled. The initial review cadence is 12 months unless a credential warrants a shorter interval.
+
+Credential changes should include the official provider page and verification date in the pull request evidence. A provider-controlled certification or credential page is preferred; third-party training providers, search snippets, and community summaries are not authoritative evidence.
+
+## Rollout
+
+The Kubernetes pilot is complete when all four role files have been audited and validation covers the registry and their references. The follow-up catalogue rollout should proceed in bounded technology or role-family batches:
+
+1. inventory unique certification strings and group likely aliases;
+2. prioritize common and high-risk recommendations;
+3. verify each credential against an issuer source;
+4. migrate role bullets to stable markers;
+5. run validation and review removals or reclassifications; and
+6. track remaining unaudited roles in GitHub rather than treating their legacy prose as verified.
+
+The pilot must not imply that the other role files have already been audited. Documentation and validator output should clearly distinguish registry-backed references from legacy unmarked recommendations until the rollout is complete.
+
+## Alternatives Considered
+
+Visible credential IDs in role text were rejected because they add implementation noise to human-facing documents. Fully generating certification sections from structured data was also rejected for the pilot because it would make editorial contributions harder and expand the change beyond issue #178.
+
+The chosen design keeps role content editable, adds stable machine linkage, and allows gradual adoption without a catalogue-wide migration in one pull request.
+
+## Completion Evidence
+
+The pull request for #178 should include:
+
+- links to the authoritative sources used for the Kubernetes audit;
+- a summary of corrected, removed, or reclassified recommendations;
+- validator and test output;
+- confirmation that all four pilot roles use known registry IDs; and
+- a clearly scoped follow-up issue or issues for the remaining catalogue rollout.

--- a/test/credential-registry.test.js
+++ b/test/credential-registry.test.js
@@ -9,6 +9,8 @@ const path = require('node:path');
 const {
   validateCredentialRegistry,
   loadCredentialRegistry,
+  findCredentialReferences,
+  validateRoleCredentialReferences,
 } = require('../credentialRegistry');
 
 const NOW = new Date('2026-08-08T00:00:00Z');
@@ -97,4 +99,55 @@ test('malformed JSON is returned as a registry error', () => {
   const result = loadCredentialRegistry(file, NOW);
   assert.ok(result.errors.some(error => /parse/i.test(error)));
   fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const known = new Map([['cncf-cka', { id: 'cncf-cka' }]]);
+
+test('a known credential marker passes', () => {
+  const markdown = '## Recommended Certifications & Learning Paths\n\n- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->\n';
+  assert.deepEqual(validateRoleCredentialReferences(markdown, known, { requireComplete: true }),
+    { errors: [], warnings: [] });
+});
+
+test('an unknown credential marker is an error', () => {
+  const markdown = '- Imaginary Credential <!-- credential: invented-one -->\n';
+  assert.ok(validateRoleCredentialReferences(markdown, known, { requireComplete: false })
+    .errors.some(error => /unknown.*invented-one/i.test(error)));
+});
+
+test('a duplicate marker in one role is an error', () => {
+  const markdown = '- CKA <!-- credential: cncf-cka -->\n- CKA again <!-- credential: cncf-cka -->\n';
+  assert.ok(validateRoleCredentialReferences(markdown, known, { requireComplete: false })
+    .errors.some(error => /duplicate.*cncf-cka/i.test(error)));
+});
+
+test('audited recommendation bullets require exactly one marker', () => {
+  const markdown = `## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA)
+
+**Learning Resources and Communities:**
+
+- Kubernetes documentation
+`;
+  const result = validateRoleCredentialReferences(markdown, known, { requireComplete: true });
+  assert.ok(result.errors.some(error => /missing credential marker/i.test(error)));
+  assert.equal(result.errors.filter(error => /Kubernetes documentation/.test(error)).length, 0);
+});
+
+test('legacy unmarked recommendations remain allowed', () => {
+  const markdown = '## Recommended Certifications & Learning Paths\n\n- Legacy free text\n';
+  assert.deepEqual(validateRoleCredentialReferences(markdown, known, { requireComplete: false }),
+    { errors: [], warnings: [] });
+});
+
+test('credential references include their marker line and source text', () => {
+  const markdown = 'Intro\n- CKA <!-- credential: cncf-cka -->\n';
+  assert.deepEqual(findCredentialReferences(markdown), [{
+    id: 'cncf-cka',
+    line: 2,
+    raw: '<!-- credential: cncf-cka -->',
+  }]);
 });

--- a/test/credential-registry.test.js
+++ b/test/credential-registry.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  validateCredentialRegistry,
+  loadCredentialRegistry,
+} = require('../credentialRegistry');
+
+const NOW = new Date('2026-08-08T00:00:00Z');
+
+function validRegistry() {
+  return {
+    schema_version: 1,
+    audited_roles: ['Roles/kubernetes/kubernetes_engineer.md'],
+    credentials: [{
+      id: 'cncf-cka',
+      name: 'Certified Kubernetes Administrator (CKA)',
+      issuer: 'Cloud Native Computing Foundation and The Linux Foundation',
+      type: 'certification',
+      url: 'https://www.cncf.io/training/certification/cka/',
+      status: 'active',
+      verified_on: '2026-08-08',
+      owner: 'catalogue-maintainers',
+      review_months: 12,
+    }],
+  };
+}
+
+test('a valid registry builds ID and audited-role indexes', () => {
+  const result = validateCredentialRegistry(validRegistry(), NOW);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.warnings, []);
+  assert.equal(result.credentialsById.get('cncf-cka').name,
+    'Certified Kubernetes Administrator (CKA)');
+  assert.ok(result.auditedRoles.has('Roles/kubernetes/kubernetes_engineer.md'));
+});
+
+test('duplicate credential IDs are errors', () => {
+  const registry = validRegistry();
+  registry.credentials.push({ ...registry.credentials[0] });
+  assert.ok(validateCredentialRegistry(registry, NOW).errors
+    .some(error => /duplicate.*cncf-cka/i.test(error)));
+});
+
+test('missing required credential fields are errors', () => {
+  const registry = validRegistry();
+  delete registry.credentials[0].issuer;
+  assert.ok(validateCredentialRegistry(registry, NOW).errors
+    .some(error => /issuer/i.test(error)));
+});
+
+test('credential names and issuers must be non-empty strings', () => {
+  const registry = validRegistry();
+  registry.credentials[0].name = 42;
+  assert.ok(validateCredentialRegistry(registry, NOW).errors
+    .some(error => /name.*string/i.test(error)));
+});
+
+for (const [field, value, pattern] of [
+  ['id', 'CKA', /id/i],
+  ['type', 'badge', /type/i],
+  ['url', 'http://example.com/cka', /https/i],
+  ['status', 'maybe', /status/i],
+  ['verified_on', '2026-02-30', /verified_on/i],
+  ['review_months', 0, /review_months/i],
+]) {
+  test(`invalid ${field} is an error`, () => {
+    const registry = validRegistry();
+    registry.credentials[0][field] = value;
+    assert.ok(validateCredentialRegistry(registry, NOW).errors.some(error => pattern.test(error)));
+  });
+}
+
+test('an entry becomes stale only after its review interval', () => {
+  const registry = validRegistry();
+  registry.credentials[0].verified_on = '2025-08-07';
+  const result = validateCredentialRegistry(registry, NOW);
+  assert.deepEqual(result.errors, []);
+  assert.ok(result.warnings.some(warning => /cncf-cka.*stale/i.test(warning)));
+});
+
+test('a review due on the reference date is not stale', () => {
+  const registry = validRegistry();
+  registry.credentials[0].verified_on = '2025-08-08';
+  assert.deepEqual(validateCredentialRegistry(registry, NOW).warnings, []);
+});
+
+test('malformed JSON is returned as a registry error', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-registry-'));
+  const file = path.join(dir, 'credentials.json');
+  fs.writeFileSync(file, '{ invalid json');
+  const result = loadCredentialRegistry(file, NOW);
+  assert.ok(result.errors.some(error => /parse/i.test(error)));
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/test/credential-registry.test.js
+++ b/test/credential-registry.test.js
@@ -151,3 +151,15 @@ test('credential references include their marker line and source text', () => {
     raw: '<!-- credential: cncf-cka -->',
   }]);
 });
+
+test('a credential marker without canonical spacing is an error', () => {
+  const markdown = '- CKA <!--credential:cncf-cka-->\n';
+  const result = validateRoleCredentialReferences(markdown, known, { requireComplete: false });
+  assert.ok(result.errors.some(error => /invalid credential marker/i.test(error)));
+});
+
+test('an uppercase credential ID is an error instead of an ignored marker', () => {
+  const markdown = '- CKA <!-- credential: CNCF-CKA -->\n';
+  const result = validateRoleCredentialReferences(markdown, known, { requireComplete: false });
+  assert.ok(result.errors.some(error => /invalid credential marker/i.test(error)));
+});

--- a/test/credential-registry.test.js
+++ b/test/credential-registry.test.js
@@ -163,3 +163,15 @@ test('an uppercase credential ID is an error instead of an ignored marker', () =
   const result = validateRoleCredentialReferences(markdown, known, { requireComplete: false });
   assert.ok(result.errors.some(error => /invalid credential marker/i.test(error)));
 });
+
+test('a credential comment without a colon is an error', () => {
+  const markdown = '- CKA <!-- credential cncf-cka -->\n';
+  const result = validateRoleCredentialReferences(markdown, known, { requireComplete: false });
+  assert.ok(result.errors.some(error => /invalid credential marker/i.test(error)));
+});
+
+test('a credential comment using an equals sign is an error', () => {
+  const markdown = '- CKA <!-- credential=cncf-cka -->\n';
+  const result = validateRoleCredentialReferences(markdown, known, { requireComplete: false });
+  assert.ok(result.errors.some(error => /invalid credential marker/i.test(error)));
+});

--- a/test/credential-registry.test.js
+++ b/test/credential-registry.test.js
@@ -92,6 +92,43 @@ test('a review due on the reference date is not stale', () => {
   assert.deepEqual(validateCredentialRegistry(registry, NOW).warnings, []);
 });
 
+test('a review is non-stale through its UTC due date and stale the next date', () => {
+  const registry = validRegistry();
+  registry.credentials[0].verified_on = '2025-08-08';
+  const dueDateWarnings = validateCredentialRegistry(
+    registry, new Date('2026-08-08T12:00:00Z'),
+  ).warnings;
+  const nextDateWarnings = validateCredentialRegistry(
+    registry, new Date('2026-08-09T00:00:00Z'),
+  ).warnings;
+  assert.deepEqual({
+    dueDateIsStale: dueDateWarnings.some(warning => /stale/i.test(warning)),
+    nextDateIsStale: nextDateWarnings.some(warning => /stale/i.test(warning)),
+  }, {
+    dueDateIsStale: false,
+    nextDateIsStale: true,
+  });
+});
+
+test('a month interval clamps an end-of-month due date to the destination month', () => {
+  const registry = validRegistry();
+  registry.credentials[0].verified_on = '2025-01-31';
+  registry.credentials[0].review_months = 1;
+  const dueDateWarnings = validateCredentialRegistry(
+    registry, new Date('2025-02-28T12:00:00Z'),
+  ).warnings;
+  const nextDateWarnings = validateCredentialRegistry(
+    registry, new Date('2025-03-01T00:00:00Z'),
+  ).warnings;
+  assert.deepEqual({
+    dueDateIsStale: dueDateWarnings.some(warning => /stale/i.test(warning)),
+    nextDateIsStale: nextDateWarnings.some(warning => /stale/i.test(warning)),
+  }, {
+    dueDateIsStale: false,
+    nextDateIsStale: true,
+  });
+});
+
 test('malformed JSON is returned as a registry error', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-registry-'));
   const file = path.join(dir, 'credentials.json');
@@ -135,6 +172,43 @@ test('audited recommendation bullets require exactly one marker', () => {
   const result = validateRoleCredentialReferences(markdown, known, { requireComplete: true });
   assert.ok(result.errors.some(error => /missing credential marker/i.test(error)));
   assert.equal(result.errors.filter(error => /Kubernetes documentation/.test(error)).length, 0);
+});
+
+test('the canonical ampersand learning heading ends audited recommendations', () => {
+  const markdown = `## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->
+
+**Learning Resources & Communities:**
+
+- Kubernetes documentation
+`;
+  assert.deepEqual(validateRoleCredentialReferences(markdown, known, { requireComplete: true }),
+    { errors: [], warnings: [] });
+});
+
+test('an unmarked star recommendation bullet fails audited completeness', () => {
+  const markdown = `## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
+* Certified Kubernetes Administrator (CKA)
+`;
+  assert.ok(validateRoleCredentialReferences(markdown, known, { requireComplete: true })
+    .errors.some(error => /missing credential marker/i.test(error)));
+});
+
+test('an unmarked plus recommendation bullet fails audited completeness', () => {
+  const markdown = `## Recommended Certifications & Learning Paths
+
+**Core Certifications:**
+
++ Certified Kubernetes Administrator (CKA)
+`;
+  assert.ok(validateRoleCredentialReferences(markdown, known, { requireComplete: true })
+    .errors.some(error => /missing credential marker/i.test(error)));
 });
 
 test('legacy unmarked recommendations remain allowed', () => {

--- a/test/kubernetes-credentials.test.js
+++ b/test/kubernetes-credentials.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { loadCredentialRegistry, validateRoleCredentialReferences } = require('../credentialRegistry');
+
+const ROOT = path.join(__dirname, '..');
+const REGISTRY = path.join(ROOT, 'data', 'credentials.json');
+const EXPECTED_ROLES = [
+  'Roles/kubernetes/kubernetes_architect.md',
+  'Roles/kubernetes/kubernetes_engineer.md',
+  'Roles/kubernetes/kubernetes_product_owner.md',
+  'Roles/kubernetes/kubernetes_senior_engineer.md',
+];
+
+test('the Kubernetes pilot contains exactly the four audited roles', () => {
+  const result = loadCredentialRegistry(REGISTRY, new Date('2026-08-08T00:00:00Z'));
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual([...result.auditedRoles].sort(), EXPECTED_ROLES);
+});
+
+test('every Kubernetes pilot recommendation references a known credential', () => {
+  const registry = loadCredentialRegistry(REGISTRY, new Date('2026-08-08T00:00:00Z'));
+  for (const relativePath of EXPECTED_ROLES) {
+    const markdown = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+    const result = validateRoleCredentialReferences(
+      markdown,
+      registry.credentialsById,
+      { requireComplete: true },
+    );
+    assert.deepEqual(result.errors, [], `${relativePath}: ${result.errors.join('; ')}`);
+  }
+});
+
+test('KCSP is not presented as an individual credential', () => {
+  for (const relativePath of EXPECTED_ROLES) {
+    const markdown = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+    assert.doesNotMatch(markdown, /Certified Kubernetes Service Provider|\bKCSP\b/i);
+  }
+});

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -75,6 +75,21 @@ test('a well-formed role file passes with 0 errors and 0 warnings', () => {
   assert.equal(r.skipped, false);
 });
 
+test('validateFile applies credential markers from an explicit registry context', () => {
+  const file = writeFixture('credential-context.md', completeRole({
+    transform: c => c.replace(
+      'Content for Recommended Certifications & Learning Paths.',
+      '- Imaginary Credential <!-- credential: invented-one -->'
+    ),
+  }));
+  const rel = path.relative(path.dirname(tmpRoot), file).replace(/\\/g, '/');
+  const result = validateFile(file, tmpRoot, {
+    credentialsById: new Map(),
+    auditedRoles: new Set([rel]),
+  });
+  assert.ok(result.errors.some(error => /unknown.*invented-one/i.test(error)));
+});
+
 // ── required sections ────────────────────────────────────
 
 test('each required section individually missing produces exactly that error', () => {
@@ -249,9 +264,9 @@ test('listRoleFiles finds .md files in domain folders and skips READMEs', () => 
 
 // ── CLI exit codes (spawned against a fixture tree) ─────
 
-function runCli(rolesDir, args = []) {
+function runCli(rolesDir, args = [], env = {}) {
   return spawnSync(process.execPath, [path.join(__dirname, '..', 'validate-roles.js'), ...args], {
-    env: { ...process.env, ROLES_DIR: rolesDir },
+    env: { ...process.env, ROLES_DIR: rolesDir, ...env },
     encoding: 'utf8',
   });
 }
@@ -283,6 +298,28 @@ test('CLI exits 1 when a file has errors', () => {
   const run = runCli(cliRoot);
   assert.equal(run.status, 1);
   assert.match(run.stdout, /Missing section: ## Business Impact/);
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+
+test('CLI exits 1 for an unknown credential marker from CREDENTIALS_FILE', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-credentials-'));
+  const credentialsFile = path.join(cliRoot, 'credentials.json');
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'unknown-marker.md'), completeRole({
+    transform: c => c.replace(
+      'Content for Recommended Certifications & Learning Paths.',
+      '- Imaginary Credential <!-- credential: invented-one -->'
+    ),
+  }));
+  fs.writeFileSync(credentialsFile, JSON.stringify({
+    schema_version: 1,
+    audited_roles: [],
+    credentials: [],
+  }));
+
+  const run = runCli(cliRoot, [], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(run.status, 1, run.stdout);
+  assert.match(run.stdout, /unknown credential reference.*invented-one/i);
   fs.rmSync(cliRoot, { recursive: true, force: true });
 });
 

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -10,11 +10,15 @@
 const fs   = require('fs');
 const path = require('path');
 const { parseMeta, KNOWN_LEVELS, normalizeLevel, REFERENCE_DOC_PATTERN, DOMAIN_LABELS } = require('./roleMeta');
+const { loadCredentialRegistry, validateRoleCredentialReferences } = require('./credentialRegistry');
 
 const ROOT       = __dirname;
 // ROLES_DIR env override exists for the test suite, which points the
 // validator at a fixture tree; normal runs always use Roles/.
 const ROLES_DIR  = process.env.ROLES_DIR ? path.resolve(process.env.ROLES_DIR) : path.join(ROOT, 'Roles');
+const CREDENTIALS_FILE = process.env.CREDENTIALS_FILE
+  ? path.resolve(process.env.CREDENTIALS_FILE)
+  : path.join(ROOT, 'data', 'credentials.json');
 const STRICT     = process.argv.includes('--strict');
 
 // Required section headings. Each entry accepts one or more historical
@@ -103,7 +107,7 @@ function listRoleFiles(rolesDir = ROLES_DIR) {
   return files.sort();
 }
 
-function validateFile(filePath, rolesDir = ROLES_DIR) {
+function validateFile(filePath, rolesDir = ROLES_DIR, credentialContext = null) {
   const rel     = path.relative(path.dirname(rolesDir), filePath).replace(/\\/g, '/');
   const content = fs.readFileSync(filePath, 'utf8');
   const meta    = parseMeta(content);
@@ -195,6 +199,16 @@ function validateFile(filePath, rolesDir = ROLES_DIR) {
     errors.push('Interactions table is missing the "Interaction Mode" column');
   }
 
+  if (credentialContext) {
+    const credentialResult = validateRoleCredentialReferences(
+      content,
+      credentialContext.credentialsById,
+      { requireComplete: credentialContext.auditedRoles.has(rel) },
+    );
+    errors.push(...credentialResult.errors);
+    warnings.push(...credentialResult.warnings);
+  }
+
   return { rel, errors, warnings, skipped: false };
 }
 
@@ -219,13 +233,20 @@ function findDuplicateTitles(rolesDir = ROLES_DIR) {
 }
 
 function main() {
+  const credentialContext = loadCredentialRegistry(CREDENTIALS_FILE);
   const files   = listRoleFiles();
-  const results = files.map(f => validateFile(f));
+  const results = files.map(f => validateFile(f, ROLES_DIR, credentialContext));
 
   const withErrors   = results.filter(r => r.errors.length > 0);
   const withWarnings = results.filter(r => r.warnings.length > 0);
   const skipped      = results.filter(r => r.skipped);
   const duplicates   = findDuplicateTitles();
+
+  if (credentialContext.errors.length > 0 || credentialContext.warnings.length > 0) {
+    console.log(`\n${CREDENTIALS_FILE}`);
+    for (const error of credentialContext.errors) console.log(`  ERROR: ${error}`);
+    for (const warning of credentialContext.warnings) console.log(`  warn:  ${warning}`);
+  }
 
   for (const r of withErrors) {
     console.log(`\n✖ ${r.rel}`);
@@ -249,7 +270,8 @@ function main() {
   console.log(`  ${duplicates.length} duplicate title(s)`);
   console.log('─'.repeat(60));
 
-  if (withErrors.length > 0 || duplicates.length > 0 || (STRICT && withWarnings.length > 0)) {
+  if (withErrors.length > 0 || credentialContext.errors.length > 0 || duplicates.length > 0 ||
+      (STRICT && (withWarnings.length > 0 || credentialContext.warnings.length > 0))) {
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary

- add a dependency-free credential registry with schema, lifecycle, ownership, source, and staleness validation;
- integrate exact credential markers into the role validator while leaving legacy domains visibly unaudited;
- audit all four Kubernetes roles against 13 issuer-controlled credentials and remove KCSP as an individual certification;
- document contributor governance and track the remaining-domain rollout in #210.

## Why

Credential recommendations were free text, so readers could not distinguish verified individual credentials from courses, vague provider tracks, retired names, or organisation programmes. This change establishes a source-backed trust boundary and proves it with a bounded Kubernetes pilot.

## Authoritative sources

- CNCF certification catalogue and individual CKA, CKAD, CKS, KCNA, PCA, ICA, CAPA, and CGOA pages
- HashiCorp Infrastructure Automation certification page
- Scrum.org PSPO I certification page
- FinOps Certified Practitioner page
- The Open Group TOGAF certification page
- Red Hat OpenShift administration certification page

Every registry record uses its issuer-controlled HTTPS page and was verified on `2026-08-08`.

## Removed or reclassified recommendations

- removed KCSP because it is a company/service-provider programme rather than an individual credential;
- removed generic, invented, or unsupported certification families instead of presenting them as authoritative;
- retained specific courses, documentation, communities, and publications only under learning resources.

## Verification

- `node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js` — 72 passed
- `npm test` — 272 passed
- `npm run validate` — 0 error files; no credential staleness or marker gaps
- `npm run check-counts` — 226 roles, 34 domains, 7 chapters; README matches
- `npm run verify-vendor` — passed
- `npx --yes markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#.superpowers/sdd"` — 275 files, 0 errors
- `git diff --check` — passed
- final whole-branch review and scoped re-review — no remaining Critical or Important findings

## Follow-up

- #210 tracks rollout across the remaining role domains with independent acceptance gates.
- #212 tracks the deferred malformed-registry and spawned-CLI hardening cases from final review.

Closes #178
