### PR TITLE
fix: harden credential registry validation

### DIFF
--- a/credentialRegistry.js
+++ b/credentialRegistry.js
@@ -46,13 +46,14 @@ function validateCredentialRegistry(value, now = new Date()) {
     return result;
   }
   if (value.schema_version !== 1) result.errors.push('schema_version must be 1');
+  const auditedRoles = Array.isArray(value.audited_roles) ? value.audited_roles : [];
   if (!Array.isArray(value.audited_roles)) result.errors.push('audited_roles must be an array');
   if (!Array.isArray(value.credentials)) {
     result.errors.push('credentials must be an array');
     return result;
   }
 
-  for (const role of value.audited_roles || []) {
+  for (const role of auditedRoles) {
     if (typeof role !== 'string' || !/^Roles\/[a-z0-9_/-]+\.md$/.test(role)) {
       result.errors.push(`Invalid audited role path: ${String(role)}`);
     } else if (result.auditedRoles.has(role)) {

--- a/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
@@ -1,0 +1,236 @@
+# Credential Registry Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make malformed credential-registry shapes fail safely and prove the registry CLI exit-code contract with spawned-process tests.
+
+**Architecture:** Keep `credentialRegistry.js` responsible for pure schema validation and index construction. Normalize a malformed `audited_roles` field to an empty iterable after recording its structured error, while allowing independent credential validation to continue. Exercise CLI behavior only through the existing `CREDENTIALS_FILE` environment override and `validate-roles.js` entry point.
+
+**Tech Stack:** Node.js CommonJS, built-in `node:test`, `node:assert/strict`, `node:child_process`, and filesystem-backed temporary fixtures.
+
+## Global Constraints
+
+- Do not change the credential registry schema, marker syntax, or CLI interface.
+- Preserve behavior for valid registries.
+- Return structured validation errors instead of throwing for malformed `audited_roles` values.
+- Continue validating the independent `credentials` array after an `audited_roles` type error.
+- Add no dependencies and perform no network access.
+- Do not run local Firefox or any browser test for this issue.
+
+---
+
+### Task 1: Make `audited_roles` validation non-throwing
+
+**Files:**
+- Modify: `credentialRegistry.js:43-63`
+- Test: `test/credential-registry.test.js`
+
+**Interfaces:**
+- Consumes: `validateCredentialRegistry(value, now = new Date())` and the existing `{ errors, warnings, credentialsById, auditedRoles }` result shape.
+- Produces: The same result shape, with an empty `auditedRoles` set and a structured error for every non-array `audited_roles` value; independent valid credentials remain indexed.
+
+- [ ] **Step 1: Write the failing malformed-shape test**
+
+Add after the valid-registry test in `test/credential-registry.test.js`:
+
+```js
+for (const [label, auditedRoles] of [
+  ['object', {}],
+  ['number', 42],
+  ['string', 'Roles/kubernetes/kubernetes_engineer.md'],
+  ['boolean', true],
+  ['null', null],
+]) {
+  test(`a ${label} audited_roles value returns a structured error`, () => {
+    const registry = validRegistry();
+    registry.audited_roles = auditedRoles;
+
+    let result;
+    assert.doesNotThrow(() => {
+      result = validateCredentialRegistry(registry, NOW);
+    });
+    assert.ok(result.errors.some(error => /audited_roles must be an array/i.test(error)));
+    assert.deepEqual([...result.auditedRoles], []);
+    assert.ok(result.credentialsById.has('cncf-cka'),
+      'independent credential validation should continue');
+  });
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm the original defect**
+
+Run: `node --test test/credential-registry.test.js`
+
+Expected: FAIL for at least the truthy non-iterable values because the current loop iterates `value.audited_roles || []`.
+
+- [ ] **Step 3: Normalize the collection after recording the error**
+
+In `validateCredentialRegistry()`, replace the direct check and loop source with:
+
+```js
+  const auditedRoles = Array.isArray(value.audited_roles) ? value.audited_roles : [];
+  if (!Array.isArray(value.audited_roles)) result.errors.push('audited_roles must be an array');
+```
+
+Then iterate the normalized local value:
+
+```js
+  for (const role of auditedRoles) {
+```
+
+Do not change the existing non-array `credentials` early return.
+
+- [ ] **Step 4: Run the focused credential-registry tests**
+
+Run: `node --test test/credential-registry.test.js`
+
+Expected: PASS; all malformed-shape cases return normally, report the structured error, keep `auditedRoles` empty, and still index the valid credential.
+
+- [ ] **Step 5: Commit the validator hardening**
+
+```bash
+git add credentialRegistry.js test/credential-registry.test.js
+git commit -m "fix: harden audited role validation"
+```
+
+---
+
+### Task 2: Prove registry CLI exit codes
+
+**Files:**
+- Test: `test/validate-roles.test.js`
+
+**Interfaces:**
+- Consumes: `runCli(rolesDir, args = [], env = {})`, the `CREDENTIALS_FILE` environment override, and the current normal/strict exit-code rules in `validate-roles.js`.
+- Produces: Spawned-process regression coverage for invalid-registry errors and stale-registry warnings without changing production CLI behavior.
+
+- [ ] **Step 1: Add an invalid-registry spawned CLI test**
+
+Add near the existing credential CLI test in `test/validate-roles.test.js`:
+
+```js
+test('CLI exits 1 and identifies an invalid credential registry', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-invalid-registry-'));
+  const credentialsFile = path.join(cliRoot, 'credentials.json');
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'),
+    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role') }));
+  fs.writeFileSync(credentialsFile, JSON.stringify({
+    schema_version: 1,
+    audited_roles: {},
+    credentials: [],
+  }));
+
+  const run = runCli(cliRoot, [], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(run.status, 1, run.stdout);
+  assert.match(run.stdout, /credentials\.json/i);
+  assert.match(run.stdout, /audited_roles must be an array/i);
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+```
+
+- [ ] **Step 2: Add normal and strict stale-registry CLI assertions**
+
+Add a second spawned-process test:
+
+```js
+test('CLI stale registry warnings exit 0 normally and 1 with --strict', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-stale-registry-'));
+  const credentialsFile = path.join(cliRoot, 'credentials.json');
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'),
+    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role') }));
+  fs.writeFileSync(credentialsFile, JSON.stringify({
+    schema_version: 1,
+    audited_roles: [],
+    credentials: [{
+      id: 'example-certification',
+      name: 'Example Certification',
+      issuer: 'Example Issuer',
+      type: 'certification',
+      url: 'https://example.com/certification',
+      status: 'active',
+      verified_on: '2020-01-01',
+      owner: 'catalogue-maintainers',
+      review_months: 12,
+    }],
+  }));
+
+  const normal = runCli(cliRoot, [], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(normal.status, 0, normal.stdout);
+  assert.match(normal.stdout, /example-certification.*stale/i);
+
+  const strict = runCli(cliRoot, ['--strict'], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(strict.status, 1, strict.stdout);
+  assert.match(strict.stdout, /example-certification.*stale/i);
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+```
+
+- [ ] **Step 3: Run the focused CLI tests**
+
+Run: `node --test test/validate-roles.test.js`
+
+Expected: PASS. The invalid registry exits 1 with its field error; the stale registry exits 0 normally and 1 with `--strict`.
+
+- [ ] **Step 4: Commit the CLI regression coverage**
+
+```bash
+git add test/validate-roles.test.js
+git commit -m "test: cover registry CLI exit codes"
+```
+
+---
+
+### Task 3: Verify issue #212 as a whole
+
+**Files:**
+- Modify only if execution evidence is recorded: `docs/superpowers/plans/2026-08-08-credential-registry-hardening.md`
+
+**Interfaces:**
+- Consumes: The completed validator and CLI tests from Tasks 1 and 2.
+- Produces: Reproducible local evidence for every code-level acceptance criterion in issue #212.
+
+- [ ] **Step 1: Run all focused registry and validator tests**
+
+Run:
+
+```bash
+node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js
+```
+
+Expected: exit 0 with no failed tests.
+
+- [ ] **Step 2: Run the full Node test suite**
+
+Run: `npm test`
+
+Expected: exit 0 with every test passing.
+
+- [ ] **Step 3: Run repository validation**
+
+Run: `npm run validate`
+
+Expected: exit 0 with zero files containing errors. Existing non-strict KPI warnings may remain and do not fail validation.
+
+- [ ] **Step 4: Check diff and worktree scope**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff main...HEAD -- credentialRegistry.js test/credential-registry.test.js test/validate-roles.test.js docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+```
+
+Expected: no whitespace errors; only issue #212 implementation, test, design, and plan files are included. The pre-existing untracked `.claude/settings.local.json` remains untouched and unstaged.
+
+- [ ] **Step 5: Record verification evidence and commit the completed plan**
+
+Append the actual command results under a `## Verification evidence` section,
+check only steps demonstrated by the recorded output, then commit:
+
+```bash
+git add docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+git commit -m "docs: record registry hardening evidence"
+```

--- a/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
@@ -191,7 +191,7 @@ git commit -m "test: cover registry CLI exit codes"
 - Consumes: The completed validator and CLI tests from Tasks 1 and 2.
 - Produces: Reproducible local evidence for every code-level acceptance criterion in issue #212.
 
-- [ ] **Step 1: Run all focused registry and validator tests**
+- [x] **Step 1: Run all focused registry and validator tests**
 
 Run:
 
@@ -201,19 +201,19 @@ node --test test/credential-registry.test.js test/kubernetes-credentials.test.js
 
 Expected: exit 0 with no failed tests.
 
-- [ ] **Step 2: Run the full Node test suite**
+- [x] **Step 2: Run the full Node test suite**
 
 Run: `npm test`
 
 Expected: exit 0 with every test passing.
 
-- [ ] **Step 3: Run repository validation**
+- [x] **Step 3: Run repository validation**
 
 Run: `npm run validate`
 
 Expected: exit 0 with zero files containing errors. Existing non-strict KPI warnings may remain and do not fail validation.
 
-- [ ] **Step 4: Check diff and worktree scope**
+- [x] **Step 4: Check diff and worktree scope**
 
 Run:
 
@@ -225,7 +225,7 @@ git diff main...HEAD -- credentialRegistry.js test/credential-registry.test.js t
 
 Expected: no whitespace errors; only issue #212 implementation, test, design, and plan files are included. The pre-existing untracked `.claude/settings.local.json` remains untouched and unstaged.
 
-- [ ] **Step 5: Record verification evidence and commit the completed plan**
+- [x] **Step 5: Record verification evidence and commit the completed plan**
 
 Append the actual command results under a `## Verification evidence` section,
 check only steps demonstrated by the recorded output, then commit:
@@ -234,3 +234,25 @@ check only steps demonstrated by the recorded output, then commit:
 git add docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
 git commit -m "docs: record registry hardening evidence"
 ```
+
+## Verification evidence
+
+Executed on 2026-08-08 in the isolated issue #212 worktree. No browser or
+Firefox check was run.
+
+1. `node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js`
+   exited `0`: `79` tests passed, `0` failed, `0` skipped, duration `867.8424 ms`.
+2. `npm test` exited `0`: `279` tests passed, `0` failed, `0` skipped, duration
+   `1758.3867 ms`.
+3. `npm run validate` exited `0`: checked `227` role files (`1` reference doc
+   skipped), with `0 file(s) with errors`, `199 file(s) with warnings`, and
+   `0 duplicate title(s)`. The warnings were non-strict KPI target/proposed-target
+   warnings.
+4. `git diff --check` exited `0` with no output (no whitespace errors).
+   `git status --short` exited `0` with no status entries; Git emitted only
+   permission warnings while reading the global ignore file. The scoped
+   `git diff main...HEAD -- credentialRegistry.js test/credential-registry.test.js
+   test/validate-roles.test.js docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md
+   docs/superpowers/plans/2026-08-08-credential-registry-hardening.md` exited
+   `0` and showed only the issue #212 validator, focused-test, design, and plan
+   changes.

--- a/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
@@ -22,10 +22,12 @@
 ### Task 1: Make `audited_roles` validation non-throwing
 
 **Files:**
+
 - Modify: `credentialRegistry.js:43-63`
 - Test: `test/credential-registry.test.js`
 
 **Interfaces:**
+
 - Consumes: `validateCredentialRegistry(value, now = new Date())` and the existing `{ errors, warnings, credentialsById, auditedRoles }` result shape.
 - Produces: The same result shape, with an empty `auditedRoles` set and a structured error for every non-array `audited_roles` value; independent valid credentials remain indexed.
 
@@ -98,9 +100,11 @@ git commit -m "fix: harden audited role validation"
 ### Task 2: Prove registry CLI exit codes
 
 **Files:**
+
 - Test: `test/validate-roles.test.js`
 
 **Interfaces:**
+
 - Consumes: `runCli(rolesDir, args = [], env = {})`, the `CREDENTIALS_FILE` environment override, and the current normal/strict exit-code rules in `validate-roles.js`.
 - Produces: Spawned-process regression coverage for invalid-registry errors and stale-registry warnings without changing production CLI behavior.
 
@@ -185,9 +189,11 @@ git commit -m "test: cover registry CLI exit codes"
 ### Task 3: Verify issue #212 as a whole
 
 **Files:**
+
 - Modify only if execution evidence is recorded: `docs/superpowers/plans/2026-08-08-credential-registry-hardening.md`
 
 **Interfaces:**
+
 - Consumes: The completed validator and CLI tests from Tasks 1 and 2.
 - Produces: Reproducible local evidence for every code-level acceptance criterion in issue #212.
 

--- a/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
@@ -255,4 +255,14 @@ Firefox check was run.
    test/validate-roles.test.js docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md
    docs/superpowers/plans/2026-08-08-credential-registry-hardening.md` exited
    `0` and showed only the issue #212 validator, focused-test, design, and plan
-   changes.
+   changes. Follow-up scope evidence: `git diff --name-only main...HEAD` exited
+   `0` and printed exactly `credentialRegistry.js`,
+   `docs/superpowers/plans/2026-08-08-credential-registry-hardening.md`,
+   `docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md`,
+   `test/credential-registry.test.js`, and `test/validate-roles.test.js`.
+   The primary checkout was confirmed on `main`; with a per-command
+   `safe.directory` override (required by sandbox ownership),
+   `git -C C:\\Claude\\Projects\\DOC-ITRoles status --short` exited `0` and
+   printed `?? .claude/settings.local.json` (in addition to two global-ignore
+   permission warnings). This proves that pre-existing file remains untracked
+   and unstaged in the primary checkout.

--- a/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
+++ b/docs/superpowers/plans/2026-08-08-credential-registry-hardening.md
@@ -29,7 +29,7 @@
 - Consumes: `validateCredentialRegistry(value, now = new Date())` and the existing `{ errors, warnings, credentialsById, auditedRoles }` result shape.
 - Produces: The same result shape, with an empty `auditedRoles` set and a structured error for every non-array `audited_roles` value; independent valid credentials remain indexed.
 
-- [ ] **Step 1: Write the failing malformed-shape test**
+- [x] **Step 1: Write the failing malformed-shape test**
 
 Add after the valid-registry test in `test/credential-registry.test.js`:
 
@@ -57,13 +57,13 @@ for (const [label, auditedRoles] of [
 }
 ```
 
-- [ ] **Step 2: Run the focused test and confirm the original defect**
+- [x] **Step 2: Run the focused test and confirm the original defect**
 
 Run: `node --test test/credential-registry.test.js`
 
 Expected: FAIL for at least the truthy non-iterable values because the current loop iterates `value.audited_roles || []`.
 
-- [ ] **Step 3: Normalize the collection after recording the error**
+- [x] **Step 3: Normalize the collection after recording the error**
 
 In `validateCredentialRegistry()`, replace the direct check and loop source with:
 
@@ -80,13 +80,13 @@ Then iterate the normalized local value:
 
 Do not change the existing non-array `credentials` early return.
 
-- [ ] **Step 4: Run the focused credential-registry tests**
+- [x] **Step 4: Run the focused credential-registry tests**
 
 Run: `node --test test/credential-registry.test.js`
 
 Expected: PASS; all malformed-shape cases return normally, report the structured error, keep `auditedRoles` empty, and still index the valid credential.
 
-- [ ] **Step 5: Commit the validator hardening**
+- [x] **Step 5: Commit the validator hardening**
 
 ```bash
 git add credentialRegistry.js test/credential-registry.test.js
@@ -104,7 +104,7 @@ git commit -m "fix: harden audited role validation"
 - Consumes: `runCli(rolesDir, args = [], env = {})`, the `CREDENTIALS_FILE` environment override, and the current normal/strict exit-code rules in `validate-roles.js`.
 - Produces: Spawned-process regression coverage for invalid-registry errors and stale-registry warnings without changing production CLI behavior.
 
-- [ ] **Step 1: Add an invalid-registry spawned CLI test**
+- [x] **Step 1: Add an invalid-registry spawned CLI test**
 
 Add near the existing credential CLI test in `test/validate-roles.test.js`:
 
@@ -129,7 +129,7 @@ test('CLI exits 1 and identifies an invalid credential registry', () => {
 });
 ```
 
-- [ ] **Step 2: Add normal and strict stale-registry CLI assertions**
+- [x] **Step 2: Add normal and strict stale-registry CLI assertions**
 
 Add a second spawned-process test:
 
@@ -167,13 +167,13 @@ test('CLI stale registry warnings exit 0 normally and 1 with --strict', () => {
 });
 ```
 
-- [ ] **Step 3: Run the focused CLI tests**
+- [x] **Step 3: Run the focused CLI tests**
 
 Run: `node --test test/validate-roles.test.js`
 
 Expected: PASS. The invalid registry exits 1 with its field error; the stale registry exits 0 normally and 1 with `--strict`.
 
-- [ ] **Step 4: Commit the CLI regression coverage**
+- [x] **Step 4: Commit the CLI regression coverage**
 
 ```bash
 git add test/validate-roles.test.js
@@ -260,9 +260,10 @@ Firefox check was run.
    `docs/superpowers/plans/2026-08-08-credential-registry-hardening.md`,
    `docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md`,
    `test/credential-registry.test.js`, and `test/validate-roles.test.js`.
-   The primary checkout was confirmed on `main`; with a per-command
-   `safe.directory` override (required by sandbox ownership),
-   `git -C C:\\Claude\\Projects\\DOC-ITRoles status --short` exited `0` and
+   The primary checkout was confirmed on `main`; the exact temporary
+   safe-directory status command,
+   `git -c safe.directory='C:/Claude/Projects/DOC-ITRoles' -C C:\\Claude\\Projects\\DOC-ITRoles status --short`,
+   exited `0` and
    printed `?? .claude/settings.local.json` (in addition to two global-ignore
    permission warnings). This proves that pre-existing file remains untracked
    and unstaged in the primary checkout.

--- a/docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-08-credential-registry-hardening-design.md
@@ -1,0 +1,59 @@
+# Credential Registry Hardening Design
+
+## Goal
+
+Make credential-registry validation fail safely for malformed `audited_roles`
+values and prove the registry-related CLI exit-code contract with spawned-process
+tests.
+
+## Scope
+
+This change is limited to issue #212. It hardens the existing registry validator
+and adds focused tests. It does not change the registry schema, marker syntax,
+CLI interface, or behavior for valid registries.
+
+## Validator behavior
+
+`validateCredentialRegistry()` will treat any non-array `audited_roles` value as
+invalid. It will add the existing structured error, `audited_roles must be an
+array`, and use an empty audited-role collection for subsequent processing.
+
+Validation will continue through the independent `credentials` array. This
+allows one invocation to report both the malformed top-level field and any
+credential-record problems. The returned `auditedRoles` value remains an empty
+`Set`, so callers cannot accidentally treat malformed input as an audited role.
+
+The existing early return for a non-array `credentials` value remains unchanged
+because credential-record iteration cannot continue without that collection.
+
+## CLI behavior
+
+The CLI continues to load a registry through `CREDENTIALS_FILE` and use the
+existing exit-code rules:
+
+- registry validation errors are printed with the registry path and exit 1;
+- stale-registry warnings are printed but exit 0 in normal mode;
+- stale-registry warnings exit 1 with `--strict`.
+
+No new command-line options or output formats are introduced.
+
+## Tests
+
+Direct validator tests will supply representative non-array values, including an
+object, number, string, boolean, and `null`. Each case must return normally with
+the structured `audited_roles` error and an empty audited-role set.
+
+Spawned CLI fixtures will prove:
+
+1. an invalid registry exits 1 and identifies the registry validation failure;
+2. a stale registry exits 0 normally and prints its warning;
+3. the same stale registry exits 1 under `--strict`.
+
+Verification will run the focused credential-registry and validator tests, the
+full Node test suite, and `npm run validate`.
+
+## Error handling and compatibility
+
+Malformed registry data remains a validation failure rather than throwing to the
+caller. Valid input produces the same indexes, warnings, and exit codes as
+before. The change adds no dependencies and performs no network access.

--- a/test/credential-registry.test.js
+++ b/test/credential-registry.test.js
@@ -42,6 +42,28 @@ test('a valid registry builds ID and audited-role indexes', () => {
   assert.ok(result.auditedRoles.has('Roles/kubernetes/kubernetes_engineer.md'));
 });
 
+for (const [label, auditedRoles] of [
+  ['object', {}],
+  ['number', 42],
+  ['string', 'Roles/kubernetes/kubernetes_engineer.md'],
+  ['boolean', true],
+  ['null', null],
+]) {
+  test(`a ${label} audited_roles value returns a structured error`, () => {
+    const registry = validRegistry();
+    registry.audited_roles = auditedRoles;
+
+    let result;
+    assert.doesNotThrow(() => {
+      result = validateCredentialRegistry(registry, NOW);
+    });
+    assert.ok(result.errors.some(error => /audited_roles must be an array/i.test(error)));
+    assert.deepEqual([...result.auditedRoles], []);
+    assert.ok(result.credentialsById.has('cncf-cka'),
+      'independent credential validation should continue');
+  });
+}
+
 test('duplicate credential IDs are errors', () => {
   const registry = validRegistry();
   registry.credentials.push({ ...registry.credentials[0] });

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -323,6 +323,57 @@ test('CLI exits 1 for an unknown credential marker from CREDENTIALS_FILE', () =>
   fs.rmSync(cliRoot, { recursive: true, force: true });
 });
 
+test('CLI exits 1 and identifies an invalid credential registry', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-invalid-registry-'));
+  const credentialsFile = path.join(cliRoot, 'credentials.json');
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'),
+    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role') }));
+  fs.writeFileSync(credentialsFile, JSON.stringify({
+    schema_version: 1,
+    audited_roles: {},
+    credentials: [],
+  }));
+
+  const run = runCli(cliRoot, [], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(run.status, 1, run.stdout);
+  assert.match(run.stdout, /credentials\.json/i);
+  assert.match(run.stdout, /audited_roles must be an array/i);
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+
+test('CLI stale registry warnings exit 0 normally and 1 with --strict', () => {
+  const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-stale-registry-'));
+  const credentialsFile = path.join(cliRoot, 'credentials.json');
+  fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'),
+    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role') }));
+  fs.writeFileSync(credentialsFile, JSON.stringify({
+    schema_version: 1,
+    audited_roles: [],
+    credentials: [{
+      id: 'example-certification',
+      name: 'Example Certification',
+      issuer: 'Example Issuer',
+      type: 'certification',
+      url: 'https://example.com/certification',
+      status: 'active',
+      verified_on: '2020-01-01',
+      owner: 'catalogue-maintainers',
+      review_months: 12,
+    }],
+  }));
+
+  const normal = runCli(cliRoot, [], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(normal.status, 0, normal.stdout);
+  assert.match(normal.stdout, /example-certification.*stale/i);
+
+  const strict = runCli(cliRoot, ['--strict'], { CREDENTIALS_FILE: credentialsFile });
+  assert.equal(strict.status, 1, strict.stdout);
+  assert.match(strict.stdout, /example-certification.*stale/i);
+  fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+
 // ── findDuplicateTitles (#67) ────────────────────────────
 // Isolated temp trees (not the shared tmpRoot, which accumulates many
 // "Test Role" H1s across the other tests).


### PR DESCRIPTION
Closes #212

## Summary

- normalize malformed non-array `audited_roles` values to an empty iterable after recording a structured registry error
- continue validating independent credential records instead of throwing
- add spawned CLI fixtures for invalid registries and stale-warning normal/strict exit codes
- commit the approved design, implementation plan, and verification evidence

## Verification

- `node --test test/credential-registry.test.js test/kubernetes-credentials.test.js test/validate-roles.test.js` — 79 passed, 0 failed
- `npm test` — 279 passed, 0 failed
- `npm run validate` — exit 0; 0 errors, 199 pre-existing non-strict KPI warnings, 0 duplicate titles
- final whole-branch review — ready to merge; no Critical, Important, or remaining Minor findings

## Scope

- no credential schema, marker syntax, CLI interface, dependencies, or browser behavior changed
- no local browser or Firefox checks were run because this issue is Node-only
