### PR TITLE
feat: add a reproducible credential inventory and decompose the rollout

### DIFF
--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -30,6 +30,21 @@ function normalize(text) {
     return String(text).replace(/^﻿/, '').replace(/\r\n/g, '\n');
 }
 
+// Strip to a fixed point: one pass over `<!-- ... -->` leaves the outer opener
+// behind when a comment encloses another, so the marker survives into the
+// credential name.
+function stripComments(value) {
+    let out = String(value);
+    let previous;
+    do {
+        previous = out;
+        out = out.replace(/<!--[\s\S]*?-->/g, '');
+    } while (out !== previous);
+    // A lazy match consumes `<!--<!-- x -->` and leaves the trailing `-->`
+    // orphaned; drop any delimiter that outlived its comment.
+    return out.replace(/<!--|-->/g, '');
+}
+
 // Returns the body of the certification section, or '' when a role has none.
 // Sliced by index deliberately: with the /m flag a `$` end-anchor matches a line
 // end, which silently yields an empty section.
@@ -108,7 +123,7 @@ function inventoryRole(text) {
         if (LEARNING_SUBHEAD.test(subhead)) continue;
 
         const marker = raw.match(CREDENTIAL_MARKER);
-        const name = raw.replace(/<!--[\s\S]*?-->/g, '').replace(/\s+/g, ' ').trim();
+        const name = stripComments(raw).replace(/\s+/g, ' ').trim();
         if (!name) continue;
 
         if (marker) {

--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -1,0 +1,235 @@
+'use strict';
+
+// Inventories the legacy credential text still present in the catalogue, so the
+// rollout in #210 can be split into bounded, reviewable batches and its progress
+// re-measured after each one.
+//
+// This reports; it never edits a role file.
+//
+// The certification sections are not uniform, and the variation distorts a naive
+// bullet count in both directions:
+//
+//   * some roles carry a flat list *and* "**Complementary Certifications:**"
+//     subheads naming the same credentials again;
+//   * some write "Complementary certifications:" as a bullet, not a subhead;
+//   * many pack several credentials into one comma-joined bullet.
+//
+// So an "entry" here is one credential-shaped claim, not one bullet.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
+const CREDENTIAL_MARKER = /<!--\s*credential:\s*([a-z0-9]+(?:-[a-z0-9]+)*)\s*-->/;
+
+// Bullets under these subheads are reading material, not credentials. See the
+// "Courses and organisation programmes" rule in docs/CREDENTIAL_REGISTRY.md.
+const LEARNING_SUBHEAD = /learning|resource|communit|training/i;
+
+function normalize(text) {
+    return String(text).replace(/^﻿/, '').replace(/\r\n/g, '\n');
+}
+
+// Returns the body of the certification section, or '' when a role has none.
+// Sliced by index deliberately: with the /m flag a `$` end-anchor matches a line
+// end, which silently yields an empty section.
+function certificationSection(text) {
+    const body = normalize(text);
+    const heading = body.match(/^## [^\n]*Certification[^\n]*$/mi);
+    if (!heading) return '';
+
+    const rest = body.slice(heading.index + heading[0].length);
+    const next = rest.search(/\n## /);
+    return next === -1 ? rest : rest.slice(0, next);
+}
+
+// "Oracle Certified Master, Java Architect" is one credential; "Docker
+// Certified Associate, CompTIA Security+, and ITIL 4 Foundation" is three.
+// Only split when the bullet reads as a list: three or more comma-separated
+// parts, or two joined by "and"/"or" where both sides look self-contained.
+function splitJoined(value) {
+    const parts = value.split(/,\s*(?:and\s+|or\s+)?|\s+and\s+|\s+or\s+/i)
+        .map(part => part.trim())
+        .filter(Boolean);
+
+    if (parts.length < 3) return [value];
+    // A trailing fragment such as "Java Architect" is a continuation of the
+    // preceding name, not a credential of its own.
+    if (parts.some(part => part.split(/\s+/).length < 2)) return [value];
+    return parts;
+}
+
+// One key per credential, so "Microsoft Certified: Identity and Access
+// Administrator", its "Associate" spelling, and its "(SC-300)" spelling group
+// together.
+function aliasKey(name) {
+    return String(name)
+        .toLowerCase()
+        .replace(/\([^)]*\)/g, ' ')
+        .replace(/\b(certification|certifications|certificate|certified|associate|professional|expert|fundamentals|foundation)\b/g, ' ')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+}
+
+// A family or a topic is not an individual credential and must not become a
+// registry record; a vague claim has to be rewritten before it can be audited.
+function classifyEntry(name) {
+    const value = String(name).trim();
+
+    if (/\bor\s+(other|similar|equivalent)\b/i.test(value)) return 'vague';
+    if (/\b(certifications|certificates)\b/i.test(value)) return 'family';
+    if (/\b(fundamentals|basics|essentials)\b/i.test(value)) return 'topic';
+    return 'credential';
+}
+
+// Every credential-shaped claim in one role's certification section.
+function inventoryRole(text) {
+    const section = certificationSection(text);
+    if (!section) return [];
+
+    const entries = [];
+    let subhead = '';
+
+    for (const line of section.split('\n')) {
+        const heading = line.match(/^\*\*(.+?):?\*\*\s*$/);
+        if (heading) { subhead = heading[1]; continue; }
+
+        const bullet = line.match(/^\s*[-*]\s+(.*\S)\s*$/);
+        if (!bullet) continue;
+
+        const raw = bullet[1].trim();
+
+        // A bullet that is only a label introduces the bullets beneath it.
+        if (/^[^:]+:$/.test(raw.replace(/\*\*/g, ''))) {
+            subhead = raw.replace(/\*\*/g, '').replace(/:$/, '');
+            continue;
+        }
+
+        if (LEARNING_SUBHEAD.test(subhead)) continue;
+
+        const marker = raw.match(CREDENTIAL_MARKER);
+        const name = raw.replace(/<!--[\s\S]*?-->/g, '').replace(/\s+/g, ' ').trim();
+        if (!name) continue;
+
+        if (marker) {
+            entries.push({ name, marked: true, credentialId: marker[1], subhead });
+            continue;
+        }
+
+        for (const part of splitJoined(name)) {
+            entries.push({ name: part, marked: false, credentialId: null, subhead });
+        }
+    }
+
+    return entries;
+}
+
+// --- reporting -------------------------------------------------------------
+
+function roleFiles(dir = ROLES_DIR, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) roleFiles(full, out);
+        else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(full);
+    }
+    return out;
+}
+
+// Roles carrying both a flat list and subhead groups repeat the same
+// credentials twice; those duplicates have to be reconciled before a batch can
+// migrate the role cleanly.
+function sectionShape(text) {
+    const section = certificationSection(text);
+    if (!section) return 'none';
+
+    const lines = section.split('\n');
+    const firstSubhead = lines.findIndex(line => /^\*\*/.test(line));
+    const hasSubheads = firstSubhead !== -1;
+    const hasFlat = lines.some((line, index) =>
+        /^\s*[-*]\s+\S/.test(line) && (!hasSubheads || index < firstSubhead));
+
+    if (hasFlat && hasSubheads) return 'mixed';
+    if (hasFlat) return 'flat';
+    if (hasSubheads) return 'grouped';
+    return 'empty';
+}
+
+function buildInventory() {
+    const registry = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'data', 'credentials.json'), 'utf8'));
+    const audited = new Set(registry.audited_roles);
+
+    const domains = new Map();
+    const aliases = new Map();
+    const shapes = { none: 0, flat: 0, grouped: 0, mixed: 0, empty: 0 };
+
+    for (const file of roleFiles()) {
+        const rel = path.relative(path.dirname(ROLES_DIR), file).split(path.sep).join('/');
+        const text = fs.readFileSync(file, 'utf8');
+        const domain = rel.split('/')[1];
+
+        shapes[sectionShape(text)]++;
+
+        if (!domains.has(domain)) {
+            domains.set(domain, { roles: 0, audited: 0, legacy: 0, migrated: 0, affected: new Set(), mixed: 0 });
+        }
+        const stats = domains.get(domain);
+        stats.roles++;
+        if (audited.has(rel)) stats.audited++;
+        if (sectionShape(text) === 'mixed') stats.mixed++;
+
+        for (const entry of inventoryRole(text)) {
+            if (entry.marked) { stats.migrated++; continue; }
+            stats.legacy++;
+            stats.affected.add(rel);
+
+            const key = aliasKey(entry.name);
+            if (!aliases.has(key)) aliases.set(key, { spellings: new Map(), domains: new Set(), total: 0, kind: classifyEntry(entry.name) });
+            const alias = aliases.get(key);
+            alias.spellings.set(entry.name, (alias.spellings.get(entry.name) || 0) + 1);
+            alias.domains.add(domain);
+            alias.total++;
+        }
+    }
+
+    return { domains, aliases, shapes };
+}
+
+function report() {
+    const { domains, aliases, shapes } = buildInventory();
+
+    const legacy = [...domains.values()].reduce((total, d) => total + d.legacy, 0);
+    const migrated = [...domains.values()].reduce((total, d) => total + d.migrated, 0);
+    const kinds = { credential: 0, family: 0, topic: 0, vague: 0 };
+    for (const alias of aliases.values()) kinds[alias.kind] += alias.total;
+
+    console.log(`Legacy credential entries: ${legacy}   migrated: ${migrated}`);
+    console.log(`Distinct credentials after alias grouping: ${aliases.size}`);
+    console.log('');
+    console.log('Entries by kind:');
+    console.log(`  credential ${String(kinds.credential).padStart(5)}   auditable as an individual credential`);
+    console.log(`  family     ${String(kinds.family).padStart(5)}   a group, not one credential — must be rewritten or dropped`);
+    console.log(`  topic      ${String(kinds.topic).padStart(5)}   a subject, not a credential`);
+    console.log(`  vague      ${String(kinds.vague).padStart(5)}   "or other ..." — unverifiable as written`);
+    console.log('');
+    console.log('Certification section shapes:');
+    console.log(`  grouped ${String(shapes.grouped).padStart(4)}   subheads only`);
+    console.log(`  mixed   ${String(shapes.mixed).padStart(4)}   flat list AND subheads — duplicated recommendations`);
+    console.log(`  flat    ${String(shapes.flat).padStart(4)}   no subheads`);
+    console.log(`  none    ${String(shapes.none).padStart(4)}   no certification section`);
+    console.log('');
+    console.log('Legacy entries by domain:');
+    console.log('  legacy  roles  mixed  domain');
+    for (const [domain, stats] of [...domains].filter(([, s]) => s.legacy > 0).sort((a, b) => b[1].legacy - a[1].legacy)) {
+        console.log(`  ${String(stats.legacy).padStart(6)}  ${String(stats.affected.size).padStart(5)}  ${String(stats.mixed).padStart(5)}  ${domain}`);
+    }
+    console.log('');
+    console.log('Cross-cutting credentials (3+ domains), audit once and reuse everywhere:');
+    for (const [, alias] of [...aliases].filter(([, a]) => a.domains.size >= 3 && a.kind === 'credential').sort((a, b) => b[1].total - a[1].total).slice(0, 25)) {
+        const spellings = [...alias.spellings.keys()];
+        console.log(`  ${String(alias.total).padStart(3)}  ${String(alias.domains.size).padStart(2)}d  ${spellings[0].slice(0, 64)}${spellings.length > 1 ? `  (+${spellings.length - 1} spelling(s))` : ''}`);
+    }
+}
+
+if (require.main === module) report();
+
+module.exports = { certificationSection, inventoryRole, aliasKey, classifyEntry, sectionShape, buildInventory };

