### PR TITLE
fix: run the browser suite serially everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ Consumers must read domain labels, icons, chapter membership, and order from
 - For a credential change, include the registry ID, authoritative issuer URL, verification date, and `npm run validate` output; use the canonical marker in every audited role recommendation.
 - Update an ADR when the change creates or reverses a durable taxonomy decision.
 - Run `npm test`, `npm run validate`, `npm run check-counts`, and any focused generator or verifier command affected by the change.
+- For a viewer change, also run `npm run test:browser`. It drives Chromium, Firefox, and WebKit serially and takes roughly two and a half minutes; the projects share one server, so it is deliberately not parallel. A failure there is a real defect — re-run it rather than assuming a flake, and if it does prove intermittent, file it.
 - Keep generated output, documentation links, and the changelog consistent with the implementation.
 
 Security vulnerabilities and credentials must not be filed in a public issue; follow [SECURITY.md](SECURITY.md).

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,8 +7,15 @@ module.exports = defineConfig({
   testDir: './test/browser',
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
+  // CI retries once to absorb runner noise. Locally a flake stays visible:
+  // papering over it is how an intermittent defect reaches CI in the first
+  // place.
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Serial everywhere (#222). fullyParallel is off, but that only orders the
+  // tests within a file — without this the three browser projects still run
+  // concurrently against the single webServer below, and the contention
+  // failed a different three tests on every local run.
+  workers: 1,
   reporter: process.env.CI
     ? [['line'], ['html', { outputFolder: 'playwright-report', open: 'never' }]]
     : 'list',

--- a/test/playwright-config.test.js
+++ b/test/playwright-config.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// The browser suite drives three browser projects against a single webServer.
+// Letting Playwright pick its own worker count locally (half the CPU cores)
+// made those projects contend, and the suite failed a different three tests on
+// every run — timeouts, not product defects (#222). These tests pin the
+// setting that keeps a local run as trustworthy as a CI run.
+
+const CONFIG_PATH = path.resolve(__dirname, '..', 'playwright.config.js');
+
+// The config reads process.env.CI at module load, so each load needs a fresh
+// require and its own environment.
+function loadConfig({ ci }) {
+    const previous = process.env.CI;
+
+    if (ci) {
+        process.env.CI = 'true';
+    } else {
+        delete process.env.CI;
+    }
+
+    delete require.cache[require.resolve(CONFIG_PATH)];
+
+    try {
+        return require(CONFIG_PATH);
+    } finally {
+        if (previous === undefined) {
+            delete process.env.CI;
+        } else {
+            process.env.CI = previous;
+        }
+        delete require.cache[require.resolve(CONFIG_PATH)];
+    }
+}
+
+test('the browser suite runs serially, so the projects cannot contend', () => {
+    assert.equal(loadConfig({ ci: false }).workers, 1);
+});
+
+test('local and CI runs use the same worker count', () => {
+    assert.equal(loadConfig({ ci: false }).workers, loadConfig({ ci: true }).workers);
+});

--- a/test/playwright-config.test.js
+++ b/test/playwright-config.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const Module = require('node:module');
 
 // The browser suite drives three browser projects against a single webServer.
 // Letting Playwright pick its own worker count locally (half the CPU cores)
@@ -10,10 +11,33 @@ const path = require('node:path');
 
 const CONFIG_PATH = path.resolve(__dirname, '..', 'playwright.config.js');
 
+// The Tests CI job runs `npm test` with no install step at all — the repo has
+// no runtime dependencies, so there is no node_modules there. Stub the one
+// dev-dependency the config imports, so asserting on the config does not
+// quietly require the whole Playwright package to be present.
+// `defineConfig` is identity in Playwright too, so this reads the config as
+// authored.
+function stubPlaywright() {
+    const originalLoad = Module._load;
+
+    Module._load = function (request, ...rest) {
+        if (request === '@playwright/test') {
+            return {
+                defineConfig: config => config,
+                devices: new Proxy({}, { get: () => ({}) }),
+            };
+        }
+        return originalLoad.call(this, request, ...rest);
+    };
+
+    return () => { Module._load = originalLoad; };
+}
+
 // The config reads process.env.CI at module load, so each load needs a fresh
 // require and its own environment.
 function loadConfig({ ci }) {
     const previous = process.env.CI;
+    const restoreLoad = stubPlaywright();
 
     if (ci) {
         process.env.CI = 'true';
@@ -26,6 +50,7 @@ function loadConfig({ ci }) {
     try {
         return require(CONFIG_PATH);
     } finally {
+        restoreLoad();
         if (previous === undefined) {
             delete process.env.CI;
         } else {


### PR DESCRIPTION
Closes #222.

## Problem

`playwright.config.js` set `workers: process.env.CI ? 1 : undefined`, so a local run used Playwright's default of half the CPU cores. `fullyParallel: false` only orders tests *within* a file — the three browser projects still ran concurrently against the single `webServer`.

The result was a suite that failed a different three tests on every run, always as timeouts rather than assertion failures, while the same suite passed completely at `--workers=1`. A local suite less reliable than CI trains maintainers to distrust or skip it.

## Fix

- `workers: 1` unconditionally, so local and CI runs behave identically.
- `retries` stays CI-only, now with a comment giving the reason: CI retries once to absorb runner noise, while locally a flake should stay visible rather than be papered over.
- `CONTRIBUTING.md` records the ~2.5 minute runtime and says the suite is deliberately serial, so the cost is not a surprise and a failure is not dismissed as a flake.

## Test

`test/playwright-config.test.js` pins both settings. Written first and observed failing for the right reason:

```
the browser suite runs serially, so the projects cannot contend
  actual: undefined, expected: 1
local and CI runs use the same worker count
  actual: undefined, expected: 1
```

The config reads `process.env.CI` at module load, so each assertion loads it fresh under its own environment.

## Verification

- `npm run test:browser` — **three consecutive runs, 48/48 each**, 2.2m / 2.1m / 2.0m. This is the acceptance criterion; one green run would not have demonstrated it.
- `npm test` — 303/303 pass (was 301)
- `markdownlint-cli2 CONTRIBUTING.md` — 0 issues

## Note

This changes only how the suite is *scheduled*; no test or viewer behaviour changes. The trade is ~2.1 minutes serial against a suite whose result can be trusted.
