### PR TITLE
fix: stop classifying real certifications as families and topics

### DIFF
--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -105,21 +105,39 @@ function splitJoined(value) {
 // Administrator", its "Associate" spelling, and its "(SC-300)" spelling group
 // together.
 function aliasKey(name) {
-    return String(name)
+    const normalized = String(name)
         .toLowerCase()
         .replace(/\([^)]*\)/g, ' ')
         .replace(/\b(certification|certifications|certificate|certified|associate|professional|expert|fundamentals|foundation)\b/g, ' ')
         .replace(/[^a-z0-9]+/g, ' ')
         .trim();
+
+    // Stripped this far, a specific credential and a generic family collide --
+    // "Certified Cloud Security Professional (CCSP)" and "Cloud security
+    // certifications" both reduce to "cloud security". Keying on the kind as
+    // well keeps them apart, so a family cannot absorb a credential and hand it
+    // its own classification (#248).
+    return `${classifyEntry(name)}:${normalized}`;
 }
 
 // A family or a topic is not an individual credential and must not become a
 // registry record; a vague claim has to be rewritten before it can be audited.
+// A single parenthesised exam or credential code — (AZ-900), (MS-900), (CCSP) —
+// names one specific, individually-held credential. A list of them, as in
+// "Kubernetes certifications (CKA, CKAD)", does not, which is why the plural
+// family test runs first.
+const EXAM_CODE = /\(([A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*)\)/;
+
 function classifyEntry(name) {
     const value = String(name).trim();
 
     if (/\bor\s+(other|similar|equivalent)\b/i.test(value)) return 'vague';
     if (/\b(certifications|certificates)\b/i.test(value)) return 'family';
+    // Several real Microsoft certifications are named "... Fundamentals", so the
+    // wording alone cannot rule a credential out; the code decides (#248).
+    // "Microsoft Certified: ... Fundamentals" and "Microsoft 365 Certified:
+    // Fundamentals" are certification brandings, not subject descriptions.
+    if (EXAM_CODE.test(value) || /\bCertified:/.test(value)) return 'credential';
     if (/\b(fundamentals|basics|essentials)\b/i.test(value)) return 'topic';
     return 'credential';
 }

--- a/test/credential-inventory.test.js
+++ b/test/credential-inventory.test.js
@@ -155,6 +155,40 @@ test('aliasKey keeps genuinely different credentials apart', () => {
     assert.notEqual(aliasKey('Certified Kubernetes Administrator (CKA)'), aliasKey('Certified Kubernetes Application Developer (CKAD)'));
 });
 
+// Several real Microsoft certifications are literally named "Fundamentals", so
+// the word alone cannot mean "not a credential". A parenthesised exam code is
+// decisive evidence of an individually-held credential (#248).
+test('an exam code outweighs the fundamentals wording', () => {
+    assert.equal(classifyEntry('Microsoft Azure Fundamentals (AZ-900)'), 'credential');
+    assert.equal(classifyEntry('Microsoft 365 Certified: Fundamentals (MS-900)'), 'credential');
+    assert.equal(classifyEntry('Certified Cloud Security Professional (CCSP)'), 'credential');
+});
+
+// aliasKey strips level and certification wording to group spellings. Stripped
+// far enough, a specific credential and a generic family collide -- and the
+// group then inherits one kind for both (#248).
+test('aliasKey does not merge a credential with a generic family', () => {
+    assert.notEqual(
+        aliasKey('Certified Cloud Security Professional (CCSP)'),
+        aliasKey('Cloud security certifications'),
+    );
+});
+
+// "Certified:" is certification branding, not a subject description, so it
+// carries the same weight as an exam code even when the code is omitted.
+test('Certified: branding outweighs the fundamentals wording', () => {
+    assert.equal(classifyEntry('Microsoft Certified: Security, Compliance, and Identity Fundamentals'), 'credential');
+    assert.equal(classifyEntry('Microsoft 365 Certified: Fundamentals'), 'credential');
+    // No branding and no code: a subject, and the audit decides otherwise.
+    assert.equal(classifyEntry('Linux fundamentals'), 'topic');
+});
+
+test('classifyEntry still recognises a genuine family', () => {
+    assert.equal(classifyEntry('Cloud platform associate certifications'), 'family');
+    assert.equal(classifyEntry('ITIL Service Management certifications'), 'family');
+    assert.equal(classifyEntry('Kubernetes certifications (CKA, CKAD)'), 'family');
+});
+
 test('classifyEntry separates credentials from families, topics and vague claims', () => {
     assert.equal(classifyEntry('Certified Kubernetes Administrator (CKA)'), 'credential');
     assert.equal(classifyEntry('ITIL Service Management certifications'), 'family');


### PR DESCRIPTION
Closes #248. Blocks #228 until merged — that decision cannot be made on the figures the inventory was publishing.

## Problem

The inventory reported 524 entries as families, topics, or vague text. Preparing the #228 decision showed that bucket contained real, individually-held certifications:

| Entry | Entries | Was | Is |
|---|---|---|---|
| `Certified Cloud Security Professional (CCSP)` | 18 | family | credential |
| `Microsoft Azure Fundamentals (AZ-900)` | 17 | topic | credential |
| `Microsoft 365 Certified: Fundamentals (MS-900)` | 13 | family | credential |
| `VMware Certified Professional` | 9 | family | credential |

**Defect 1 — `aliasKey` merged across kinds.** It strips `certified`, `professional`, `fundamentals` and friends to group spelling variants, which collapsed a specific credential and a generic family onto one key:

```
aliasKey('Certified Cloud Security Professional (CCSP)')  ->  "cloud security"
aliasKey('Cloud security certifications')                 ->  "cloud security"
```

`buildInventory` then took the group's kind from whichever entry it saw first, so an 18-entry credential inherited `family` from a generic neighbour.

**Defect 2 — real credentials are named "Fundamentals".** `classifyEntry` read the word as a subject marker, but `Microsoft Certified: Azure Fundamentals (AZ-900)` is a certification.

## Fix

- Key aliases by kind, so a family can never absorb a credential.
- Treat a single parenthesised exam code or `Certified:` branding as decisive evidence of a credential.
- The plural family test runs **first**, so `Kubernetes certifications (CKA, CKAD)` stays a family — a list of codes is not one credential.

## Corrected figures

| Kind | Was | Now |
|---|---|---|
| credential | 1642 | **1690** |
| family | 398 | **384** |
| topic | 94 | **57** |
| vague | 32 | **35** |

The 2,166 total is unchanged: this was a classification error, never a parsing one.

## Known residue, left deliberately

`Microsoft Azure Fundamentals` without its code still reads as a topic. Separating that from `Linux fundamentals` needs issuer knowledge, which is the audit in #229 — not something a heuristic should guess. The remaining 57 topic entries are a review list, not a verdict.

## Verification

- `npm test` — 318/318 pass (was 314)
- `npm run validate` — 0 errors, warnings unchanged
- Four new tests, each written first and observed failing on the exact misclassification above

## Follow-up

#210 and #228 carry the old figures in their bodies and comments; both are corrected once this merges.