--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -30,19 +30,46 @@ function normalize(text) {
     return String(text).replace(/^﻿/, '').replace(/\r\n/g, '\n');
 }
 
-// Strip to a fixed point: one pass over `<!-- ... -->` leaves the outer opener
-// behind when a comment encloses another, so the marker survives into the
-// credential name.
+// Removes HTML comments from a bullet so the credential name is left behind.
+//
+// Scanned rather than pattern-replaced, for two reasons a regex kept getting
+// wrong: a lazy `<!--[\s\S]*?-->` matches from the first opener to the first
+// closer, so a comment enclosing another leaves the outer `<!--` in the name;
+// and `-->` is not the only terminator HTML accepts — `--!>` closes a comment
+// too, so a filter that knows only `-->` under-reads the text.
+const COMMENT_OPEN = '<!--';
+const COMMENT_ENDS = ['-->', '--!>'];
+
+function firstEnd(value) {
+    let at = -1;
+    let length = 0;
+    for (const end of COMMENT_ENDS) {
+        const index = value.indexOf(end);
+        if (index !== -1 && (at === -1 || index < at)) { at = index; length = end.length; }
+    }
+    return { at, length };
+}
+
 function stripComments(value) {
-    let out = String(value);
-    let previous;
-    do {
-        previous = out;
-        out = out.replace(/<!--[\s\S]*?-->/g, '');
-    } while (out !== previous);
-    // A lazy match consumes `<!--<!-- x -->` and leaves the trailing `-->`
-    // orphaned; drop any delimiter that outlived its comment.
-    return out.replace(/<!--|-->/g, '');
+    let rest = String(value);
+    let out = '';
+
+    for (;;) {
+        const open = rest.indexOf(COMMENT_OPEN);
+        if (open === -1) { out += rest; break; }
+
+        out += rest.slice(0, open);
+        const after = rest.slice(open + COMMENT_OPEN.length);
+        const end = firstEnd(after);
+        // An unterminated comment swallows the remainder, as a parser would.
+        if (end.at === -1) break;
+        rest = after.slice(end.at + end.length);
+    }
+
+    // A nested comment leaves its outer terminator orphaned once the inner one
+    // has been consumed; drop any delimiter that outlived its comment.
+    for (const end of COMMENT_ENDS) out = out.split(end).join('');
+    return out.split(COMMENT_OPEN).join('');
 }
 
 // Returns the body of the certification section, or '' when a role has none.

