### PR TITLE
fix: escape backslashes before pipes in KPI metric cells

### DIFF
--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -1379,6 +1379,16 @@ test('parseKpiBullet escapes a pipe so it cannot break the table', () => {
     assert.equal(parseKpiBullet('Uptime | availability').metric, 'Uptime \\| availability');
 });
 
+// A backslash already in the bullet must be escaped before the pipe is, or
+// the escape the line above depends on is itself escaped away and the column
+// breaks anyway.
+test('parseKpiBullet escapes a backslash so it cannot cancel the pipe escape', () => {
+    assert.equal(
+        parseKpiBullet(String.raw`Uptime \| availability`).metric,
+        String.raw`Uptime \\\| availability`,
+    );
+});
+
 // ── proposedKpiTarget (#140) ──────────────────────────────
 // Seeds a recognised industry benchmark for the metric families that have
 // one. Every value is marked "(proposed)" so it cannot be mistaken for an

--- a/test/viewer-logic.test.js
+++ b/test/viewer-logic.test.js
@@ -1289,11 +1289,14 @@ test('orgListHtml adds no lead line to a node without one', () => {
     assert.doesNotMatch(orgListHtml({ name: 'Role', file: 'r.md' }), /lead:/);
 });
 
-test('orgListHtml escapes names and file paths', () => {
-    const html = orgListHtml({ name: '<img src=x onerror=alert(1)>', file: '"><script>' });
-    assert.doesNotMatch(html, /<img/);
-    assert.doesNotMatch(html, /<script>/);
-    assert.match(html, /&lt;img/);
+// Tag casing is matched case-insensitively: HTML tag names are not
+// case-sensitive, so a lower-case-only assertion would pass while "<SCRIPT>"
+// survived escaping.
+test('orgListHtml escapes names and file paths whatever the tag casing', () => {
+    const html = orgListHtml({ name: '<IMG src=x onerror=alert(1)>', file: '"><script>' });
+    assert.doesNotMatch(html, /<img/i);
+    assert.doesNotMatch(html, /<script>/i);
+    assert.match(html, /&lt;IMG/);
 });
 
 test('graphListHtml lists each node with its relationships and chapter', () => {

--- a/viewer-logic.js
+++ b/viewer-logic.js
@@ -827,7 +827,9 @@
 
         return {
             // A pipe would silently split the cell and shift every column.
-            metric:    raw.replace(/\|/g, '\\|'),
+            // Backslashes go first, or an existing "\|" turns into "\\|" —
+            // an escaped backslash followed by a live column separator.
+            metric:    raw.replace(/\\/g, '\\\\').replace(/\|/g, '\\|'),
             target:    target ? target[0].replace(/\s+/g, ' ').trim() : '—',
             frequency: cadence ? FREQ[cadence[0].toLowerCase()] : '—',
         };


### PR DESCRIPTION
Closes #223.

Clears both open CodeQL alerts on the repository.

## 1. `js/incomplete-sanitization` — `viewer-logic.js:830` (production)

`parseKpiBullet` escaped a pipe so a KPI bullet could not break out of its markdown table cell, but left backslashes alone:

```js
metric: raw.replace(/\|/g, '\|'),
```

A bullet containing a literal `\|` became `\|` after the replace — an escaped backslash followed by a *live* column separator. That is precisely the column shift the escape exists to prevent.

Fix — escape backslashes first, so the pipe escape cannot itself be escaped away:

```js
metric: raw.replace(/\/g, '\\').replace(/\|/g, '\|'),
```

The test was written first and confirmed failing for the right reason:

```
actual:   'Uptime \| availability'
expected: 'Uptime \\| availability'
```

The pre-existing pipe test passed only because it never fed a backslash, so it could not have caught this.

## 2. `js/bad-tag-filter` — `test/viewer-logic.test.js:1295` (test hardening)

`assert.doesNotMatch(html, /<script>/)` is case-sensitive, so it would not have caught a surviving `<SCRIPT>`. HTML tag names are not case-sensitive, so the assertion read stronger than it was.

Added the `i` flag and made the input use an upper-case tag, so the test exercises the casing it now claims to cover.

There is no production defect here — `escapeHtml` escapes `<` regardless of casing — so this could not be driven by a failing test. Instead the assertion was verified honest by mutation: removing the `<` escape from `escapeHtml` makes it fail on `<IMG`, which the previous lower-case-only pattern would have let through.

## Verification

- `npm test` — 301/301 pass (was 300)
- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `npx playwright test --workers=1` — 48/48 pass, no viewer regression
- Mutation check on the escaping assertion, described above

## Scope

- The backslash defect is latent, not live: no role file currently has a backslash in a KPI bullet, so behaviour is unchanged for all existing catalogue content.
- `parseKpiBullet` has one definition and one call site, so there is no duplicated escaping elsewhere to correct.
