### PR TITLE
release: 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.17.1] - 2026-08-11
+
+A maintenance release. Both of the repository's open code-scanning alerts are
+cleared, and the browser suite is as trustworthy locally as it is on CI. No
+catalogue content or viewer behaviour changes.
+
+### Fixed
+
+- **KPI table cells escape backslashes before pipes (#223).** A KPI bullet
+  containing a literal `\|` previously became `\\|` — an escaped backslash
+  followed by a live column separator, which is the exact column shift the
+  escape exists to prevent. Latent rather than live: no role file currently
+  contains a backslash in a KPI bullet, so no rendered output changes.
+- **The browser suite runs serially everywhere (#222).** `workers` was left
+  unset off CI, so the three browser projects ran concurrently against a single
+  server and the suite failed a different three tests on every local run, always
+  as timeouts. Local and CI runs now use the same worker count.
+
+### Changed
+
+- **Escaping assertions match tag casing case-insensitively (#223).** A
+  lower-case-only assertion would not have caught a surviving `<SCRIPT>`. No
+  production change; `escapeHtml` was already casing-agnostic.
+- **Contribution guidance records the browser-suite cost (#222).** The PR
+  checklist states the roughly two-and-a-half minute runtime, notes the suite is
+  deliberately serial, and says a failure should be re-run rather than assumed
+  to be a flake.
+
 ## [1.17.0] - 2026-08-11
 
 The catalogue now has durable URLs and a single validated configuration for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roles-master",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roles-master",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "UNLICENSED",
       "devDependencies": {
         "@axe-core/playwright": "4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
Cuts the 1.17.1 maintenance release.

## Contents

Two merged PRs since v1.17.0:

- #224 — KPI table cells escape backslashes before pipes, and escaping assertions match tag casing case-insensitively (closes #223)
- #225 — the browser suite runs serially everywhere (closes #222)

Both of the repository's open code-scanning alerts are now `fixed`, and the open alert count is **0**.

## Why a patch

Fixes only. No new behaviour, no catalogue content change, and no rendered output change — the KPI escaping defect is latent, since no role file currently contains a backslash in a KPI bullet.

## This PR

- `package.json` and `package-lock.json` to 1.17.1
- `CHANGELOG.md` gains a `## [1.17.1] - 2026-08-11` section with Fixed and Changed entries referencing #222 and #223

## Verification

Run on this branch before opening:

- `npm test` — 303/303 pass
- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `npm run check-counts` — 226 roles / 34 domains / 7 chapters, README matches
- `npm run verify-vendor` — manifest and checksums verified
- `markdownlint-cli2 CHANGELOG.md` — 0 issues

The browser suite was run five times across the two fix branches and merged `main`, 48/48 every time.

## After merge

Tag `v1.17.1` on updated `main` and publish the release. The milestone stays **open** — Catalogue Trust & Adoption still has open issues (#179, #180, #186, #187, #210, #140), so this release does not close it.