--- a/test/credential-inventory.test.js
+++ b/test/credential-inventory.test.js
@@ -132,6 +132,19 @@ test('a nested comment is stripped completely, leaving no marker in the name', (
     assert.doesNotMatch(entries[0].name, /<!--/);
 });
 
+// `--!>` closes an HTML comment as surely as `-->`; a stripper that knows only
+// the latter leaves the comment body in the credential name.
+test('a comment closed with --!> is stripped as well', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- CompTIA Security+ <!-- stray --!>',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.deepEqual(entries.map(e => e.name), ['CompTIA Security+']);
+});
+
 test('aliasKey groups the spellings of one credential', () => {
     const key = aliasKey('Microsoft Certified: Identity and Access Administrator Associate (SC-300)');
     assert.equal(aliasKey('Microsoft Certified: Identity and Access Administrator'), key);

--- a/test/credential-inventory.test.js
+++ b/test/credential-inventory.test.js
@@ -1,0 +1,136 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+    certificationSection,
+    inventoryRole,
+    aliasKey,
+    classifyEntry,
+} = require('../scripts/credential-inventory.js');
+
+// The catalogue's certification sections are not uniform, and the differences
+// distort a naive bullet count in both directions (#210):
+//
+//   * 97 roles carry a flat list *and* "**Complementary Certifications:**"
+//     subheads naming the same credentials again — double counting;
+//   * 24 roles write "Complementary certifications:" as a bullet rather than a
+//     subhead — a non-credential counted as one;
+//   * 172 roles pack several credentials into one comma-joined bullet —
+//     undercounting.
+//
+// These tests pin the reading of each shape, so the batch sizes derived from
+// the inventory are trustworthy.
+
+function fixture(body) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-inv-'));
+    const file = path.join(dir, 'role.md');
+    // Role files carry a BOM and CRLF endings.
+    fs.writeFileSync(file, `﻿# Role\n\n${body}\n`.replace(/\n/g, '\r\n'));
+    return file;
+}
+
+test('certificationSection reads the section despite a BOM and CRLF endings', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- Certified Kubernetes Administrator (CKA)',
+        '',
+        '## Next Section',
+        '',
+        '- Not a credential',
+    ].join('\n'));
+
+    const section = certificationSection(fs.readFileSync(file, 'utf8'));
+    assert.match(section, /Certified Kubernetes Administrator/);
+    assert.doesNotMatch(section, /Not a credential/);
+});
+
+test('learning-resource subheads are excluded from credential entries', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '**Core Certifications:**',
+        '',
+        '- Certified Kubernetes Administrator (CKA)',
+        '',
+        '**Learning Resources and Communities:**',
+        '',
+        '- Postman Learning Center',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.deepEqual(entries.map(e => e.name), ['Certified Kubernetes Administrator (CKA)']);
+});
+
+test('a bullet ending in a colon is a subhead, not a credential', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- Complementary certifications:',
+        '  - Docker Certified Associate',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.deepEqual(entries.map(e => e.name), ['Docker Certified Associate']);
+});
+
+test('a comma-joined bullet is split into one entry per credential', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- Docker Certified Associate, CompTIA Security+, and ITIL 4 Foundation',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.deepEqual(
+        entries.map(e => e.name),
+        ['Docker Certified Associate', 'CompTIA Security+', 'ITIL 4 Foundation'],
+    );
+});
+
+test('a comma inside a credential name does not split it', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- Oracle Certified Master, Java Architect',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.deepEqual(entries.map(e => e.name), ['Oracle Certified Master, Java Architect']);
+});
+
+test('an already-marked bullet is reported as migrated, not as legacy text', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].marked, true);
+    assert.equal(entries[0].credentialId, 'cncf-cka');
+    assert.equal(entries[0].name, 'Certified Kubernetes Administrator (CKA)');
+});
+
+test('aliasKey groups the spellings of one credential', () => {
+    const key = aliasKey('Microsoft Certified: Identity and Access Administrator Associate (SC-300)');
+    assert.equal(aliasKey('Microsoft Certified: Identity and Access Administrator'), key);
+    assert.equal(aliasKey('Microsoft Certified: Identity and Access Administrator Associate'), key);
+});
+
+test('aliasKey keeps genuinely different credentials apart', () => {
+    assert.notEqual(aliasKey('Certified Kubernetes Administrator (CKA)'), aliasKey('Certified Kubernetes Application Developer (CKAD)'));
+});
+
+test('classifyEntry separates credentials from families, topics and vague claims', () => {
+    assert.equal(classifyEntry('Certified Kubernetes Administrator (CKA)'), 'credential');
+    assert.equal(classifyEntry('ITIL Service Management certifications'), 'family');
+    assert.equal(classifyEntry('Cloud platform associate certifications'), 'family');
+    assert.equal(classifyEntry('TOGAF or other enterprise architecture certification'), 'vague');
+    assert.equal(classifyEntry('Web security fundamentals'), 'topic');
+    assert.equal(classifyEntry('Docker and container basics'), 'topic');
+});

