### PR TITLE
docs: decide how non-credential text is rewritten

### DIFF
--- a/docs/CREDENTIAL_REGISTRY.md
+++ b/docs/CREDENTIAL_REGISTRY.md
@@ -79,3 +79,17 @@ Migrate the remaining catalogue in bounded domain or role-family batches:
 5. Add completed roles to `audited_roles` only when every certification bullet is deliberately covered, then run validation.
 
 Legacy prose stays unaudited until that work is complete. The durable tracker for unaudited domains and rollout batches is [issue #210](https://github.com/JeanKadang/DOC-ITRoles/issues/210); do not treat its open scope as verified merely because the text remains in a role file.
+
+Run `node scripts/credential-inventory.js` before and after a batch. It reports the legacy entries that remain, grouped by domain and by alias, so rollout progress is measured rather than asserted. It reports only; it never edits a role file.
+
+## Text that does not name a credential
+
+Not every certification bullet names a credential a person can hold. Around 476 legacy entries name a group, a subject, or an alternative, and none can become a registry record. The rule, decided in [ADR-0003](adr/0003-name-credentials-explicitly-rather-than-families-or-topics.md), is that **a credential recommendation names one credential a person can hold, or it is not a credential recommendation**.
+
+| Kind | Looks like | What to do |
+|---|---|---|
+| Family | `Cloud platform associate certifications`, `ITIL Service Management certifications` | Expand to the specific credentials the role actually expects, each registry-backed. If no set is determinable, name what the domain genuinely expects or drop the line — never retain the family as-is. |
+| Topic | `Linux fundamentals`, `REST API Design fundamentals` | Audit before judging. Some are real credentials with the exam code omitted — `Microsoft Azure Fundamentals` is AZ-900. Register those; treat whatever remains a genuine subject as a family. |
+| Vague | `TOGAF or other enterprise architecture certification`, `CISSP or equivalent` | Rewrite to the named credential. Do not preserve the hedge: a reader cannot act on "or equivalent" and a validator cannot verify it. Where several credentials genuinely qualify, name each one. |
+
+Two contributors applying these rules to the same entry should produce the same result. Where an entry is genuinely ambiguous, resolve it in the domain batch with the reasoning visible in the pull request, rather than inventing a local convention.

--- a/docs/adr/0003-name-credentials-explicitly-rather-than-families-or-topics.md
+++ b/docs/adr/0003-name-credentials-explicitly-rather-than-families-or-topics.md
@@ -1,0 +1,51 @@
+# ADR-0003: Name credentials explicitly rather than families or topics
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Issue/PR:** #228
+
+## Context
+
+The credential registry established in #178 records credentials that have been audited against an issuer-controlled source. Rolling it out across the remaining domains (#210) surfaced 476 legacy entries that cannot become registry records at all, because they do not name an individually-held credential:
+
+| Kind | Entries | Distinct | Example |
+|---|---|---|---|
+| family | 384 | 269 | `Cloud platform associate certifications`, `ITIL Service Management certifications` |
+| topic | 57 | 46 | `Linux fundamentals`, `REST API Design fundamentals` |
+| vague | 35 | 26 | `TOGAF or other enterprise architecture certification` |
+
+`docs/CREDENTIAL_REGISTRY.md` already excluded families and organisation programmes from the registry, but said nothing about what should replace them in a role. Sixteen domain batches migrating in parallel would each have invented an answer, and the catalogue would end up recommending credentials inconsistently — the precise failure the registry exists to prevent.
+
+These counts come from `scripts/credential-inventory.js`. An earlier version of that script misclassified real certifications as families and topics (#248); the figures above are the corrected ones.
+
+## Decision
+
+**A credential recommendation names one credential a person can hold, or it is not a credential recommendation.**
+
+Three rules follow, one per kind.
+
+### Families are expanded to named credentials
+
+Replace a family with the specific credentials it means, each registry-backed. `Cloud platform associate certifications` becomes the named associate certifications for the platforms the role actually works with — not all of them by reflex.
+
+Where a family names no determinable set, it is not rewritten into a guess. Raise it in the domain batch and either name the credentials the domain genuinely expects, or drop the line. A family retained as-is is not an acceptable outcome.
+
+### Topics are audited before they are judged
+
+A topic is only a topic once an audit says so. Several real certifications appear in the catalogue with the exam code omitted — `Microsoft Azure Fundamentals` is AZ-900 — and are indistinguishable from a genuine subject such as `Linux fundamentals` without issuer knowledge.
+
+So the cross-cutting audit (#229) resolves each topic entry first. What is a real credential becomes a registry record; what remains a subject is then treated as a family under the rule above.
+
+### Vague alternatives are rewritten to the named credential
+
+`X or other Y certification` becomes `X`. `X or equivalent` becomes `X`.
+
+The hedge is not preserved. A reader cannot act on "or equivalent", and a validator cannot verify it. Where several credentials genuinely qualify, name each one explicitly rather than gesturing at a category.
+
+## Consequences
+
+- Every certification bullet in a migrated role names a credential that a person can hold and that has been checked against its issuer.
+- The rollout is more work than deleting the 476 entries would have been, and it requires a judgement per family about which credentials a domain expects. That judgement belongs in the domain batch, with the reasoning visible in the PR.
+- Roles lose the latitude "or equivalent" implied. Where that latitude was real, it must be made explicit by naming the alternatives — which is the point.
+- Some of the 57 topic entries will turn out to be credentials during #229. The topic count is a review list, not a verdict.
+- A future contributor adding `Security architecture certifications` to a role is now contradicting a recorded decision rather than filling a gap.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ Allowed statuses are `Proposed`, `Accepted`, `Deprecated`, and `Superseded by AD
 |---|---|---|
 | [0001](0001-organise-domains-into-seven-capability-chapters.md) | Accepted | Organise domains into seven capability chapters |
 | [0002](0002-separate-technical-product-and-people-leadership-tracks.md) | Accepted | Separate technical, product, and people-leadership tracks |
+| [0003](0003-name-credentials-explicitly-rather-than-families-or-topics.md) | Accepted | Name credentials explicitly rather than families or topics |


### PR DESCRIPTION
Closes #228. Records the decision you made on how non-credential text is rewritten, so sixteen parallel domain batches apply one rule rather than sixteen.

## The problem this settles

476 legacy entries name a group, a subject, or an alternative rather than a credential a person can hold. None can become a registry record. `docs/CREDENTIAL_REGISTRY.md` already excluded them, but said nothing about what should *replace* them in a role.

| Kind | Entries | Distinct | Example |
|---|---|---|---|
| family | 384 | 269 | `Cloud platform associate certifications` |
| topic | 57 | 46 | `Linux fundamentals` |
| vague | 35 | 26 | `TOGAF or other enterprise architecture certification` |

## The decision

**A credential recommendation names one credential a person can hold, or it is not a credential recommendation.**

- **Families expand** to the specific credentials the role actually expects, each registry-backed. Where no set is determinable, name what the domain genuinely expects or drop the line — retaining the family as-is is not an acceptable outcome.
- **Topics are audited before they are judged.** Several real certifications appear with the exam code omitted — `Microsoft Azure Fundamentals` is AZ-900 — and cannot be told from a genuine subject such as `Linux fundamentals` without issuer knowledge. #229 resolves each one first.
- **Vague alternatives are rewritten** to the named credential. The hedge is not preserved: a reader cannot act on "or equivalent" and a validator cannot verify it. Where several credentials genuinely qualify, name each.

Recorded as [ADR-0003](docs/adr/0003-name-credentials-explicitly-rather-than-families-or-topics.md), with an operational table in `CREDENTIAL_REGISTRY.md` that a contributor can apply entry by entry.

The rollout policy section also now points at `scripts/credential-inventory.js`, so batches measure progress rather than assert it.

## Trade-off accepted

Expanding families is materially more work than deleting them, and needs a judgement per family about which credentials a domain expects. That judgement belongs in the domain batch with the reasoning visible in the PR. Roles also lose the latitude "or equivalent" implied — where that latitude was real, it must now be made explicit by naming the alternatives, which is the point.

## Verification

- `npm test` — 318/318 pass
- `markdownlint-cli2` on the changed docs — 0 issues
- ADR index updated; ADR follows the repo's existing Context / Decision / Consequences shape

## Scope

Documentation only. No role file, registry record, or `audited_roles` entry changes here — the batches do that, under this rule.
