### PR TITLE
release: 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-08-11
+
+The catalogue now has durable URLs and a single validated configuration for
+its domain and chapter structure. Repository workflow guidance and pinned
+automation dependencies also move forward with the catalogue.
+
 ### Added
 
+- **Shareable, reload-safe catalogue routes (#181).** Roles, comparisons,
+  matrices, and registered documents have canonical URLs that survive reload,
+  browser Back/Forward navigation, and direct sharing. Viewer titles provide
+  useful browser-tab context, and Copy link exposes the canonical URL.
 - **Versioned GitHub workflow guidance (#216).** DOC-ITRoles now documents its
   repository-specific adoption of the public
   [`DOC-GitHub-Practice-Skills` v0.1.0 release](https://github.com/JeanKadang/DOC-GitHub-Practice-Skills/releases/tag/v0.1.0),
   including issue, acceptance, merge, release, browser-CI, and security-routing
   conventions.
+
+### Changed
+
+- **Central catalogue configuration (#184).** Chapters, domains, labels,
+  icons, ordering, and legacy aliases now come from one validated source shared
+  by the server, viewer, metadata helpers, counts, and generators. The FinOps
+  directory is canonicalised as `Roles/finops` while legacy routes still work.
+- **Pinned GitHub Actions dependencies (#217).** CI uses the refreshed,
+  commit-pinned checkout, Node setup, Markdown lint, and artifact-upload
+  actions.
 
 ## [1.16.0] - 2026-08-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roles-master",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roles-master",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@axe-core/playwright": "4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
Refs #220

## Summary

- bump package and lockfile versions from 1.16.0 to 1.17.0
- add the dated v1.17.0 changelog section
- document the shareable-route, workflow-guidance, Actions-maintenance, and
  central-catalogue changes shipped since v1.16.0

## Release contents

- #181 — shareable, reload-safe routes and contextual document titles
- #216 — repository-specific GitHub workflow guidance
- #217 — refreshed pinned GitHub Actions dependencies
- #184 — central catalogue configuration and canonical `finops` path

## Verification

- `npm test` — 300 passed, 0 failed
- `npm run validate` — exit 0; 0 errors, 199 existing non-strict KPI warnings,
  0 duplicate titles
- `npm run check-counts` — 226 roles, 34 domains, 7 chapters
- `npm run verify-vendor` — passed
- Markdown lint — 0 errors
- release version assertion — package, lock root, and lock package are 1.17.0
- `git diff --check` — clean

## Publication

Issue #220 intentionally remains open after this PR merges. It closes only
after the annotated `v1.17.0` tag and GitHub release are published and verified.