--- a/test/credential-inventory.test.js
+++ b/test/credential-inventory.test.js
@@ -116,6 +116,22 @@ test('an already-marked bullet is reported as migrated, not as legacy text', () 
     assert.equal(entries[0].name, 'Certified Kubernetes Administrator (CKA)');
 });
 
+// Stripping comments in a single pass leaves a marker behind when one comment
+// encloses another: removing the inner `<!-- x -->` re-forms nothing, but the
+// outer opener survives into the credential name.
+test('a nested comment is stripped completely, leaving no marker in the name', () => {
+    const file = fixture([
+        '## Recommended Certifications & Learning Paths',
+        '',
+        '- CompTIA Security+ <!--<!-- stray -->-->',
+    ].join('\n'));
+
+    const entries = inventoryRole(fs.readFileSync(file, 'utf8'));
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].name, 'CompTIA Security+');
+    assert.doesNotMatch(entries[0].name, /<!--/);
+});
+
 test('aliasKey groups the spellings of one credential', () => {
     const key = aliasKey('Microsoft Certified: Identity and Access Administrator Associate (SC-300)');
     assert.equal(aliasKey('Microsoft Certified: Identity and Access Administrator'), key);


### PR DESCRIPTION
Refs #210. Delivers acceptance criteria 1 and 2 — the inventory and the decomposition. The migration itself is the sub-issues, not this PR.

## Why a script rather than a one-off count

The first count I took was a naive bullet count: 1,884 legacy bullets. It was wrong in both directions, because the catalogue's certification sections are not uniform:

- **97 roles** carry a flat list *and* `**Complementary Certifications:**` subheads naming the same credentials again — double counting.
- **24 roles** write `Complementary certifications:` as a bullet rather than a subhead — a non-credential counted as one.
- **172 roles** pack several credentials into one comma-joined bullet — undercounting.

Counting credential-shaped *claims* instead gives **2,166**, of which **524** are families, topics, or vague "or other …" text that can never become registry records. Batch sizes come straight from these numbers, so getting them right had to come before filing anything.

Keeping the script in the repo makes the criterion-1 evidence re-runnable after each batch, so rollout progress is measured rather than asserted.

## What it reports

```
Legacy credential entries: 2166   migrated: 25
Distinct credentials after alias grouping: 1100

Entries by kind:
  credential  1642   auditable as an individual credential
  family       398   a group, not one credential
  topic         94   a subject, not a credential
  vague         32   "or other ..." -- unverifiable as written

Certification section shapes:
  grouped  121   subheads only
  mixed     97   flat list AND subheads -- duplicated recommendations
  flat       8   no subheads
  none       1   no certification section
```

Plus legacy entries per domain, and the cross-cutting credentials with their alias groups — `FinOps Certified Practitioner` alone appears in 14 spellings.

The script reports and never edits a role file.

## Test

Nine tests written first, each pinning a shape found in the real catalogue: BOM/CRLF handling, learning-resource exclusion, bullet-as-subhead, comma-joined splitting, and the case that must *not* split (`Oracle Certified Master, Java Architect` is one credential, not two). Also `aliasKey` grouping and the family/topic/vague classification.

A parser bug is exactly what these guard: the first version used a `$` end-anchor under the `/m` flag, where `$` matches a *line* end, and silently captured an empty section for every role — reporting 0 bullets across 227 files.

## Decomposition

19 native sub-issues on #210, each with a milestone, labels, and assignee. The first three are prerequisites — structure normalisation (#227), family/topic policy (#228), and the cross-cutting credential audit (#229) — because without them every domain batch re-audits shared credentials and guesses at duplicated lists.

## Verification

- `npm test` — 312/312 pass (was 303)
- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `node scripts/credential-inventory.js` — output above

## Scope

No role file, registry record, or `audited_roles` entry changes here. #210 stays open until its batches land.
