### PR TITLE
release: 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-08-08
+
+### Added
+
+- **Authoritative credential registry and rollout guardrails (#211).** Adds a
+  Kubernetes pilot, marker validation, stale-review warnings, and rollout
+  documentation.
+- **Spawned validator CLI regression coverage (#213).** Proves invalid
+  registries exit 1 with the registry error, while stale-registry warnings exit
+  0 normally and exit 1 under `--strict`.
+
+### Changed
+
+- **Vendored dependency integrity and governance are traceable (#209).**
+  `npm run verify-vendor` enforces checksum/manifest verification, alongside
+  recorded checksum and licence provenance, contribution evidence, and ADR
+  governance.
+
+### Fixed
+
+- **Dark-theme contrast now meets the viewer accessibility gate (#208).**
+- **Malformed `audited_roles` input is handled safely (#213).**
+
 ## [1.15.0] - 2026-08-07
 
 The catalogue becomes easier to explore and safer to change. This release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roles-master",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roles-master",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@axe-core/playwright": "4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
Refs #214

## Summary

- bump package and lockfile versions from 1.15.0 to 1.16.0
- add the dated v1.16.0 changelog section
- document the dark-theme, repository-governance, credential-registry, and registry-hardening changes shipped since v1.15.0

## Release contents

- #208 — dark-theme contrast improvements
- #209 — enforced vendored dependency integrity and evidence-focused governance
- #211 — authoritative credential registry and Kubernetes pilot
- #213 — malformed-registry safety and validator CLI regression coverage

## Verification

- `npm test` — 279 passed, 0 failed
- `npm run validate` — exit 0; 0 errors, 199 pre-existing non-strict KPI warnings, 0 duplicate titles
- `git diff --check` — clean
- independent release-diff review — approved after two changelog accuracy corrections

## Publication

Issue #214 intentionally remains open after this PR merges. It will close only after the annotated `v1.16.0` tag and GitHub release are published and verified.
