### PR TITLE
docs: document GitHub practice skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.log
 node_modules/
 
+# Local isolated implementation worktrees
+.worktrees/
+
 # Local Claude Code session artifacts, not project content
 .claude/scheduled_tasks.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Versioned GitHub workflow guidance (#216).** DOC-ITRoles now documents its
+  repository-specific adoption of the public
+  [`DOC-GitHub-Practice-Skills` v0.1.0 release](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/releases/tag/v0.1.0),
+  including issue, acceptance, merge, release, browser-CI, and security-routing
+  conventions.
+
 ## [1.16.0] - 2026-08-08
 
 ### Added

--- a/docs/GITHUB_WORKFLOW_SKILLS.md
+++ b/docs/GITHUB_WORKFLOW_SKILLS.md
@@ -1,0 +1,101 @@
+# GitHub workflow skills
+
+DOC-ITRoles adopts version
+[`v0.1.0`](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/releases/tag/v0.1.0)
+of the public
+[`DOC-GitHub-Practice-Skills`](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills)
+repository. Reusable policy is maintained and released there; this document
+records only the conventions specific to DOC-ITRoles.
+
+## Adopted skills
+
+The release contains eight complementary skills:
+
+- `github-repo-bootstrap` creates a repository through an issue-tracked,
+  verified bootstrap sequence.
+- `github-issue-first` turns actionable findings into owned, scoped issues
+  before implementation.
+- `github-hygiene` governs acceptance gates, merges, milestones, releases, and
+  cleanup.
+- `github-pr-review` provides evidence-based pull-request review.
+- `github-repo-review` audits a repository and converts accepted findings into
+  a traceable backlog.
+- `github-projects` adds a shared Projects board only when collaboration needs
+  one.
+- `github-security-response` keeps sensitive findings out of public issues and
+  coordinates safe remediation.
+- `github-for-ado-users` maps Azure DevOps concepts to GitHub without pretending
+  the two products have identical work-tracking models.
+
+Canonical instructions are in the
+[workflow guide](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/blob/v0.1.0/docs/GUIDE.md).
+Installation is handled by the
+[safe PowerShell installer](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/blob/v0.1.0/scripts/install-skills.ps1),
+with separate guidance for
+[OpenAI Codex](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/blob/v0.1.0/docs/openai-codex.md),
+[Claude](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/blob/v0.1.0/docs/claude.md),
+and
+[Azure DevOps migration](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/blob/v0.1.0/docs/azure-devops-migration.md).
+Installed copies are deployment outputs; policy changes originate in the
+canonical repository and arrive through a reviewed release.
+
+## DOC-ITRoles conventions
+
+### Issues and milestones
+
+- File actionable work before changing the repository. Assign it, add exactly
+  one priority label (`P0` through `P3`), add relevant category labels, and
+  attach it to an existing thematic milestone.
+- The active milestone model separates foundation work in **Catalogue Trust &
+  Adoption** from later product discovery in **Adoption & Discovery**. GitHub
+  Issues remain the source of truth; review documents are traceability indexes,
+  not parallel backlogs.
+- Create work branches with `gh issue develop` so GitHub records the issue
+  relationship. Use one focused branch and pull request per issue or bounded
+  sub-issue.
+- Large work uses native sub-issues plus a readable checklist in the parent.
+  After each child merges, update both the native relationship and parent
+  checklist. Reconcile parent epic #193 whenever a listed child changes state.
+
+### Acceptance and merge gates
+
+- Acceptance criteria are evidence gates. Evaluate every criterion against a
+  diff, test, hosted check, document, or reproducible result before checking it.
+  Green CI alone does not prove criteria it does not exercise.
+- Start pull requests with `Refs #N`. A connected development branch may still
+  close its issue when merged, so immediately audit the issue state and body
+  after every merge and reopen it if any in-scope criterion remains unchecked,
+  unmet, or unevaluated.
+- Use `Closes #N` only after every in-scope criterion is evidenced and checked.
+  Scope removal or deferral needs a recorded decision and linked follow-up; it
+  must not be presented as delivered.
+- DOC-ITRoles retains merge commits. Every required check must be green, and
+  merging requires explicit maintainer approval. Release approval is a separate
+  explicit gate.
+
+### Validation and releases
+
+- Run the relevant focused checks plus `npm test`, `npm run validate`, Markdown
+  lint for changed Markdown, and `git diff --check` before requesting review.
+- Hosted browser CI is authoritative when a local browser cannot be simulated
+  reliably. Record the hosted run as evidence instead of repeatedly retrying a
+  failing local browser environment.
+- Release from updated `main` through a dedicated release branch and pull
+  request. Update the version and `CHANGELOG.md`, wait for all checks, obtain
+  merge approval, then tag the exact merged commit only after explicit release
+  approval. Verify the published release before closing its milestone.
+- Apply release-note category labels to pull requests, not only their issues.
+
+### Security boundary
+
+Suspected credentials, vulnerabilities, or exploitable details do not belong in
+a public issue, branch, commit, or pull request. Stop public handling and use the
+repository's private vulnerability-reporting path and `github-security-response`.
+Public tracking begins only when coordinated disclosure makes it safe.
+
+## Updating the adoption
+
+When adopting a later skills release, review its changelog and migration notes,
+test staged Codex and Claude installations, update the pinned version and links
+in this document, and ship that change through the ordinary DOC-ITRoles issue
+and pull-request workflow.

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -466,17 +466,17 @@ git commit -m "feat: add safe skill installer"
 - Consumes: eight validated skills and installer interface.
 - Produces: complete public documentation, intake templates, CI, dependency updates, release notes, security policy, and release automation.
 
-- [ ] **Step 1: Write the layered guide**
+- [x] **Step 1: Write the layered guide**
 
 `docs/GUIDE.md` covers all eight triggers, responsibilities, boundaries, outputs, and handoffs. Start with the issue → linked branch → `Refs` → criterion evidence → `Closes` → epic/milestone → release chain. Include ordinary change, repository review, PR review, security, multi-maintainer, release, and new-repository examples. Label current policy separately from improvements and record version/review date.
 
 `docs/WORKFLOW.md` expands the lifecycle. `docs/MAINTAINING.md` defines the cross-skill invariant review, parent-epic reconciliation, issue-versus-PR number verification, and compatibility recording.
 
-- [ ] **Step 2: Write platform tracks**
+- [x] **Step 2: Write platform tracks**
 
 Create OpenAI Codex and Claude guides that link to the same skill directories, document discovery/restart behavior, and show `-DryRun` before installation. Create neutral ADO mappings for work items, types, iterations, milestones, Projects, repos, pipelines, Test Plans, and Wiki; state that workplace templates belong in a future private companion.
 
-- [ ] **Step 3: Write root policies**
+- [x] **Step 3: Write root policies**
 
 README: purpose, eight skills, quick install, docs, compatibility, licence, security, release status. CONTRIBUTING: issue-first, conventional commits, linked branches, evidence gates, focused PRs, tests, and no workplace content. SECURITY: current release, private vulnerability reporting, no public disclosure, no fictitious guarantees.
 
@@ -496,15 +496,15 @@ Start `CHANGELOG.md` with:
 - General Azure DevOps-to-GitHub migration guidance.
 ```
 
-- [ ] **Step 4: Add issue forms and PR template**
+- [x] **Step 4: Add issue forms and PR template**
 
 Bug and improvement forms require evidence, scope, acceptance criteria, affected skills, and public-content confirmation. Disable blank issues and route security reports to SECURITY.md. PR template begins `Refs #N`, asks for criterion evidence and validation, and never defaults to `Closes #N`.
 
-- [ ] **Step 5: Add dependency and release-note configuration**
+- [x] **Step 5: Add dependency and release-note configuration**
 
 Dependabot checks npm and GitHub Actions weekly, grouped, assigned to `JeanKadang`, with Task 2 labels. Release notes categorize Security, Features, Fixes, Documentation, Tooling & CI, Maintenance, and Other; exclude `ignore-for-release`; keep `"*"` last.
 
-- [ ] **Step 6: Add pinned CI**
+- [x] **Step 6: Add pinned CI**
 
 `validate.yml` uses `permissions: contents: read` and stable job names:
 
@@ -515,7 +515,7 @@ Dependabot checks npm and GitHub Actions weekly, grouped, assigned to `JeanKadan
 
 Use pinned `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` and `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`. Node jobs use `npm ci`; Windows runs installer tests and direct dry-run against temporary homes.
 
-- [ ] **Step 7: Add tag release workflow**
+- [x] **Step 7: Add tag release workflow**
 
 Trigger `v*`; use `permissions: contents: write`; checkout tag; run `npm ci` and `npm run check`; require package and inventory versions to equal the tag without `v`; then run this release step with `shell: pwsh`:
 
@@ -526,7 +526,7 @@ gh release create $env:GITHUB_REF_NAME `
 
 Expose `${{ github.token }}` only as `GH_TOKEN` for that step. Use no third-party release action.
 
-- [ ] **Step 8: Verify and commit Task 5**
+- [x] **Step 8: Verify and commit Task 5**
 
 Run `npm run check`, the public-content regex from Task 2 across the repo excluding `node_modules` and lockfile, and `git diff --check`. Review any generic documentation match manually.
 

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -399,13 +399,13 @@ git commit -m "feat: add canonical skill inventory"
 - Consumes: inventory and validated `skills/` tree.
 - Produces: `install-skills.ps1 -Target Codex|Claude|Both -SourceRoot <path> -CodexHome <path> -ClaudeHome <path> -DryRun -Force`.
 
-- [ ] **Step 1: Write failing installer tests**
+- [x] **Step 1: Write failing installer tests**
 
 Spawn `pwsh -NoProfile -File scripts/install-skills.ps1` with temporary homes. Test that dry-run changes nothing, both targets receive eight skills, corresponding `SKILL.md` hashes match, an untracked existing skill is refused without `-Force`, and `-Force` backs up a modified tracked skill before replacement.
 
 Run the focused test and confirm failure because the installer is absent.
 
-- [ ] **Step 2: Implement parameters and discovery**
+- [x] **Step 2: Implement parameters and discovery**
 
 ```powershell
 [CmdletBinding()]
@@ -430,13 +430,13 @@ if (-not $ClaudeHome) {
 
 Do not declare or repurpose `$HOME`, `$home`, or `$CODEX_HOME`.
 
-- [ ] **Step 3: Implement staging and overwrite safety**
+- [x] **Step 3: Implement staging and overwrite safety**
 
 Validate `SourceRoot` before destination writes. Load the inventory, compute SHA-256 for required files, and stage under a GUID directory inside each target parent. `-DryRun` prints source, target, eight skills, overwrite decisions, and backup paths without creating anything.
 
 Write `.doc-github-practice-skills.json` with release and file hashes. If an existing skill has no matching marker or current hashes differ, exit one unless `-Force`. With `-Force`, back up to `<platform-home>/skill-backups/<UTC timestamp>/<skill-name>/`. Move staged directories only after every check succeeds.
 
-- [ ] **Step 4: Run installer red-green verification**
+- [x] **Step 4: Run installer red-green verification**
 
 ```powershell
 npm test
@@ -445,7 +445,7 @@ npm run check
 
 Expected: staged Codex and Claude hashes match for all eight skills; overwrite and backup tests pass.
 
-- [ ] **Step 5: Commit Task 4**
+- [x] **Step 5: Commit Task 4**
 
 ```powershell
 git add scripts/install-skills.ps1 tests/install-skills.test.mjs package.json package-lock.json

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -675,7 +675,7 @@ git diff --check
 
 Expected: zero lint issues, at least 279 Node tests pass, role validation zero errors, clean diff.
 
-- [ ] **Step 4: Open the DOC-ITRoles PR**
+- [x] **Step 4: Open the DOC-ITRoles PR**
 
 From `docs/216-github-skills-guide`, open a ready PR titled `docs: document GitHub practice skills` with `Refs #216`, release evidence, local validation, and scope-decision history.
 

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -679,7 +679,7 @@ Expected: zero lint issues, at least 279 Node tests pass, role validation zero e
 
 From `docs/216-github-skills-guide`, open a ready PR titled `docs: document GitHub practice skills` with `Refs #216`, release evidence, local validation, and scope-decision history.
 
-- [ ] **Step 5: Reconcile all ten #216 criteria**
+- [x] **Step 5: Reconcile all ten #216 criteria**
 
 Map criteria to design, public repo, eight packages, bootstrap evidence, docs, CI, installer tests, release, integration guide, content scan, and both validations. Only when all are `Met`, change PR to `Closes #216` and check every box with a newline-preserving body file.
 

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -598,7 +598,7 @@ After merge, create an active `~DEFAULT_BRANCH` ruleset with deletion and non-fa
 - Consumes: updated `main`, green validation, matching `0.1.0` versions, changelog, approved release.
 - Produces: annotated tag, latest release, completed issue #1, closed milestone, clean branches.
 
-- [ ] **Step 1: Verify fresh `main`**
+- [x] **Step 1: Verify fresh `main`**
 
 ```powershell
 git checkout main
@@ -611,7 +611,7 @@ git diff --check
 
 Expected: all checks pass, versions match, tree clean.
 
-- [ ] **Step 2: Preview release notes**
+- [x] **Step 2: Preview release notes**
 
 ```powershell
 gh api repos/JeanKadang/DOC-GitHub-Practice-Skills/releases/generate-notes `

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -550,15 +550,15 @@ git commit -m "docs: add skill workflow guidance"
 - Consumes: complete bootstrap branch with green local validation.
 - Produces: configured repository, green PR, evidence-backed issue state, and approved merge commit.
 
-- [ ] **Step 1: Push and open the PR**
+- [x] **Step 1: Push and open the PR**
 
 Push `bootstrap/1-initial-release`. Open a ready PR titled `feat: bootstrap GitHub practice skills` with `Refs #1`, exact commits, inventory, validation, settings still to verify, and public-content scan result.
 
-- [ ] **Step 2: Enable and verify security settings**
+- [x] **Step 2: Enable and verify security settings**
 
 Enable private vulnerability reporting. Query `security_and_analysis`; enable secret scanning and push protection where the public repository reports them available. Record an unavailable API/plan control as a constraint, not a fabricated defect.
 
-- [ ] **Step 3: Audit actual settings**
+- [x] **Step 3: Audit actual settings**
 
 ```powershell
 gh repo view JeanKadang/DOC-GitHub-Practice-Skills `
@@ -569,19 +569,19 @@ gh api repos/JeanKadang/DOC-GitHub-Practice-Skills --jq .security_and_analysis
 
 Expected: public/main, delete true, merge commit true, squash/rebase false, issues true, Projects/Wiki false, default Actions read, available security controls enabled.
 
-- [ ] **Step 4: Wait for every PR check**
+- [x] **Step 4: Wait for every PR check**
 
 Resolve the PR number from the branch, then run `gh pr checks <N> --watch`. All four stable CI jobs must be green. Diagnose failures before any rerun.
 
-- [ ] **Step 5: Review issue criteria and PR scope**
+- [x] **Step 5: Review issue criteria and PR scope**
 
 Use `github-pr-review` to map each non-release criterion to diff, tests, CI, docs, or settings. Keep the release criterion unchecked and keep `Refs #1`, because `v0.1.0` does not exist yet.
 
-- [ ] **Step 6: Request explicit merge approval**
+- [x] **Step 6: Request explicit merge approval**
 
 Present PR URL, criterion table, CI matrix, settings audit, content scan, and the remaining release criterion. Merge only after approval, with a merge commit.
 
-- [ ] **Step 7: Create the main ruleset after CI names exist**
+- [x] **Step 7: Create the main ruleset after CI names exist**
 
 After merge, create an active `~DEFAULT_BRANCH` ruleset with deletion and non-fast-forward protection, pull requests required with zero approvals for the solo maintainer, and strict required checks using the four exact Task 5 job names. Verify with `gh ruleset check main` and the API. Record why the first PR preceded the ruleset.
 

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -1,0 +1,690 @@
+# GitHub Practice Skills Repository Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create and release the public `JeanKadang/DOC-GitHub-Practice-Skills` repository as the canonical home of eight GitHub workflow skills, then pin DOC-ITRoles to its verified `v0.1.0` release.
+
+**Architecture:** Eight canonical skill directories feed both OpenAI Codex and Claude installations; platform directories contain adapter documentation only. A manifest-driven Node validator checks package structure and metadata, while a PowerShell installer stages and verifies copies without silently overwriting local changes. The new `github-repo-bootstrap` skill governs creation of its own repository, and DOC-ITRoles retains only a version-pinned integration guide.
+
+**Tech Stack:** GitHub CLI 2.97.0, Git 2.55.0, Node.js 20/22 in CI, Node.js built-in test runner, `yaml`, `markdownlint-cli2`, PowerShell 7.6, GitHub Actions, Markdown, YAML, JSON.
+
+## Global Constraints
+
+- Repository: public `JeanKadang/DOC-GitHub-Practice-Skills`, MIT licence, `main` default branch.
+- Initial release: `v0.1.0`; do not claim `v1.0.0` until installation is proven outside the source checkout.
+- Canonical inventory: the seven existing `github-*` skills plus `github-repo-bootstrap`, exactly eight packages.
+- One canonical `SKILL.md` per skill; Claude and OpenAI Codex never carry separate policy copies.
+- OpenAI metadata lives at `skills/<name>/agents/openai.yaml`; Claude ignores that additional file.
+- Documentation lives in the repository; GitHub Wiki stays disabled.
+- The ADO track contains general migration guidance only. No workplace names, URLs, fields, screenshots, templates, or policies may enter the public repository.
+- Windows PowerShell is the verified installer platform for `v0.1.0`; other installers remain out of scope.
+- Existing installed skills remain untouched until staged installation tests pass.
+- Installed copies are deployment outputs; changes originate in the public repository and ship through releases.
+- Issue #216 remains open until both repositories satisfy every criterion with evidence.
+- Merge and release actions require explicit maintainer approval and every applicable CI check green.
+- Preserve `.claude/settings.local.json` in DOC-ITRoles; never stage or modify it.
+
+## File Map
+
+### DOC-ITRoles
+
+- Existing: `docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md`
+- Create: `docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md`
+- Create after release: `docs/GITHUB_WORKFLOW_SKILLS.md`
+- Modify after release: `CHANGELOG.md`
+
+### Temporary Bootstrap Staging
+
+- Create: `.superpowers/sdd/doc-github-practice-skills-bootstrap/skills/github-repo-bootstrap/SKILL.md`
+- Create: `.superpowers/sdd/doc-github-practice-skills-bootstrap/skills/github-repo-bootstrap/agents/openai.yaml`
+- Delete after the canonical copy is verified in the new repository.
+
+### DOC-GitHub-Practice-Skills
+
+- Create: `.github/ISSUE_TEMPLATE/{bug.yml,improvement.yml,config.yml}`
+- Create: `.github/{PULL_REQUEST_TEMPLATE.md,dependabot.yml,release.yml}`
+- Create: `.github/workflows/{validate.yml,release.yml}`
+- Create: `contracts/skill-inventory.json`
+- Create: `docs/{GUIDE.md,WORKFLOW.md,MAINTAINING.md,openai-codex.md,claude.md,azure-devops-migration.md}`
+- Create: `platforms/{openai-codex,claude,azure-devops}/README.md`
+- Create: `scripts/{validate-skills.mjs,install-skills.ps1}`
+- Create: `tests/{validate-skills.test.mjs,install-skills.test.mjs}`
+- Create: `skills/github-repo-bootstrap/{SKILL.md,agents/openai.yaml}`
+- Copy: seven existing skill directories from `C:\Users\Jean\.codex\skills`
+- Create: `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `package.json`, `package-lock.json`
+- Modify generated: `README.md`, `LICENSE`
+
+---
+
+### Task 1: Draft and Validate `github-repo-bootstrap`
+
+**Files:**
+
+- Create: `.superpowers/sdd/doc-github-practice-skills-bootstrap/skills/github-repo-bootstrap/SKILL.md`
+- Create: `.superpowers/sdd/doc-github-practice-skills-bootstrap/skills/github-repo-bootstrap/agents/openai.yaml`
+
+**Interfaces:**
+
+- Consumes: the approved design's “New-repository bootstrap skill” section.
+- Produces: a complete draft package accepted by the local skill validator and ready to govern Task 2.
+
+- [ ] **Step 1: Read both required skill-authoring instructions**
+
+```powershell
+Get-Content C:\Users\Jean\.codex\skills\.system\skill-creator\SKILL.md -Raw
+Get-Content C:\Users\Jean\.codex\plugins\cache\claude-plugins-official\superpowers\6.2.0\skills\writing-skills\SKILL.md -Raw
+```
+
+Expected: both files are read completely before drafting.
+
+- [ ] **Step 2: Write the bootstrap skill contract**
+
+Use this frontmatter and introduction:
+
+```markdown
+---
+name: github-repo-bootstrap
+description: Use before creating a GitHub repository or completing the initial setup of a newly created repository. Governs public-content preflight, the minimum-shell issue-first exception, bootstrap issue and branch creation, conditional community files, repository and security settings, CI-aware rulesets, initial release readiness, and post-creation verification.
+---
+
+# GitHub repository bootstrap
+
+Create the smallest safe repository shell, cross the issue-first boundary
+immediately, and prove the resulting GitHub settings match the approved design.
+Do not treat repository creation as permission to publish unreviewed local files.
+```
+
+Implement these sections in order:
+
+1. Required decisions before external state.
+2. Public-content and history preflight.
+3. The minimum-shell exception.
+4. Bootstrap issue and linked branch.
+5. Conditional scaffolding matrix.
+6. Repository and Actions settings.
+7. Security settings.
+8. CI first, ruleset second.
+9. Initial pull request and release.
+10. Post-bootstrap API audit.
+11. Handoffs to companion skills.
+12. Common mistakes.
+
+The minimum-shell exception allows only README, licence, default branch, and repository metadata before the first issue. Require the first issue and issue-linked branch immediately afterward. Explicitly forbid Wiki enablement, workplace content, an unmaintained Projects board, CODEOWNERS for a solo maintainer, and rules requiring self-approval.
+
+- [ ] **Step 3: Add OpenAI metadata**
+
+```yaml
+interface:
+  display_name: "GitHub Repository Bootstrap"
+  short_description: "Create and verify a new GitHub repository safely"
+  default_prompt: "Use $github-repo-bootstrap to create or finish bootstrapping this GitHub repository by the approved workflow."
+```
+
+- [ ] **Step 4: Validate the draft package**
+
+Run `quick_validate.py` from the installed `skill-creator` against the staged skill directory. If Python is absent from `PATH`, use the runtime returned by `codex_app__load_workspace_dependencies`.
+
+Expected: zero frontmatter, naming, or metadata errors.
+
+- [ ] **Step 5: Review all bootstrap gates**
+
+Create a criterion table covering the 12 sections, public/private boundary, conditional scaffolding, plan-gated rulesets, solo-maintainer behavior, release handoff, and actual-settings verification. Every row must be `Met` before Task 2. No commit occurs because this is temporary pre-repository staging.
+
+---
+
+### Task 2: Create the Minimum Public Shell
+
+**Files:**
+
+- Create remotely: `JeanKadang/DOC-GitHub-Practice-Skills`
+- Clone to: `C:\Claude\Projects\DOC-GitHub-Practice-Skills`
+- Generated: `README.md`, `LICENSE`
+- Create through GitHub: labels, milestone `v0.1.0`, bootstrap issue, linked branch.
+
+**Interfaces:**
+
+- Consumes: the validated Task 1 bootstrap skill.
+- Produces: a minimal public repository and linked `bootstrap/1-initial-release` branch.
+
+- [ ] **Step 1: Verify authentication and name availability**
+
+```powershell
+gh auth status
+gh repo view JeanKadang/DOC-GitHub-Practice-Skills
+```
+
+Expected: authentication succeeds and the repository is not found. Stop and inspect if it already exists.
+
+- [ ] **Step 2: Scan the staged public content**
+
+```powershell
+rg -n -i "dev\.azure\.com|visualstudio\.com|password\s*[:=]|client[_-]?secret|api[_-]?key|BEGIN (RSA|OPENSSH|EC) PRIVATE KEY" `
+  .superpowers/sdd/doc-github-practice-skills-bootstrap
+```
+
+Expected: no matches. Confirm DOC-ITRoles history and `.claude/settings.local.json` will not be copied.
+
+- [ ] **Step 3: Create and clone only the minimum shell**
+
+From `C:\Claude\Projects` run:
+
+```powershell
+gh repo create JeanKadang/DOC-GitHub-Practice-Skills `
+  --public --add-readme --license mit `
+  --description "Versioned GitHub workflow skills for OpenAI Codex, Claude, and ADO-to-GitHub migration" `
+  --clone
+```
+
+Expected: public repository with README, MIT licence, and `main`; no DOC-ITRoles files or history.
+
+- [ ] **Step 4: Configure minimum repository behavior**
+
+```powershell
+gh repo edit JeanKadang/DOC-GitHub-Practice-Skills `
+  --enable-issues=true --enable-projects=false --enable-wiki=false --enable-discussions=false `
+  --delete-branch-on-merge --enable-merge-commit `
+  --enable-squash-merge=false --enable-rebase-merge=false `
+  --add-topic github --add-topic github-actions --add-topic codex `
+  --add-topic claude --add-topic skills --add-topic azure-devops
+
+gh api -X PUT repos/JeanKadang/DOC-GitHub-Practice-Skills/actions/permissions/workflow `
+  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
+```
+
+Expected: issues on; Projects, Wiki, Discussions off; merge commits only; branches auto-delete; Actions token read-only.
+
+- [ ] **Step 5: Create labels and milestone**
+
+Create or reconcile: `P0`, `P1`, `P2`, `P3`, `bug`, `documentation`, `enhancement`, `process`, `tooling`, `security`, `maintenance`, `developer-experience`, `dependencies`, `github-actions`, `npm`, `ignore-for-release`. Reuse the descriptions already established in DOC-ITRoles.
+
+```powershell
+gh api -X POST repos/JeanKadang/DOC-GitHub-Practice-Skills/milestones `
+  -f title='v0.1.0' `
+  -f description='Bootstrap eight canonical skills, validation, installation, documentation, and the initial release.'
+```
+
+- [ ] **Step 6: File bootstrap issue #1**
+
+Title: `Repository lacks its canonical skill packages and release scaffolding`. Assign `@me`; label `P1`, `enhancement`, `tooling`; milestone `v0.1.0`. Use these criteria:
+
+```markdown
+- [ ] Eight canonical skills validate from one inventory.
+- [ ] OpenAI Codex and Claude staged installations use identical SKILL.md content.
+- [ ] The installer refuses unapproved overwrites and supports dry-run and backup behavior.
+- [ ] Contributor, maintainer, OpenAI Codex, Claude, and ADO migration documentation is complete.
+- [ ] CI, dependency updates, release notes, security policy, issue forms, and PR template are active.
+- [ ] Repository and Actions settings match the approved bootstrap design.
+- [ ] All CI checks pass on the bootstrap pull request.
+- [ ] v0.1.0 is tagged from updated main and published with generated release notes.
+```
+
+- [ ] **Step 7: Create the issue-linked branch**
+
+```powershell
+gh issue develop 1 --repo JeanKadang/DOC-GitHub-Practice-Skills `
+  --name bootstrap/1-initial-release --base main --checkout
+```
+
+Expected: clean `bootstrap/1-initial-release`, linked to issue #1. Comment on #1 with Task 2 settings and branch evidence; do not check implementation criteria yet.
+
+---
+
+### Task 3: Import Eight Packages and Build Validation
+
+**Files:**
+
+- Create: `skills/<eight names>/**`
+- Create: `contracts/skill-inventory.json`
+- Create: `scripts/validate-skills.mjs`
+- Create: `tests/validate-skills.test.mjs`
+- Create: `package.json`, `package-lock.json`
+
+**Interfaces:**
+
+- Consumes: seven existing Codex skill directories and the Task 1 draft.
+- Produces: `validateRepository(root) -> { errors, warnings, skills }`, CLI exit status, and the inventory consumed by the installer.
+
+- [ ] **Step 1: Copy sources without policy edits**
+
+Copy these exact directories into `skills/`:
+
+```text
+C:\Users\Jean\.codex\skills\github-for-ado-users
+C:\Users\Jean\.codex\skills\github-hygiene
+C:\Users\Jean\.codex\skills\github-issue-first
+C:\Users\Jean\.codex\skills\github-pr-review
+C:\Users\Jean\.codex\skills\github-projects
+C:\Users\Jean\.codex\skills\github-repo-review
+C:\Users\Jean\.codex\skills\github-security-response
+```
+
+Copy the Task 1 draft as `skills/github-repo-bootstrap`. Verify `github-repo-review/review-prompt.md` and all eight `agents/openai.yaml` files exist.
+
+- [ ] **Step 2: Define the inventory**
+
+Create `contracts/skill-inventory.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "packageVersion": "0.1.0",
+  "skills": [
+    { "name": "github-for-ado-users", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] },
+    { "name": "github-hygiene", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] },
+    { "name": "github-issue-first", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] },
+    { "name": "github-pr-review", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] },
+    { "name": "github-projects", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] },
+    { "name": "github-repo-bootstrap", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] },
+    { "name": "github-repo-review", "requiredFiles": ["SKILL.md", "agents/openai.yaml", "review-prompt.md"] },
+    { "name": "github-security-response", "requiredFiles": ["SKILL.md", "agents/openai.yaml"] }
+  ]
+}
+```
+
+- [ ] **Step 3: Define the Node package**
+
+Create `package.json`:
+
+```json
+{
+  "name": "doc-github-practice-skills",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "node --test",
+    "validate": "node scripts/validate-skills.mjs",
+    "lint:markdown": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "check": "npm run validate && npm test && npm run lint:markdown"
+  },
+  "devDependencies": {
+    "markdownlint-cli2": "^0.23.2",
+    "yaml": "^2.8.1"
+  }
+}
+```
+
+Run `npm install` and commit the generated lockfile.
+
+- [ ] **Step 4: Write failing validator tests**
+
+Use `node:test` and temporary copies. Include:
+
+```javascript
+test('accepts the canonical eight-skill checkout', async () => {
+  const result = await validateRepository(repoRoot);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.skills.length, 8);
+});
+
+test('rejects an unregistered github skill directory', async () => {
+  const root = await fixtureFromRepo();
+  await mkdir(join(root, 'skills', 'github-unregistered'));
+  const result = await validateRepository(root);
+  assert.match(result.errors.join('\n'), /unregistered skill/i);
+});
+
+test('rejects missing companion files', async () => {
+  const root = await fixtureFromRepo();
+  await rm(join(root, 'skills', 'github-repo-review', 'review-prompt.md'));
+  const result = await validateRepository(root);
+  assert.match(result.errors.join('\n'), /review-prompt\.md/);
+});
+
+test('rejects a frontmatter name that differs from its directory', async () => {
+  const root = await fixtureFromRepo();
+  await writeFile(join(root, 'skills', 'github-hygiene', 'SKILL.md'), '---\nname: wrong\n---\n');
+  const result = await validateRepository(root);
+  assert.match(result.errors.join('\n'), /frontmatter name/i);
+});
+```
+
+Run the focused test and confirm failure because `validateRepository` is absent.
+
+- [ ] **Step 5: Implement manifest validation**
+
+`scripts/validate-skills.mjs` exports:
+
+```javascript
+export async function validateRepository(root = process.cwd()) {
+  return { errors: [], warnings: [], skills: [] };
+}
+```
+
+Expand it to load the inventory, compare registered and actual `skills/github-*` directories, verify files, parse `SKILL.md` YAML frontmatter, require `name === directory name`, parse `agents/openai.yaml`, and require non-empty `interface.display_name`, `short_description`, and `default_prompt`. The CLI prints a deterministic summary and exits one on errors.
+
+- [ ] **Step 6: Run red-green verification**
+
+```powershell
+npm run validate
+npm test
+npm run lint:markdown
+```
+
+Expected: eight skills, all tests pass, zero Markdown issues.
+
+- [ ] **Step 7: Commit Task 3**
+
+```powershell
+git add skills contracts scripts/validate-skills.mjs tests/validate-skills.test.mjs package.json package-lock.json
+git commit -m "feat: add canonical skill inventory"
+```
+
+---
+
+### Task 4: Build the Safe PowerShell Installer
+
+**Files:**
+
+- Create: `scripts/install-skills.ps1`
+- Create: `tests/install-skills.test.mjs`
+- Modify: `package.json`
+
+**Interfaces:**
+
+- Consumes: inventory and validated `skills/` tree.
+- Produces: `install-skills.ps1 -Target Codex|Claude|Both -SourceRoot <path> -CodexHome <path> -ClaudeHome <path> -DryRun -Force`.
+
+- [ ] **Step 1: Write failing installer tests**
+
+Spawn `pwsh -NoProfile -File scripts/install-skills.ps1` with temporary homes. Test that dry-run changes nothing, both targets receive eight skills, corresponding `SKILL.md` hashes match, an untracked existing skill is refused without `-Force`, and `-Force` backs up a modified tracked skill before replacement.
+
+Run the focused test and confirm failure because the installer is absent.
+
+- [ ] **Step 2: Implement parameters and discovery**
+
+```powershell
+[CmdletBinding()]
+param(
+    [ValidateSet('Codex', 'Claude', 'Both')]
+    [string]$Target = 'Both',
+    [string]$SourceRoot = (Split-Path $PSScriptRoot -Parent),
+    [string]$CodexHome,
+    [string]$ClaudeHome,
+    [switch]$DryRun,
+    [switch]$Force
+)
+
+$userProfilePath = [Environment]::GetFolderPath('UserProfile')
+if (-not $CodexHome) {
+    $CodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $userProfilePath '.codex' }
+}
+if (-not $ClaudeHome) {
+    $ClaudeHome = if ($env:CLAUDE_HOME) { $env:CLAUDE_HOME } else { Join-Path $userProfilePath '.claude' }
+}
+```
+
+Do not declare or repurpose `$HOME`, `$home`, or `$CODEX_HOME`.
+
+- [ ] **Step 3: Implement staging and overwrite safety**
+
+Validate `SourceRoot` before destination writes. Load the inventory, compute SHA-256 for required files, and stage under a GUID directory inside each target parent. `-DryRun` prints source, target, eight skills, overwrite decisions, and backup paths without creating anything.
+
+Write `.doc-github-practice-skills.json` with release and file hashes. If an existing skill has no matching marker or current hashes differ, exit one unless `-Force`. With `-Force`, back up to `<platform-home>/skill-backups/<UTC timestamp>/<skill-name>/`. Move staged directories only after every check succeeds.
+
+- [ ] **Step 4: Run installer red-green verification**
+
+```powershell
+npm test
+npm run check
+```
+
+Expected: staged Codex and Claude hashes match for all eight skills; overwrite and backup tests pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+```powershell
+git add scripts/install-skills.ps1 tests/install-skills.test.mjs package.json package-lock.json
+git commit -m "feat: add safe skill installer"
+```
+
+---
+
+### Task 5: Add Documentation and Repository Health Scaffolding
+
+**Files:**
+
+- Create: all documentation, platform, community-health, CI, dependency, and release files from the file map.
+- Modify: `README.md`
+
+**Interfaces:**
+
+- Consumes: eight validated skills and installer interface.
+- Produces: complete public documentation, intake templates, CI, dependency updates, release notes, security policy, and release automation.
+
+- [ ] **Step 1: Write the layered guide**
+
+`docs/GUIDE.md` covers all eight triggers, responsibilities, boundaries, outputs, and handoffs. Start with the issue → linked branch → `Refs` → criterion evidence → `Closes` → epic/milestone → release chain. Include ordinary change, repository review, PR review, security, multi-maintainer, release, and new-repository examples. Label current policy separately from improvements and record version/review date.
+
+`docs/WORKFLOW.md` expands the lifecycle. `docs/MAINTAINING.md` defines the cross-skill invariant review, parent-epic reconciliation, issue-versus-PR number verification, and compatibility recording.
+
+- [ ] **Step 2: Write platform tracks**
+
+Create OpenAI Codex and Claude guides that link to the same skill directories, document discovery/restart behavior, and show `-DryRun` before installation. Create neutral ADO mappings for work items, types, iterations, milestones, Projects, repos, pipelines, Test Plans, and Wiki; state that workplace templates belong in a future private companion.
+
+- [ ] **Step 3: Write root policies**
+
+README: purpose, eight skills, quick install, docs, compatibility, licence, security, release status. CONTRIBUTING: issue-first, conventional commits, linked branches, evidence gates, focused PRs, tests, and no workplace content. SECURITY: current release, private vulnerability reporting, no public disclosure, no fictitious guarantees.
+
+Start `CHANGELOG.md` with:
+
+```markdown
+# Changelog
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-08
+
+### Added
+
+- Eight canonical GitHub workflow skills for OpenAI Codex and Claude.
+- Safe Windows PowerShell installation and manifest validation.
+- General Azure DevOps-to-GitHub migration guidance.
+```
+
+- [ ] **Step 4: Add issue forms and PR template**
+
+Bug and improvement forms require evidence, scope, acceptance criteria, affected skills, and public-content confirmation. Disable blank issues and route security reports to SECURITY.md. PR template begins `Refs #N`, asks for criterion evidence and validation, and never defaults to `Closes #N`.
+
+- [ ] **Step 5: Add dependency and release-note configuration**
+
+Dependabot checks npm and GitHub Actions weekly, grouped, assigned to `JeanKadang`, with Task 2 labels. Release notes categorize Security, Features, Fixes, Documentation, Tooling & CI, Maintenance, and Other; exclude `ignore-for-release`; keep `"*"` last.
+
+- [ ] **Step 6: Add pinned CI**
+
+`validate.yml` uses `permissions: contents: read` and stable job names:
+
+- `Validate skills (Node 20)`
+- `Validate skills (Node 22)`
+- `Markdown lint`
+- `Installer dry run (Windows)`
+
+Use pinned `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` and `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`. Node jobs use `npm ci`; Windows runs installer tests and direct dry-run against temporary homes.
+
+- [ ] **Step 7: Add tag release workflow**
+
+Trigger `v*`; use `permissions: contents: write`; checkout tag; run `npm ci` and `npm run check`; require package and inventory versions to equal the tag without `v`; then run this release step with `shell: pwsh`:
+
+```powershell
+gh release create $env:GITHUB_REF_NAME `
+  --verify-tag --generate-notes --title $env:GITHUB_REF_NAME
+```
+
+Expose `${{ github.token }}` only as `GH_TOKEN` for that step. Use no third-party release action.
+
+- [ ] **Step 8: Verify and commit Task 5**
+
+Run `npm run check`, the public-content regex from Task 2 across the repo excluding `node_modules` and lockfile, and `git diff --check`. Review any generic documentation match manually.
+
+```powershell
+git add README.md CHANGELOG.md CONTRIBUTING.md SECURITY.md docs platforms .github
+git commit -m "docs: add skill workflow guidance"
+```
+
+---
+
+### Task 6: Open, Verify, and Merge the Bootstrap PR
+
+**Files:**
+
+- Create temporarily: `.superpowers/sdd/repo-settings.json`
+- Create temporarily: `.superpowers/sdd/main-ruleset.json`
+- Delete both after API verification.
+
+**Interfaces:**
+
+- Consumes: complete bootstrap branch with green local validation.
+- Produces: configured repository, green PR, evidence-backed issue state, and approved merge commit.
+
+- [ ] **Step 1: Push and open the PR**
+
+Push `bootstrap/1-initial-release`. Open a ready PR titled `feat: bootstrap GitHub practice skills` with `Refs #1`, exact commits, inventory, validation, settings still to verify, and public-content scan result.
+
+- [ ] **Step 2: Enable and verify security settings**
+
+Enable private vulnerability reporting. Query `security_and_analysis`; enable secret scanning and push protection where the public repository reports them available. Record an unavailable API/plan control as a constraint, not a fabricated defect.
+
+- [ ] **Step 3: Audit actual settings**
+
+```powershell
+gh repo view JeanKadang/DOC-GitHub-Practice-Skills `
+  --json nameWithOwner,visibility,defaultBranchRef,deleteBranchOnMerge,mergeCommitAllowed,rebaseMergeAllowed,squashMergeAllowed,hasIssuesEnabled,hasProjectsEnabled,hasWikiEnabled
+gh api repos/JeanKadang/DOC-GitHub-Practice-Skills/actions/permissions/workflow
+gh api repos/JeanKadang/DOC-GitHub-Practice-Skills --jq .security_and_analysis
+```
+
+Expected: public/main, delete true, merge commit true, squash/rebase false, issues true, Projects/Wiki false, default Actions read, available security controls enabled.
+
+- [ ] **Step 4: Wait for every PR check**
+
+Resolve the PR number from the branch, then run `gh pr checks <N> --watch`. All four stable CI jobs must be green. Diagnose failures before any rerun.
+
+- [ ] **Step 5: Review issue criteria and PR scope**
+
+Use `github-pr-review` to map each non-release criterion to diff, tests, CI, docs, or settings. Keep the release criterion unchecked and keep `Refs #1`, because `v0.1.0` does not exist yet.
+
+- [ ] **Step 6: Request explicit merge approval**
+
+Present PR URL, criterion table, CI matrix, settings audit, content scan, and the remaining release criterion. Merge only after approval, with a merge commit.
+
+- [ ] **Step 7: Create the main ruleset after CI names exist**
+
+After merge, create an active `~DEFAULT_BRANCH` ruleset with deletion and non-fast-forward protection, pull requests required with zero approvals for the solo maintainer, and strict required checks using the four exact Task 5 job names. Verify with `gh ruleset check main` and the API. Record why the first PR preceded the ruleset.
+
+---
+
+### Task 7: Publish and Verify `v0.1.0`
+
+**Files:**
+
+- No source changes unless verification finds a genuine defect.
+
+**Interfaces:**
+
+- Consumes: updated `main`, green validation, matching `0.1.0` versions, changelog, approved release.
+- Produces: annotated tag, latest release, completed issue #1, closed milestone, clean branches.
+
+- [ ] **Step 1: Verify fresh `main`**
+
+```powershell
+git checkout main
+git pull --ff-only
+npm ci
+npm run check
+node -e "const p=require('./package.json'),i=require('./contracts/skill-inventory.json');if(p.version!=='0.1.0'||i.packageVersion!=='0.1.0')process.exit(1)"
+git diff --check
+```
+
+Expected: all checks pass, versions match, tree clean.
+
+- [ ] **Step 2: Preview release notes**
+
+```powershell
+gh api repos/JeanKadang/DOC-GitHub-Practice-Skills/releases/generate-notes `
+  -f tag_name=v0.1.0 -f target_commitish=main `
+  --jq '{name: .name, body: .body}'
+```
+
+Expected: bootstrap PR categorized correctly and no unrelated changes.
+
+- [ ] **Step 3: Request explicit release approval**
+
+Present release commit, check results, notes preview, open release criterion, and annotated-tag command. Do not tag without approval.
+
+- [ ] **Step 4: Tag updated `main`**
+
+```powershell
+git tag -a v0.1.0 -m "Release 0.1.0"
+git rev-list -n 1 v0.1.0
+git push origin v0.1.0
+```
+
+Verify tag commit equals `main`, then watch release automation. Do not create a duplicate manual release.
+
+- [ ] **Step 5: Verify and close release tracking**
+
+Confirm `v0.1.0` is latest, not draft/prerelease, annotated tag resolves to updated `main`, generated notes exist, and release workflow is green. Add criterion evidence to issue #1, check all eight boxes with a body file, close Completed, verify zero unchecked, close milestone `v0.1.0`, prune the branch, and report any open PR.
+
+---
+
+### Task 8: Integrate the Released Skills into DOC-ITRoles
+
+**Files:**
+
+- Create: `docs/GITHUB_WORKFLOW_SKILLS.md`
+- Modify: `CHANGELOG.md`
+- Modify remotely: issue #216 and the current branch PR metadata.
+
+**Interfaces:**
+
+- Consumes: verified public `v0.1.0` and canonical documentation URLs.
+- Produces: repository-specific integration guide, green DOC-ITRoles PR, and evidence-backed #216 closure.
+
+- [ ] **Step 1: Write the integration guide**
+
+Include repository URL and adopted `v0.1.0`; all eight names; canonical guide/installer/platform links; DOC-ITRoles labels, thematic milestones, linked branches, merge commits, release conventions; acceptance criteria as evidence gates; parent-epic/native-sub-issue reconciliation; explicit merge/release approval; hosted browser CI as authoritative when local simulation is unavailable; private security routing; and a statement that reusable policy lives in the released skills repository.
+
+- [ ] **Step 2: Update the changelog**
+
+Under `[Unreleased]`, record the integration guide and link #216 and the released repository. Do not bump DOC-ITRoles solely for this documentation PR.
+
+- [ ] **Step 3: Verify DOC-ITRoles**
+
+```powershell
+npx --yes markdownlint-cli2 "docs/GITHUB_WORKFLOW_SKILLS.md" `
+  "docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md" `
+  "docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md"
+npm test
+npm run validate
+git diff --check
+```
+
+Expected: zero lint issues, at least 279 Node tests pass, role validation zero errors, clean diff.
+
+- [ ] **Step 4: Open the DOC-ITRoles PR**
+
+From `docs/216-github-skills-guide`, open a ready PR titled `docs: document GitHub practice skills` with `Refs #216`, release evidence, local validation, and scope-decision history.
+
+- [ ] **Step 5: Reconcile all ten #216 criteria**
+
+Map criteria to design, public repo, eight packages, bootstrap evidence, docs, CI, installer tests, release, integration guide, content scan, and both validations. Only when all are `Met`, change PR to `Closes #216` and check every box with a newline-preserving body file.
+
+- [ ] **Step 6: Request merge approval and merge on green**
+
+Wait for every DOC-ITRoles check; present criterion table and PR URL; merge with a merge commit only after explicit approval.
+
+- [ ] **Step 7: Verify closure and cleanup**
+
+Confirm #216 Closed/Completed with ten checked and zero unchecked. Reconcile epic #193 if #216 is listed. Verify both `main` branches equal origin, merged remote branches are gone, temporary bootstrap staging is deleted, no active agents remain, and only the user's `.claude/settings.local.json` remains untracked in DOC-ITRoles.
+
+## Plan Self-Review Checklist
+
+- [ ] Every approved design section maps to a task.
+- [ ] Every external-state mutation has an exact target and verification step.
+- [ ] The issue-first exception ends immediately after the minimum shell.
+- [ ] Public/private ADO boundaries are checked before publication.
+- [ ] OpenAI Codex and Claude consume identical skill text.
+- [ ] Ruleset creation follows observation of CI names.
+- [ ] Merge and release approvals remain explicit gates.
+- [ ] Both repositories have criterion-level closure evidence and cleanup.

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -621,11 +621,11 @@ gh api repos/JeanKadang/DOC-GitHub-Practice-Skills/releases/generate-notes `
 
 Expected: bootstrap PR categorized correctly and no unrelated changes.
 
-- [ ] **Step 3: Request explicit release approval**
+- [x] **Step 3: Request explicit release approval**
 
 Present release commit, check results, notes preview, open release criterion, and annotated-tag command. Do not tag without approval.
 
-- [ ] **Step 4: Tag updated `main`**
+- [x] **Step 4: Tag updated `main`**
 
 ```powershell
 git tag -a v0.1.0 -m "Release 0.1.0"
@@ -635,7 +635,7 @@ git push origin v0.1.0
 
 Verify tag commit equals `main`, then watch release automation. Do not create a duplicate manual release.
 
-- [ ] **Step 5: Verify and close release tracking**
+- [x] **Step 5: Verify and close release tracking**
 
 Confirm `v0.1.0` is latest, not draft/prerelease, annotated tag resolves to updated `main`, generated notes exist, and release workflow is green. Add criterion evidence to issue #1, check all eight boxes with a body file, close Completed, verify zero unchecked, close milestone `v0.1.0`, prune the branch, and report any open PR.
 
@@ -654,15 +654,15 @@ Confirm `v0.1.0` is latest, not draft/prerelease, annotated tag resolves to upda
 - Consumes: verified public `v0.1.0` and canonical documentation URLs.
 - Produces: repository-specific integration guide, green DOC-ITRoles PR, and evidence-backed #216 closure.
 
-- [ ] **Step 1: Write the integration guide**
+- [x] **Step 1: Write the integration guide**
 
 Include repository URL and adopted `v0.1.0`; all eight names; canonical guide/installer/platform links; DOC-ITRoles labels, thematic milestones, linked branches, merge commits, release conventions; acceptance criteria as evidence gates; parent-epic/native-sub-issue reconciliation; explicit merge/release approval; hosted browser CI as authoritative when local simulation is unavailable; private security routing; and a statement that reusable policy lives in the released skills repository.
 
-- [ ] **Step 2: Update the changelog**
+- [x] **Step 2: Update the changelog**
 
 Under `[Unreleased]`, record the integration guide and link #216 and the released repository. Do not bump DOC-ITRoles solely for this documentation PR.
 
-- [ ] **Step 3: Verify DOC-ITRoles**
+- [x] **Step 3: Verify DOC-ITRoles**
 
 ```powershell
 npx --yes markdownlint-cli2 "docs/GITHUB_WORKFLOW_SKILLS.md" `

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -66,7 +66,7 @@
 **Interfaces:**
 
 - Consumes: the approved design's “New-repository bootstrap skill” section.
-- Produces: a complete draft package accepted by the local skill validator and ready to govern Task 2.
+- Produces: a complete draft package accepted by the local skill validator, committed in a disposable local staging repository, and ready to govern Task 2.
 
 - [ ] **Step 1: Read both required skill-authoring instructions**
 
@@ -128,7 +128,9 @@ Expected: zero frontmatter, naming, or metadata errors.
 
 - [ ] **Step 5: Review all bootstrap gates**
 
-Create a criterion table covering the 12 sections, public/private boundary, conditional scaffolding, plan-gated rulesets, solo-maintainer behavior, release handoff, and actual-settings verification. Every row must be `Met` before Task 2. No commit occurs because this is temporary pre-repository staging.
+Create a criterion table covering the 12 sections, public/private boundary, conditional scaffolding, plan-gated rulesets, solo-maintainer behavior, release handoff, and actual-settings verification. Every row must be `Met` before Task 2.
+
+Initialize a disposable Git repository at `.superpowers/sdd/doc-github-practice-skills-bootstrap`, commit the validated draft as `docs: draft repository bootstrap skill`, and use that commit for the Task 1 review package. This commit exists only to make the pre-creation artifact reviewable; it must never be merged into DOC-ITRoles or pushed as an independent repository. Delete the disposable repository after Task 3 verifies the canonical copy.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -297,7 +297,9 @@ Create `package.json`:
   "scripts": {
     "test": "node --test",
     "validate": "node scripts/validate-skills.mjs",
-    "lint:markdown": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "lint:markdown:docs": "markdownlint-cli2 \"**/*.md\" \"#node_modules/**\" \"#skills/**\"",
+    "lint:markdown:skills": "markdownlint-cli2 --config .markdownlint-skills.jsonc \"skills/**/*.md\"",
+    "lint:markdown": "npm run lint:markdown:docs && npm run lint:markdown:skills",
     "check": "npm run validate && npm test && npm run lint:markdown"
   },
   "devDependencies": {
@@ -308,6 +310,14 @@ Create `package.json`:
 ```
 
 Run `npm install` and commit the generated lockfile.
+
+Create `.markdownlint-skills.jsonc` for the byte-preserved imported skill
+sources. Disable only inherited formatting rules `MD013`, `MD022`, `MD032`,
+`MD040`, and `MD060`. Root and documentation Markdown remain subject to the
+strict default rules through `lint:markdown:docs`. This scoped exception was
+approved by the maintainer on 2026-08-09 after the exact imports exposed 266
+pre-existing findings; normalization is intentionally deferred to a separately
+reviewed change.
 
 - [ ] **Step 4: Write failing validator tests**
 
@@ -364,12 +374,13 @@ npm test
 npm run lint:markdown
 ```
 
-Expected: eight skills, all tests pass, zero Markdown issues.
+Expected: eight skills, all tests pass, zero Markdown issues under the strict
+repository-doc rules and the explicitly scoped imported-skill policy.
 
 - [ ] **Step 7: Commit Task 3**
 
 ```powershell
-git add skills contracts scripts/validate-skills.mjs tests/validate-skills.test.mjs package.json package-lock.json
+git add skills contracts scripts/validate-skills.mjs tests/validate-skills.test.mjs package.json package-lock.json .markdownlint-skills.jsonc
 git commit -m "feat: add canonical skill inventory"
 ```
 

--- a/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
+++ b/docs/superpowers/plans/2026-08-08-github-practice-skills-repository.md
@@ -246,7 +246,7 @@ Expected: clean `bootstrap/1-initial-release`, linked to issue #1. Comment on #1
 - Consumes: seven existing Codex skill directories and the Task 1 draft.
 - Produces: `validateRepository(root) -> { errors, warnings, skills }`, CLI exit status, and the inventory consumed by the installer.
 
-- [ ] **Step 1: Copy sources without policy edits**
+- [x] **Step 1: Copy sources without policy edits**
 
 Copy these exact directories into `skills/`:
 
@@ -262,7 +262,7 @@ C:\Users\Jean\.codex\skills\github-security-response
 
 Copy the Task 1 draft as `skills/github-repo-bootstrap`. Verify `github-repo-review/review-prompt.md` and all eight `agents/openai.yaml` files exist.
 
-- [ ] **Step 2: Define the inventory**
+- [x] **Step 2: Define the inventory**
 
 Create `contracts/skill-inventory.json`:
 
@@ -283,7 +283,7 @@ Create `contracts/skill-inventory.json`:
 }
 ```
 
-- [ ] **Step 3: Define the Node package**
+- [x] **Step 3: Define the Node package**
 
 Create `package.json`:
 
@@ -319,7 +319,7 @@ approved by the maintainer on 2026-08-09 after the exact imports exposed 266
 pre-existing findings; normalization is intentionally deferred to a separately
 reviewed change.
 
-- [ ] **Step 4: Write failing validator tests**
+- [x] **Step 4: Write failing validator tests**
 
 Use `node:test` and temporary copies. Include:
 
@@ -354,7 +354,7 @@ test('rejects a frontmatter name that differs from its directory', async () => {
 
 Run the focused test and confirm failure because `validateRepository` is absent.
 
-- [ ] **Step 5: Implement manifest validation**
+- [x] **Step 5: Implement manifest validation**
 
 `scripts/validate-skills.mjs` exports:
 
@@ -366,7 +366,7 @@ export async function validateRepository(root = process.cwd()) {
 
 Expand it to load the inventory, compare registered and actual `skills/github-*` directories, verify files, parse `SKILL.md` YAML frontmatter, require `name === directory name`, parse `agents/openai.yaml`, and require non-empty `interface.display_name`, `short_description`, and `default_prompt`. The CLI prints a deterministic summary and exits one on errors.
 
-- [ ] **Step 6: Run red-green verification**
+- [x] **Step 6: Run red-green verification**
 
 ```powershell
 npm run validate
@@ -377,7 +377,7 @@ npm run lint:markdown
 Expected: eight skills, all tests pass, zero Markdown issues under the strict
 repository-doc rules and the explicitly scoped imported-skill policy.
 
-- [ ] **Step 7: Commit Task 3**
+- [x] **Step 7: Commit Task 3**
 
 ```powershell
 git add skills contracts scripts/validate-skills.mjs tests/validate-skills.test.mjs package.json package-lock.json .markdownlint-skills.jsonc

--- a/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
+++ b/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
@@ -1,0 +1,328 @@
+# GitHub Workflow Skills Repository Design
+
+**Date:** 2026-08-08  
+**Bootstrap issue:** #216  
+**Status:** Proposed for maintainer review
+
+## Decision summary
+
+Create a public repository named `github-workflow-skills` under the
+`JeanKadang` account. It will become the canonical, versioned source for the
+seven GitHub workflow skills currently installed locally for Claude and OpenAI
+Codex.
+
+The repository will keep one shared skill source and provide platform-specific
+metadata, installation, and usage guidance for OpenAI Codex and Claude. A third
+track will explain general Azure DevOps-to-GitHub migration concepts. It will not
+contain company-specific ADO templates, names, fields, or policies.
+
+DOC-ITRoles will retain a short integration guide that identifies the adopted
+released version and records only repository-specific conventions.
+
+## Goals
+
+- Establish one canonical source for all seven skills.
+- Prevent Claude and Codex installations from drifting independently.
+- Publish understandable contributor and maintainer documentation.
+- Validate package structure and platform metadata automatically.
+- Provide safe, repeatable installation and update paths on Windows.
+- Version changes with a changelog and GitHub releases.
+- Preserve a clear extension point for future private ADO template work.
+
+## Non-goals
+
+- Automating Azure DevOps work items, boards, repositories, or pipelines.
+- Publishing or adapting company-specific ADO templates in the public repository.
+- Replacing the skills with a single large skill.
+- Maintaining separate policy copies for Claude and OpenAI Codex.
+- Automatically overwriting locally modified installed skills.
+- Moving DOC-ITRoles project-specific policy into the shared repository.
+
+## Repository identity
+
+| Property | Decision |
+|---|---|
+| Owner | `JeanKadang` |
+| Name | `github-workflow-skills` |
+| Visibility | Public |
+| Licence | MIT, suitable for reuse and adaptation |
+| Default branch | `main` |
+| Initial release | `v0.1.0`, promoted to `v1.0.0` after installation and reuse are proven outside the source checkout |
+
+The repository name describes the capability rather than either AI platform.
+This keeps Claude, OpenAI Codex, and ADO migration guidance as equal tracks over
+the same workflow model.
+
+## Canonical skill inventory
+
+The initial release contains exactly these seven skills:
+
+1. `github-issue-first`
+2. `github-hygiene`
+3. `github-pr-review`
+4. `github-repo-review`
+5. `github-security-response`
+6. `github-projects`
+7. `github-for-ado-users`
+
+The existing `github-repo-review/review-prompt.md` remains a self-contained
+companion artifact. Its deliberate policy repetition is preserved because it is
+also intended for colleagues who do not run the skill package.
+
+## Repository structure
+
+```text
+github-workflow-skills/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   ├── workflows/
+│   │   ├── validate.yml
+│   │   └── release.yml
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   └── release.yml
+├── contracts/
+│   └── skill-inventory.json
+├── docs/
+│   ├── GUIDE.md
+│   ├── WORKFLOW.md
+│   ├── MAINTAINING.md
+│   ├── openai-codex.md
+│   ├── claude.md
+│   └── azure-devops-migration.md
+├── platforms/
+│   ├── openai-codex/
+│   │   └── README.md
+│   ├── claude/
+│   │   └── README.md
+│   └── azure-devops/
+│       └── README.md
+├── scripts/
+│   ├── Install-GitHubWorkflowSkills.ps1
+│   └── Test-GitHubWorkflowSkills.ps1
+├── skills/
+│   ├── github-for-ado-users/
+│   ├── github-hygiene/
+│   ├── github-issue-first/
+│   ├── github-pr-review/
+│   ├── github-projects/
+│   ├── github-repo-review/
+│   └── github-security-response/
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── LICENSE
+├── README.md
+└── SECURITY.md
+```
+
+Each directory under `skills/` contains the canonical `SKILL.md`. Where OpenAI
+Codex metadata is required, the same skill directory also contains
+`agents/openai.yaml`. Claude consumes the shared `SKILL.md` and ignores the
+additional OpenAI metadata; no second policy copy is created.
+
+The `platforms/` directories explain installation and activation differences.
+They contain no forks of the skill text.
+
+## Documentation model
+
+The documentation uses two reading layers.
+
+### Contributor layer
+
+`docs/GUIDE.md` starts with the common path:
+
+```text
+finding or committed need
+  -> issue with ownership, labels, milestone, and acceptance criteria
+  -> issue-linked branch
+  -> PR using Refs #N while incomplete
+  -> criterion-by-criterion evidence review
+  -> Closes #N only after the closure gate passes
+  -> parent epic and milestone reconciliation
+  -> release and cleanup
+```
+
+A trigger matrix shows which skill owns each stage. Security-sensitive findings
+branch into private response. Projects are presented as an optional shared view
+for multi-maintainer repositories, never as a replacement for issue metadata.
+
+### Maintainer layer
+
+The remainder of the guide and `docs/MAINTAINING.md` describe each skill's:
+
+- intent and activation trigger;
+- responsibilities and expected outputs;
+- deliberate boundaries;
+- hand-off to companion skills;
+- shared workflow invariants; and
+- known improvement opportunities.
+
+Documentation identifies the repository release it describes and distinguishes
+current behavior from proposed changes.
+
+## Platform tracks
+
+### OpenAI Codex
+
+- Uses the shared `SKILL.md` plus `agents/openai.yaml` metadata.
+- Installs to the user's Codex skills directory discovered from the environment,
+  defaulting to `%USERPROFILE%\.codex\skills` only when no configured location
+  is available.
+- Documents restart or rediscovery requirements after installation.
+- Validates the OpenAI metadata for every skill before packaging a release.
+
+### Claude
+
+- Uses the same canonical `SKILL.md` files.
+- Installs to the configured Claude skills directory, defaulting to
+  `%USERPROFILE%\.claude\skills` when appropriate.
+- Does not maintain a Claude-specific policy fork.
+- Documents any Claude-only discovery behavior in the platform guide.
+
+### Azure DevOps migration
+
+- Explains how ADO work items, epics, iterations, boards, policies, pipelines,
+  test plans, and wikis map—or fail to map—to GitHub.
+- Starts from the existing `github-for-ado-users` skill.
+- Includes migration checklists and neutral example mappings only.
+- Reserves a documented extension seam for a future private companion repository.
+- Does not ingest workplace templates during the initial scope.
+
+## Installation and update behavior
+
+`Install-GitHubWorkflowSkills.ps1` accepts a target platform and source version.
+The first release supports Windows PowerShell because that is the verified local
+environment.
+
+Required behavior:
+
+- `-Target Codex`, `-Target Claude`, or both;
+- dry-run mode showing planned copies;
+- validation before any destination changes;
+- refusal to overwrite locally modified skill files unless explicitly approved;
+- backup or side-by-side staging before replacement;
+- a version marker recording the installed release; and
+- a post-install inventory and validation summary.
+
+Installation copies released canonical packages. Installed directories are
+deployment outputs, not independent editing locations. Changes flow back through
+the public repository and a new release.
+
+Cross-platform shell installers are deferred until there is a confirmed user or
+CI environment for them; the documentation must state the Windows-first support
+boundary clearly.
+
+## Validation and consistency controls
+
+`contracts/skill-inventory.json` records the seven expected skill names and
+their required files. Automated checks verify:
+
+- every inventory entry has a valid `SKILL.md` and required frontmatter;
+- every OpenAI-enabled package has valid `agents/openai.yaml` metadata;
+- referenced companion files such as `review-prompt.md` exist;
+- no unregistered `github-*` skill silently enters a release;
+- release packages for Claude and Codex originate from the same skill source;
+- documentation mentions every inventory entry;
+- Markdown passes linting; and
+- install scripts pass static analysis and dry-run tests.
+
+Semantic policies such as acceptance criteria being closure gates cannot be
+reliably proven by string matching alone. `docs/MAINTAINING.md` therefore adds a
+cross-skill review checklist for shared invariants. Automation checks structure;
+human review checks meaning.
+
+## Improvement roadmap
+
+The initial documentation will record, but not automatically implement, these
+prioritized improvements:
+
+1. Add mandatory parent-epic reconciliation after child closure.
+2. Provide audits for completed issues with unchecked criteria and stale epic
+   checkboxes.
+3. Distinguish thematic milestones from release milestones before closing them.
+4. Resolve conflicting iteration-versus-milestone guidance.
+5. Add PowerShell-native equivalents for Bash-oriented examples.
+6. Verify whether a shared GitHub number identifies an issue or a pull request
+   before attempting metadata reconciliation.
+7. Add cross-skill consistency review whenever shared invariants change.
+8. Record the GitHub CLI and API versions against which change-prone commands
+   were verified.
+
+Each improvement becomes a separate issue in the new repository after its
+bootstrap release. The migration must preserve current behavior first; redesign
+does not ride unnoticed inside the copy.
+
+## Security and public/private boundary
+
+The public repository may contain generic workflow policy, neutral examples,
+installation code, and general ADO-to-GitHub mapping.
+
+It must not contain:
+
+- company or customer names;
+- internal organization, project, repository, or account identifiers;
+- proprietary work-item fields, templates, policies, or process names;
+- credentials, endpoints, or screenshots from workplace systems; or
+- examples copied from work material without explicit sanitisation and approval.
+
+Future company-specific ADO reuse belongs in a private companion repository that
+depends on a released public-core version.
+
+## Release model
+
+The new repository follows its own skills:
+
+- issues precede changes;
+- one issue-linked branch per unit of work;
+- pull requests use `Refs #N` until all acceptance criteria have evidence;
+- all validation checks must be green before approved merge;
+- `CHANGELOG.md` records user-visible skill or packaging changes;
+- an annotated tag is created only from updated `main`;
+- GitHub generated notes accompany each release; and
+- installed copies update from releases, not arbitrary branch state.
+
+The initial `v0.1.0` release is a public preview of the packaging and installation
+contract. `v1.0.0` requires successful installation and use from a clean checkout
+outside the source repository.
+
+## Migration sequence
+
+1. Create the public repository with a README and MIT licence.
+2. File its bootstrap issue and create an issue-linked branch.
+3. Copy the seven current skill sources without policy redesign.
+4. Add OpenAI metadata, platform guides, inventory, validation, and installation.
+5. Add the layered guide and maintainer documentation.
+6. Validate a staged Claude and Codex installation from a clean checkout.
+7. Merge the bootstrap PR after acceptance review and publish `v0.1.0`.
+8. Add `docs/GITHUB_WORKFLOW_SKILLS.md` to DOC-ITRoles, pinned to `v0.1.0`,
+   containing only local conventions and canonical links.
+9. Reconcile issue #216 with evidence from both repositories.
+10. File separate improvement issues in the new repository.
+
+Existing local installations remain untouched until the released installer has
+passed staged validation. Migration is additive and recoverable.
+
+## DOC-ITRoles integration document
+
+`docs/GITHUB_WORKFLOW_SKILLS.md` will contain:
+
+- the adopted skills repository and release version;
+- the seven enabled skill names;
+- DOC-ITRoles-specific labels, milestone model, merge approval, release, and
+  acceptance-evidence conventions;
+- the parent-epic reconciliation requirement;
+- links to the canonical guide and installation instructions; and
+- a statement that the shared skill repository—not this integration file—is the
+  source for reusable workflow policy.
+
+## Acceptance and verification
+
+Completion requires evidence that:
+
+- the public repository and initial release exist;
+- all seven skills validate from the canonical checkout;
+- staged Claude and Codex installations contain the same `SKILL.md` content;
+- the guide covers all seven skills and all three tracks;
+- public-content scanning finds no company-specific material;
+- release notes and changelog identify the bootstrap contents;
+- the DOC-ITRoles integration document points to the verified release; and
+- issue #216 has every in-scope criterion checked before completed closure.

--- a/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
+++ b/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
@@ -37,6 +37,9 @@ released version and records only repository-specific conventions.
 - Maintaining separate policy copies for Claude and OpenAI Codex.
 - Automatically overwriting locally modified installed skills.
 - Moving DOC-ITRoles project-specific policy into the shared repository.
+- Publishing documentation through GitHub Wiki. The Wiki's separate repository,
+  publication workflow, and indexing caveats add more maintenance than the
+  initial release needs; reviewed Markdown under `docs/` remains authoritative.
 
 ## Repository identity
 
@@ -158,6 +161,11 @@ The remainder of the guide and `docs/MAINTAINING.md` describe each skill's:
 
 Documentation identifies the repository release it describes and distinguishes
 current behavior from proposed changes.
+
+GitHub Wiki is deliberately not part of the initial documentation model. The
+repository README and `docs/` tree provide one reviewable, testable, and
+version-matched documentation surface. Wiki publication can be reconsidered only
+if a concrete navigation or contributor need outweighs the additional sync path.
 
 ## Platform tracks
 

--- a/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
+++ b/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
@@ -6,7 +6,7 @@
 
 ## Decision summary
 
-Create a public repository named `github-workflow-skills` under the
+Create a public repository named `DOC-GitHub-Practice-Skills` under the
 `JeanKadang` account. It will become the canonical, versioned source for the
 seven GitHub workflow skills currently installed locally for Claude and OpenAI
 Codex.
@@ -46,7 +46,7 @@ released version and records only repository-specific conventions.
 | Property | Decision |
 |---|---|
 | Owner | `JeanKadang` |
-| Name | `github-workflow-skills` |
+| Name | `DOC-GitHub-Practice-Skills` |
 | Visibility | Public |
 | Licence | MIT, suitable for reuse and adaptation |
 | Default branch | `main` |
@@ -75,7 +75,7 @@ also intended for colleagues who do not run the skill package.
 ## Repository structure
 
 ```text
-github-workflow-skills/
+DOC-GitHub-Practice-Skills/
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
 │   ├── workflows/

--- a/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
+++ b/docs/superpowers/specs/2026-08-08-github-workflow-skills-repository-design.md
@@ -11,7 +11,8 @@ Create a public repository named `DOC-GitHub-Practice-Skills` under the
 seven GitHub workflow skills currently installed locally for Claude and OpenAI
 Codex.
 
-The repository will keep one shared skill source and provide platform-specific
+The repository will preserve the seven existing skills, add a dedicated
+`github-repo-bootstrap` skill, and provide platform-specific
 metadata, installation, and usage guidance for OpenAI Codex and Claude. A third
 track will explain general Azure DevOps-to-GitHub migration concepts. It will not
 contain company-specific ADO templates, names, fields, or policies.
@@ -21,7 +22,7 @@ released version and records only repository-specific conventions.
 
 ## Goals
 
-- Establish one canonical source for all seven skills.
+- Establish one canonical source for all eight skills.
 - Prevent Claude and Codex installations from drifting independently.
 - Publish understandable contributor and maintainer documentation.
 - Validate package structure and platform metadata automatically.
@@ -58,15 +59,17 @@ the same workflow model.
 
 ## Canonical skill inventory
 
-The initial release contains exactly these seven skills:
+The initial release contains the seven existing skills plus the new repository
+bootstrap skill:
 
 1. `github-issue-first`
 2. `github-hygiene`
 3. `github-pr-review`
 4. `github-repo-review`
-5. `github-security-response`
-6. `github-projects`
-7. `github-for-ado-users`
+5. `github-repo-bootstrap`
+6. `github-security-response`
+7. `github-projects`
+8. `github-for-ado-users`
 
 The existing `github-repo-review/review-prompt.md` remains a self-contained
 companion artifact. Its deliberate policy repetition is preserved because it is
@@ -108,6 +111,7 @@ DOC-GitHub-Practice-Skills/
 │   ├── github-issue-first/
 │   ├── github-pr-review/
 │   ├── github-projects/
+│   ├── github-repo-bootstrap/
 │   ├── github-repo-review/
 │   └── github-security-response/
 ├── CHANGELOG.md
@@ -124,6 +128,52 @@ additional OpenAI metadata; no second policy copy is created.
 
 The `platforms/` directories explain installation and activation differences.
 They contain no forks of the skill text.
+
+## New-repository bootstrap skill
+
+`github-repo-bootstrap` activates before creating a GitHub repository or when a
+newly created repository has not yet completed its initial setup. It orchestrates
+the other skills without absorbing their detailed policies.
+
+Its workflow is:
+
+1. Confirm owner, name availability, purpose, visibility, licence, description,
+   topics, default branch, expected maintainers, and release intent.
+2. For a public repository, scan all proposed bootstrap content for credentials,
+   personal data, company-specific material, and unintended history.
+3. Verify GitHub authentication, plan-dependent feature availability, and the
+   exact local source directory before creating external state.
+4. Create only the minimum repository shell needed to enable issue tracking: a
+   README, licence, and `main` branch. This is the documented issue-first
+   bootstrap exception because no issue can exist before the repository exists.
+5. Immediately file and assign a bootstrap issue with labels, milestone, and
+   acceptance criteria, then create its issue-linked branch.
+6. Add the warranted scaffolding through that branch: contribution and security
+   guidance, issue forms, PR template, dependency updates, CI, release-note
+   configuration, changelog, documentation, and ADR structure.
+7. Configure repository behavior deliberately: merge methods, automatic branch
+   deletion, Actions token permissions, vulnerability reporting, Dependabot,
+   secret scanning, push protection, and other available security controls.
+8. Establish rulesets only after CI job names exist, and only when the repository
+   visibility and account plan support them. A solo repository must not require
+   an impossible self-approval.
+9. Run the repository's validation, inspect the first pull request and every CI
+   leg, reconcile acceptance evidence, and merge only with maintainer approval.
+10. Query the GitHub APIs after setup and compare actual settings with the design
+    before declaring the repository bootstrapped.
+11. Publish an initial release when the repository is intended to distribute a
+    versioned artifact, then hand ongoing work to `github-hygiene`.
+
+The skill must make conditional scaffolding explicit. It does not create a
+Projects board for a solo maintainer, does not add CODEOWNERS without a real
+review-routing need, does not enable GitHub Wiki for this repository, and does
+not recommend unavailable paid controls as though they were missing work.
+
+`DOC-GitHub-Practice-Skills` is the skill's first acceptance case. A draft of the
+bootstrap skill and its checklist will be prepared before repository creation;
+the minimum shell, bootstrap issue, branch, settings, CI, verification, and first
+release will then be executed and evidenced against that draft. The accepted
+skill enters the same repository through the bootstrap pull request.
 
 ## Documentation model
 
@@ -221,7 +271,7 @@ boundary clearly.
 
 ## Validation and consistency controls
 
-`contracts/skill-inventory.json` records the seven expected skill names and
+`contracts/skill-inventory.json` records the eight expected skill names and
 their required files. Automated checks verify:
 
 - every inventory entry has a valid `SKILL.md` and required frontmatter;
@@ -296,15 +346,20 @@ outside the source repository.
 
 1. Create the public repository with a README and MIT licence.
 2. File its bootstrap issue and create an issue-linked branch.
-3. Copy the seven current skill sources without policy redesign.
-4. Add OpenAI metadata, platform guides, inventory, validation, and installation.
-5. Add the layered guide and maintainer documentation.
-6. Validate a staged Claude and Codex installation from a clean checkout.
-7. Merge the bootstrap PR after acceptance review and publish `v0.1.0`.
-8. Add `docs/GITHUB_WORKFLOW_SKILLS.md` to DOC-ITRoles, pinned to `v0.1.0`,
+3. Prepare and review the new `github-repo-bootstrap` skill locally, then use its
+   documented minimum-shell exception to create the repository.
+4. File the new repository's bootstrap issue and create its issue-linked branch.
+5. Copy the seven current skill sources without policy redesign and add the
+   bootstrap skill as the eighth canonical package.
+6. Add OpenAI metadata, platform guides, inventory, validation, and installation.
+7. Add the layered guide and maintainer documentation.
+8. Validate a staged Claude and Codex installation from a clean checkout.
+9. Verify actual repository settings against the bootstrap design.
+10. Merge the bootstrap PR after acceptance review and publish `v0.1.0`.
+11. Add `docs/GITHUB_WORKFLOW_SKILLS.md` to DOC-ITRoles, pinned to `v0.1.0`,
    containing only local conventions and canonical links.
-9. Reconcile issue #216 with evidence from both repositories.
-10. File separate improvement issues in the new repository.
+12. Reconcile issue #216 with evidence from both repositories.
+13. File separate improvement issues in the new repository.
 
 Existing local installations remain untouched until the released installer has
 passed staged validation. Migration is additive and recoverable.
@@ -314,7 +369,7 @@ passed staged validation. Migration is additive and recoverable.
 `docs/GITHUB_WORKFLOW_SKILLS.md` will contain:
 
 - the adopted skills repository and release version;
-- the seven enabled skill names;
+- the eight enabled skill names;
 - DOC-ITRoles-specific labels, milestone model, merge approval, release, and
   acceptance-evidence conventions;
 - the parent-epic reconciliation requirement;
@@ -327,9 +382,11 @@ passed staged validation. Migration is additive and recoverable.
 Completion requires evidence that:
 
 - the public repository and initial release exist;
-- all seven skills validate from the canonical checkout;
+- all eight skills validate from the canonical checkout;
+- `github-repo-bootstrap` has a criterion-by-criterion evidence record from
+  creating and verifying its own canonical repository;
 - staged Claude and Codex installations contain the same `SKILL.md` content;
-- the guide covers all seven skills and all three tracks;
+- the guide covers all eight skills and all three tracks;
 - public-content scanning finds no company-specific material;
 - release notes and changelog identify the bootstrap contents;
 - the DOC-ITRoles integration document points to the verified release; and


### PR DESCRIPTION
Closes #216

## Summary
- add the DOC-ITRoles integration guide pinned to the verified v0.1.0 skills release
- document local issue, acceptance, merge, release, browser-CI, and security conventions
- record the adoption under CHANGELOG [Unreleased] and complete the implementation plan evidence

## Scope decisions
- reusable policy remains in the released public skills repository
- DOC-ITRoles keeps only repository-specific conventions
- no DOC-ITRoles version bump is included for this documentation change

## Evidence
- v0.1.0 release: https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/releases/tag/v0.1.0
- Markdown lint: 0 issues
- npm test: 279/279 passed
- npm run validate: 0 errors; 199 known KPI warnings
- git diff --check: clean
- all hosted PR checks passed, including Chromium/Firefox/WebKit journeys