### PR TITLE
refactor: give every certification section one shape

### DIFF
--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -173,6 +173,8 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google Apigee Certified API Architect
 - MuleSoft Certified Platform Architect
 - AWS Advanced Networking Specialty
@@ -181,17 +183,16 @@ The API Platform Architect designs comprehensive strategies and architectures fo
 - API Security certifications
 - Cloud Architecture certifications with API focus
 - GraphQL Advanced certifications
-- Complementary certifications:
-  - Kubernetes certifications (CKA, CKAD)
-  - Event-Driven Architecture certifications
-  - System Design Expert
-  - Security architecture certifications
-  - Enterprise Integration Patterns
 
 **Complementary Certifications:**
 
+- Kubernetes certifications (CKA, CKAD)
+- Event-Driven Architecture certifications
+- System Design Expert
+- Security architecture certifications
+- Enterprise Integration Patterns
 - Cloud platform architect certifications (AWS/Azure/GCP), Certified Kubernetes Administrator (CKA), event-driven/Kafka certifications, and TOGAF for enterprise architecture alignment
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - API Academy (apiacademy.co), Nordic APIs blog (nordicapis.com), AsyncAPI community, Postman Learning Center, Google Apigee documentation, Kong Academy, and API The Docs conference content

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -173,6 +173,8 @@ The API Platform Engineer implements and maintains API management solutions acro
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google Apigee API Engineer certification
 - MuleSoft Certified Developer
 - AWS API Gateway Developer certification
@@ -183,17 +185,16 @@ The API Platform Engineer implements and maintains API management solutions acro
 - GraphQL Developer certification
 - API Security fundamentals
 - Postman API certification
-- Complementary certifications:
-  - Docker and container basics
-  - CI/CD pipeline certifications
-  - Cloud platform associate certifications
-  - Web security fundamentals
-  - Microservices fundamentals
 
 **Complementary Certifications:**
 
+- Docker and container basics
+- CI/CD pipeline certifications
+- Cloud platform associate certifications
+- Web security fundamentals
+- Microservices fundamentals
 - Docker and container basics, cloud platform associate certifications (AWS/Azure/GCP), web security fundamentals (OWASP), and CI/CD pipeline certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Postman Learning Center (learning.postman.com), OWASP API Security Top 10, OpenAPI Specification docs, vendor tutorials (Apigee, Kong, Azure APIM), and API Academy free courses

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -170,6 +170,8 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - API Product Management certifications
 - Google Apigee API Product Manager
@@ -180,17 +182,16 @@ The API Platform Product Owner manages the development and lifecycle of the orga
 - SAFe Product Owner/Product Manager
 - Digital Product Management certifications
 - API Monetization and Strategy certification
-- Complementary certifications:
-  - Agile Leadership certifications
-  - Cloud Platform certifications
-  - Digital Transformation strategy
-  - Business Process Management
-  - Change Management certification
 
 **Complementary Certifications:**
 
+- Agile Leadership certifications
+- Cloud Platform certifications
+- Digital Transformation strategy
+- Business Process Management
+- Change Management certification
 - SAFe Product Owner/Product Manager (SAFe POPM), digital product management certifications, ITIL Foundation for service context, and Agile leadership certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Nordic APIs blog, API Academy, Gartner API management research, Postman State of the API report, ProgrammableWeb, and Forrester API platform research

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -171,6 +171,8 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google Apigee Certified API Engineer
 - MuleSoft Certified Platform Architect
 - AWS API Gateway certifications
@@ -180,17 +182,16 @@ The API Platform Senior Engineer leads the implementation and optimization of AP
 - TOGAF certification with API focus
 - Cloud security certifications
 - API security certifications
-- Complementary certifications:
-  - OAuth 2.0 and OpenID Connect certifications
-  - Event-Driven Architecture certifications
-  - Service Mesh certifications
-  - Kafka certifications
-  - Istio Service Mesh certifications
 
 **Complementary Certifications:**
 
+- OAuth 2.0 and OpenID Connect certifications
+- Event-Driven Architecture certifications
+- Service Mesh certifications
+- Kafka certifications
+- Istio Service Mesh certifications
 - OAuth 2.0/OIDC specialist knowledge, Kafka certifications for event-driven APIs, Kubernetes (CKA/CKAD), cloud platform developer certifications (AWS/Azure/GCP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Nordic APIs blog, Kong Academy, Google Apigee training, Azure API Management documentation, Postman Learning Center, AsyncAPI community, and API security resources from OWASP

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -170,6 +170,8 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Solutions Architect Expert
 - Microsoft Certified: DevOps Engineer Expert
 - Microsoft Certified: Azure Security Engineer Associate
@@ -179,17 +181,16 @@ The .NET Architect designs comprehensive strategies and architectures for the or
 - API design certifications
 - DevSecOps certifications
 - TOGAF or other enterprise architecture certification
-- Complementary certifications:
-  - Microsoft Certified: Azure Database Administrator Associate
-  - Certified Kubernetes Administrator
-  - Site Reliability Engineering certifications
-  - Event-Driven Architecture certifications
-  - Serverless architecture certifications
 
 **Complementary Certifications:**
 
+- Microsoft Certified: Azure Database Administrator Associate
+- Certified Kubernetes Administrator
+- Site Reliability Engineering certifications
+- Event-Driven Architecture certifications
+- Serverless architecture certifications
 - TOGAF for enterprise architecture alignment, CISSP, API design certifications, CKAD for cloud-native .NET, and event-driven/Kafka certifications for distributed system patterns
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), .NET Blog (devblogs.microsoft.com/dotnet), dotnet.microsoft.com, NDC Conferences YouTube, .NET Foundation community, and Pluralsight .NET architecture paths

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -172,6 +172,8 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Developer Associate
 - Microsoft Certified: .NET Associate
 - Microsoft 365 Certified Developer Associate
@@ -181,17 +183,16 @@ The .NET Engineer implements and maintains .NET-based applications and platform 
 - Cloud platform associate certifications
 - Web development certifications
 - Entry-level security certifications
-- Complementary certifications:
-  - SQL Server certifications
-  - Git fundamentals
-  - Azure DevOps fundamentals
-  - Agile development methodologies
-  - Web accessibility certifications
 
 **Complementary Certifications:**
 
+- SQL Server certifications
+- Git fundamentals
+- Azure DevOps fundamentals
+- Agile development methodologies
+- Web accessibility certifications
 - SQL Server and database certifications, Git/GitHub fundamentals, ITIL Foundation for service management context, and Agile/Scrum developer certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), dotnet.microsoft.com, ASP.NET documentation, C# Corner community, Pluralsight .NET fundamentals, and the .NET community Discord

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -170,6 +170,8 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Microsoft Azure certifications
 - SAFe Product Owner/Product Manager
@@ -178,17 +180,16 @@ The .NET Platform Product Owner manages the development and lifecycle of the org
 - Technology Business Management
 - DevOps leadership certifications
 - Software Architecture certifications
-- Complementary certifications:
-  - Microsoft 365 certifications
-  - Azure DevOps certifications
-  - ITIL Foundation
-  - Change Management certification
-  - Product Management Professional
 
 **Complementary Certifications:**
 
+- Microsoft 365 certifications
+- Azure DevOps certifications
+- ITIL Foundation
+- Change Management certification
+- Product Management Professional
 - SAFe Product Owner/Product Manager (SAFe POPM), Azure Fundamentals, ITIL Foundation, and Change Management certification for platform upgrade programs
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), .NET Foundation community, Microsoft Build conference content, Pluralsight .NET management paths, and the ASP.NET community resources

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -170,6 +170,8 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Developer Associate
 - Microsoft Certified: DevOps Engineer Expert
 - Microsoft Certified: Azure Solutions Architect Expert
@@ -178,17 +180,16 @@ The .NET Senior Engineer leads the implementation and optimization of complex .N
 - Design patterns and software architecture certifications
 - Azure certifications for .NET hosting
 - DevSecOps certifications
-- Complementary certifications:
-  - Microsoft Certified: Azure Security Engineer Associate
-  - Certified Kubernetes Application Developer
-  - Certified Scrum Developer
-  - GitHub Actions certification
-  - Container security certifications
 
 **Complementary Certifications:**
 
+- Microsoft Certified: Azure Security Engineer Associate
+- Certified Kubernetes Application Developer
+- Certified Scrum Developer
+- GitHub Actions certification
+- Container security certifications
 - Certified Kubernetes Application Developer (CKAD), GitHub Actions certification, container security certifications, and CISSP for broader security engineering context
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), ASP.NET Community Standup (YouTube), .NET Blog (devblogs.microsoft.com/dotnet), Pluralsight .NET paths, NDC Conferences, and dotnet.microsoft.com

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -170,6 +170,8 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Oracle Certified Master, Java Architect
 - Spring Professional certification
 - Cloud platform architect certifications
@@ -180,17 +182,16 @@ The Java Platform Architect designs comprehensive strategies and architectures f
 - TOGAF or other enterprise architecture certification
 - Cloud native architect certifications
 - Microservices architecture certifications
-- Complementary certifications:
-  - Domain-Driven Design certification
-  - Event-Driven Architecture certification
-  - Certified Scrum Professional
-  - AWS Professional/Expert certifications
-  - Azure Expert certifications
 
 **Complementary Certifications:**
 
+- Domain-Driven Design certification
+- Event-Driven Architecture certification
+- Certified Scrum Professional
+- AWS Professional/Expert certifications
+- Azure Expert certifications
 - TOGAF for enterprise architecture alignment, domain-driven design (DDD) certifications, cloud architect certifications (AWS/Azure/GCP), and event-driven/Kafka certifications for distributed Java systems
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - dev.java, Spring.io blog, InfoQ Java (infoq.com), Devoxx conference recordings, Baeldung.com, Java Magazine, and Coursera cloud-native Java specializations

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -172,6 +172,8 @@ The Java Engineer implements and maintains Java-based applications and platform 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Oracle Certified Associate Java Programmer
 - Oracle Certified Professional Java Developer
 - Spring Professional certification
@@ -180,17 +182,16 @@ The Java Engineer implements and maintains Java-based applications and platform 
 - Web development certifications
 - Entry-level security certifications
 - Agile development certifications
-- Complementary certifications:
-  - Git and GitHub certifications
-  - Jenkins Essentials
-  - JUnit and Test-Driven Development
-  - REST API development
-  - SQL and database fundamentals
 
 **Complementary Certifications:**
 
+- Git and GitHub certifications
+- Jenkins Essentials
+- JUnit and Test-Driven Development
+- REST API development
+- SQL and database fundamentals
 - Git and GitHub fundamentals, Docker container basics, SQL and database fundamentals, ITIL Foundation, and REST API design principles
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Baeldung.com, Spring.io getting started guides, dev.java, Oracle Java tutorials, Pluralsight Java fundamentals, and the r/java and JVMLS community

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -171,6 +171,8 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Java Platform Strategy certification
 - Oracle Java platform certifications
@@ -181,17 +183,16 @@ The Java Platform Product Owner manages the development and lifecycle of the org
 - Enterprise Architecture fundamentals
 - Software Product Management Professional
 - Cloud Platform Product Management certification
-- Complementary certifications:
-  - ITIL Foundation
-  - Project Management Professional (PMP)
-  - AWS Cloud Practitioner
-  - Azure Fundamentals
-  - Certified Scrum Master (CSM)
 
 **Complementary Certifications:**
 
+- ITIL Foundation
+- Project Management Professional (PMP)
+- AWS Cloud Practitioner
+- Azure Fundamentals
+- Certified Scrum Master (CSM)
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL Foundation, Agile leadership certifications, and cloud platform fundamentals (AWS/Azure)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Spring.io community, Devoxx conference content, InfoQ Java platform articles, Scrum.org community, Oracle Java platform resources, and Java developer community at dev.java

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -171,6 +171,8 @@ The Java Senior Engineer leads the implementation and optimization of complex Ja
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Oracle Certified Professional Java Developer
 - Spring Professional certification
 - Cloud platform certifications for Java workloads

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -180,6 +180,8 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - AWS Certified Solutions Architect Professional (SAP-C02)
 - AWS Certified DevOps Engineer Professional
 - AWS Certified Security Specialty
@@ -195,6 +197,6 @@ The AWS Cloud Platform Architect designs, implements, and governs cloud solution
 
 - Azure or GCP architect certifications for multi-cloud context, Agile/SAFe certifications, network and security architecture certifications, and ITIL for service management context
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AWS Well-Architected Framework documentation, AWS re:Invent sessions, A Cloud Guru/Pluralsight AWS paths, AWS Training (aws.training), and the AWS Community Builders program

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -169,6 +169,8 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - AWS Certified Solutions Architect - Associate
 - AWS Certified Developer - Associate
 - AWS Certified SysOps Administrator - Associate
@@ -182,6 +184,6 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 - Linux certifications (LPIC-1, LFCS), Kubernetes fundamentals (CKAD), Docker Certified Associate, ITIL Foundation, and Python or Bash scripting proficiency
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AWS Skill Builder (skillbuilder.aws), A Cloud Guru, Pluralsight AWS tracks, Linux Foundation training, and AWS User Group community events

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -164,6 +164,8 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - AWS Certified Cloud Practitioner
 - AWS Certified Solutions Architect - Associate
@@ -177,6 +179,6 @@ The AWS Cloud Platform Product Owner manages the organization's Amazon Web Servi
 
 - SAFe Product Owner/Product Manager (SAFe POPM), FinOps Certified Practitioner (FCP), Agile certifications, and CISM or equivalent for cloud security awareness
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AWS Well-Architected Framework, FinOps Foundation (finops.org), AWS Skill Builder business tracks, AWS Partner Network content, and cloud economics resources from AWS

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -169,6 +169,8 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - AWS Certified Solutions Architect - Professional
 - AWS Certified DevOps Engineer - Professional
 - AWS Certified Security - Specialty
@@ -182,6 +184,6 @@ The AWS Cloud Senior Engineer leads the implementation and optimization of compl
 
 - Certified Kubernetes Administrator (CKA), Terraform Associate, Linux certifications (RHCE, LFCS), CISSP or AWS Security Specialty for deeper security focus
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AWS Training and Skill Builder (aws.training), A Cloud Guru, Pluralsight AWS paths, AWS re:Invent recordings, and the AWS community Slack and Discord communities

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -174,6 +174,8 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Solutions Architect Expert (AZ-305)
 - Microsoft Certified: DevOps Engineer Expert (AZ-400)
 - Microsoft Certified: Azure Security Engineer Associate (AZ-500)
@@ -189,6 +191,6 @@ The Azure Cloud Platform Architect designs, implements, and governs cloud soluti
 
 - AWS or GCP architect certifications for multi-cloud context, TOGAF for enterprise architecture, CISSP, Agile/SAFe certifications, and FinOps Certified Practitioner
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), Azure Architecture Center, Azure Friday YouTube series, A Cloud Guru Azure paths, and Microsoft Tech Community forums

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -165,6 +165,8 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Administrator Associate
 - Microsoft Certified: Azure Developer Associate
 - Microsoft Certified: Azure Security Engineer Associate
@@ -178,6 +180,6 @@ The Azure Cloud Engineer implements and maintains cloud resources and services i
 
 - Microsoft 365 certifications, PowerShell scripting proficiency, Linux fundamentals, ITIL Foundation, and Docker/Kubernetes fundamentals for container-hosted workloads
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), AZ-104 study resources, A Cloud Guru, Pluralsight Azure tracks, and the Azure community Discord and Microsoft Tech Community forums

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -164,6 +164,8 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Microsoft Certified: Azure Fundamentals
 - Microsoft Certified: Azure Solutions Architect
@@ -177,6 +179,6 @@ The Azure Cloud Platform Product Owner manages the organization's Azure cloud se
 
 - SAFe Product Owner/Product Manager (SAFe POPM), FinOps Certified Practitioner (FCP), ITIL 4 Foundation, and Agile certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), Azure Architecture Center, FinOps Foundation (finops.org), Microsoft Tech Community, and Azure customer success stories and case studies

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -168,6 +168,8 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Solutions Architect Expert
 - Microsoft Certified: DevOps Engineer Expert
 - Microsoft Certified: Azure Security Engineer Associate
@@ -181,6 +183,6 @@ The Azure Cloud Senior Engineer leads the implementation and optimization of com
 
 - Certified Kubernetes Administrator (CKA), Terraform Associate, Windows Server/Entra ID certifications, CISSP, and AWS or GCP associate-level certifications for multi-cloud awareness
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), A Cloud Guru Azure paths, Pluralsight Azure tracks, Azure Architecture Center, and Microsoft Tech Community forums

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -159,6 +159,8 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Solutions Architect Expert (AZ-305)
 - AWS Certified Solutions Architect – Professional
 - Google Professional Cloud Architect
@@ -171,6 +173,6 @@ The Cloud Lead Architect provides technical leadership across a cluster of cloud
 
 - Cloud security certifications across all three major providers, CISSP, and leadership/management training (e.g., ITIL 4 Strategist, Agile leadership)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AWS Architecture Blog, Azure Architecture Center, Google Cloud Architecture Framework, CNCF, FinOps Foundation, and multi-cloud architecture community forums

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -165,6 +165,8 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure Solutions Architect Expert (AZ-305)
 - AWS Certified Solutions Architect – Professional
 - Google Professional Cloud Architect
@@ -177,6 +179,6 @@ The Cloud Principal Architect is the organization's foremost individual contribu
 
 - Distinguished contributor status in cloud provider programs (e.g., Microsoft MVP, AWS Hero, Google Developer Expert), executive leadership programs, and enterprise architecture specializations
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Gartner and Forrester cloud research, CNCF, Cloud Native Security Con, FinOps Foundation, AWS re:Invent, Microsoft Ignite, Google Cloud Next, and internal architecture community of practice leadership

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -174,6 +174,8 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google Cloud Certified Professional Cloud Architect
 - Google Cloud Certified Professional Security Engineer
 - Google Cloud Certified Professional Network Engineer
@@ -190,6 +192,6 @@ The Google Cloud Architect designs comprehensive cloud solutions using Google Cl
 
 - AWS or Azure architect certifications for multi-cloud context, Kubernetes (CKA/CKS), TOGAF for enterprise architecture, CCSP for cloud security, and FinOps Certified Practitioner
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google Cloud training (cloud.google.com/learn), Coursera Google Cloud specializations, A Cloud Guru GCP paths, Google Cloud Architecture Center, and Google Cloud Community events

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -169,6 +169,8 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google Cloud Certified - Associate Cloud Engineer
 - Google Cloud Certified - Professional Cloud Developer
 - Certified Kubernetes Administrator (CKA)
@@ -182,6 +184,6 @@ The Google Cloud Engineer implements and maintains cloud resources and services 
 
 - Kubernetes fundamentals (CKAD), Linux certifications (LPIC-1), Terraform Associate, Python scripting proficiency, and ITIL Foundation for service management context
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google Cloud Skills Boost (cloud.google.com/learn), Coursera Google Cloud Engineer path, A Cloud Guru, HashiCorp Learn for Terraform, and Google Cloud Community user groups

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -168,6 +168,8 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Google Cloud Certified - Professional Cloud Architect
 - Google Cloud Certified - Associate Cloud Engineer
@@ -181,6 +183,6 @@ The Google Cloud Product Owner manages the development and lifecycle of the orga
 
 - SAFe Product Owner/Product Manager (SAFe POPM), FinOps Certified Practitioner (FCP), Google Cloud Fundamentals certification, ITIL 4 Foundation, and Agile certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google Cloud training (cloud.google.com/learn), FinOps Foundation (finops.org), Coursera Google Cloud management tracks, Scrum.org community, and Google Cloud case studies and customer success content

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -169,6 +169,8 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google Cloud Professional Cloud Architect
 - Google Cloud Professional Security Engineer
 - Google Cloud Professional Network Engineer
@@ -182,6 +184,6 @@ The Google Cloud Senior Engineer leads the implementation and optimization of co
 
 - Certified Kubernetes Administrator (CKA), BigQuery or data engineering certifications, Terraform Associate, Linux certifications (RHCE, LFCS), and CCSP for cloud security depth
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google Cloud Skills Boost (cloud.google.com/learn), Coursera Google Cloud specializations, A Cloud Guru GCP paths, GCP architecture documentation, and the Google Cloud Community

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -169,22 +169,23 @@ The Qumulo Storage Architect designs and oversees the implementation of enterpri
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Qumulo Certified Storage Expert
 - SNIA Certified Storage Architect
 - TOGAF Certified Architect
 - AWS/Azure/GCP Cloud Architecture certifications
 - CDMP (Certified Data Management Professional)
-- Complementary certifications:
-  - Enterprise Architecture certifications
-  - Data Governance certifications
-  - ITIL Expert
-  - Security certifications (CISSP)
-  - Business continuity planning certifications
 
 **Complementary Certifications:**
 
+- Enterprise Architecture certifications
+- Data Governance certifications
+- ITIL Expert
+- Security certifications (CISSP)
+- Business continuity planning certifications
 - SNIA Certified Storage Architect, TOGAF, cloud architecture certifications (AWS Solutions Architect/Azure Solutions Architect), and CISSP for storage security governance
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Qumulo documentation and community (community.qumulo.com), SNIA technical resources and whitepapers (snia.org), AWS storage design patterns for Qumulo Shift integration, and storage architecture practitioner blogs and SNIA educational sessions

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -165,6 +165,8 @@ The Qumulo Storage Engineer is responsible for the implementation, configuration
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Qumulo Certified Administrator
 - Qumulo Certified Professional
 - SNIA Storage Networking certifications

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -188,22 +188,23 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Qumulo Certified Administrator
 - Certified Data Storage Professional
 - SNIA Storage Networking Certification
 - AWS Storage Specialty
-- Complementary certifications:
-  - Microsoft Azure Storage certification
-  - Project Management Professional (PMP)
-  - ITIL 4 Foundation
-  - SAFe Product Owner/Product Manager
-  - Certified Agile Service Manager
 
 **Complementary Certifications:**
 
+- Microsoft Azure Storage certification
+- Project Management Professional (PMP)
+- ITIL 4 Foundation
+- SAFe Product Owner/Product Manager
+- Certified Agile Service Manager
 - SAFe Product Owner/Product Manager (SAFe POPM), SNIA Certified Storage Professional (overview level), ITIL 4 Foundation, and cloud storage fundamentals
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Qumulo blog and community (community.qumulo.com), SNIA resources (snia.org), Gartner storage and data management research, Scrum.org product owner resources, and IDC storage market research

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -174,21 +174,22 @@ The Qumulo Storage Senior Engineer leads the implementation and optimization of 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Qumulo Certified Professional
 - Qumulo Certified Administrator
 - SNIA Certified Storage Professional
 - Cloud storage certifications (AWS/Azure/GCP)
-- Complementary certifications:
-  - VMware certifications
-  - Linux administration certifications
-  - Networking certifications
-  - Python scripting certification
-  - Containerization technologies
 
 **Complementary Certifications:**
 
+- VMware certifications
+- Linux administration certifications
+- Networking certifications
+- Python scripting certification
+- Containerization technologies
 - Qumulo Certified Professional (if available), SNIA Certified Storage Professional, cloud storage specialist certifications (AWS/Azure), and Linux administration (RHCE/LFCE) for Qumulo node management
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Qumulo documentation (docs.qumulo.com), Qumulo community forums (community.qumulo.com), SNIA technical training (snia.org), Server Fault storage community, and cross-platform storage performance engineering blogs

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -170,22 +170,23 @@ The Storage Engineer implements and maintains enterprise storage solutions acros
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Dell EMC Storage Administrator
 - NetApp Certified Storage Associate
 - HPE Storage Solutions certification
 - Pure Storage certification
 - SNIA Certified Storage Professional
-- Complementary certifications:
-  - VMware vSAN certification
-  - Entry-level cloud storage certifications
-  - CompTIA Storage+
-  - Microsoft Azure Storage certifications
-  - AWS Storage specialty certification
 
 **Complementary Certifications:**
 
+- VMware vSAN certification
+- Entry-level cloud storage certifications
+- CompTIA Storage+
+- Microsoft Azure Storage certifications
+- AWS Storage specialty certification
 - CompTIA Storage+, VMware vSAN Specialist, SNIA Certified Storage Professional, and cloud storage fundamentals (AZ-104 or AWS SAA, storage domain)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - SNIA community and training (snia.org), storage vendor documentation (NetApp, Dell EMC, HPE, Pure Storage), Server Fault storage community, and storage vendor learning portals (NetApp Learning, HPE Education)

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -170,6 +170,8 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - ITIL Service Management certifications
 - SNIA Storage Networking Certification
@@ -183,6 +185,6 @@ The Storage Product Owner manages the development and lifecycle of the organizat
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, SNIA overview certifications, and cloud storage fundamentals (AZ-900 level)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - SNIA resources (snia.org), Gartner storage and data infrastructure research, IDC storage market analysis, Scrum.org product owner resources, and storage vendor roadmap and industry event content

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -170,6 +170,8 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Dell EMC Implementation Engineer (EMCIE)
 - NetApp Certified Data Administrator (NCDA)
 - HPE ASE - Storage Solutions Architect
@@ -185,6 +187,6 @@ The Storage Senior Engineer leads the implementation and optimization of complex
 
 - SNIA Certified Storage Professional, NetApp Certified Data Administrator (NCDA), Dell EMC Implementation Engineer (EMCIE), or Pure Storage Certified Architect; cloud storage specialist certifications (AWS Storage Specialty or Azure solutions architect level)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - SNIA technical resources and training (snia.org), NetApp Learning Services, Pure Storage technical whitepapers, VMware vSAN documentation, Kubernetes SIG-Storage documentation, and Server Fault storage community

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -168,6 +168,8 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Veeam Certified Engineer (VMCE)
 - Commvault Certified Professional
 - NetBackup Certified Professional
@@ -181,6 +183,6 @@ The Backup Reliability Engineer focuses on ensuring the consistency, reliability
 
 - Prometheus Certified Associate, cloud backup certifications (AWS/Azure), CKA (for cloud-native backup), and chaos engineering practitioner certifications (Gremlin, LitmusChaos)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google SRE books (sre.google), Honeycomb observability blog, Veeam community (community.veeam.com), Commvault community (community.commvault.com), and backup reliability engineering patterns blog content

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -169,22 +169,23 @@ The Commvault Architect designs enterprise data protection strategies and soluti
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Commvault Certified Architect (CCA)
 - Commvault Certified Master (CCM)
 - Certified Data Management Professional (CDMP)
 - Certified Information Systems Security Professional (CISSP)
 - TOGAF or other enterprise architecture certification
-- Complementary certifications:
-  - Cloud architecture certifications
-  - ITIL Expert or Master
-  - Data Governance certifications
-  - AWS Certified Solutions Architect
-  - Microsoft Certified: Azure Solutions Architect
 
 **Complementary Certifications:**
 
+- Cloud architecture certifications
+- ITIL Expert or Master
+- Data Governance certifications
+- AWS Certified Solutions Architect
+- Microsoft Certified: Azure Solutions Architect
 - TOGAF, CISSP, cloud architecture certifications (AWS Solutions Architect/Azure Solutions Architect), and Certified Business Continuity Professional (CBCP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Commvault documentation and community (community.commvault.com), Commvault education portal (education.commvault.com), SNIA data protection track, StorageNewsletter.com, and Gartner backup and recovery market research

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -168,6 +168,8 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Commvault Certified Professional (CCP)
 - Commvault Technical Sales Professional
 - Entry-level storage certifications
@@ -180,6 +182,6 @@ The Commvault Engineer implements and maintains backup and recovery systems usin
 
 - ITIL 4 Foundation, CompTIA Server+ or Linux+, cloud fundamentals (AZ-900 or AWS Cloud Practitioner), and scripting basics (PowerShell/Python)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Commvault education portal (education.commvault.com), Commvault community forums (community.commvault.com), backup certification study resources, and Server Fault backup/recovery community

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -186,6 +186,8 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Commvault Certified Professional
 - Commvault Certified Engineer
 - Commvault Certified Advanced Professional
@@ -201,6 +203,6 @@ The Commvault Product Owner is responsible for maximizing the value of the organ
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, Certified Business Continuity Professional (CBCP), and cloud fundamentals certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - DRII.org (disaster recovery standards), BCI (bci.org), Commvault community and events (community.commvault.com), Scrum.org product owner resources, Gartner backup and recovery research

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -167,22 +167,23 @@ The Commvault Senior Engineer leads the implementation and optimization of enter
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Commvault Certified Professional (CCP)
 - Commvault Certified Master (CCM)
 - Commvault Certified Architect (CCA)
 - Certified Information Systems Security Professional (CISSP)
 - Certified Data Center Professional (CDCP)
-- Complementary certifications:
-  - SNIA Storage Networking certifications
-  - Cloud platform certifications for backup solutions
-  - ITIL certifications
-  - VMware Certified Professional
-  - Microsoft Certified: Azure Administrator
 
 **Complementary Certifications:**
 
+- SNIA Storage Networking certifications
+- Cloud platform certifications for backup solutions
+- ITIL certifications
+- VMware Certified Professional
+- Microsoft Certified: Azure Administrator
 - Commvault Certified Master (CCM), CISSP, cloud backup certifications (AWS/Azure), and Certified Business Continuity Professional (CBCP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Commvault education portal (education.commvault.com), Commvault community forums (community.commvault.com), SNIA data protection track (snia.org), StorageNewsletter.com, and backup technology engineering blogs

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -168,22 +168,23 @@ The SimpliVity Backup Architect designs and oversees data protection strategies 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - HPE Master ASE - SimpliVity Solutions
 - HPE ASE - Storage Solutions
 - VMware Certified Professional - Data Center Virtualization
 - Certified Information Systems Security Professional (CISSP)
 - SNIA Certified Storage Professional
-- Complementary certifications:
-  - Veeam Certified Engineer (VMCE)
-  - Certified Business Continuity Professional (CBCP)
-  - TOGAF Certified
-  - ITIL 4
-  - AWS/Azure/GCP Cloud Storage certifications
 
 **Complementary Certifications:**
 
+- Veeam Certified Engineer (VMCE)
+- Certified Business Continuity Professional (CBCP)
+- TOGAF Certified
+- ITIL 4
+- AWS/Azure/GCP Cloud Storage certifications
 - HPE Master ASE - SimpliVity Solutions, Certified Business Continuity Professional (CBCP), TOGAF, VMware Certified Professional - Data Center Virtualisation (VCP-DCV), and CISSP
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HPE SimpliVity documentation and support portal, HPE education portal (education.hpe.com), VMware documentation, BCI.org business continuity resources, and Veeam tech blog for cross-platform data protection references

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -163,22 +163,23 @@ The SimpliVity Backup Engineer implements and maintains backup and recovery oper
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - HPE SimpliVity Solutions certification
 - VMware Certified Professional
 - HPE Storage certification
 - Backup and recovery fundamentals certification
 - Disaster recovery essentials
-- Complementary certifications:
-  - Business continuity basics
-  - Hyperconverged infrastructure certification
-  - Data protection compliance certification
-  - ITIL Foundation
-  - CompTIA Server+
 
 **Complementary Certifications:**
 
+- Business continuity basics
+- Hyperconverged infrastructure certification
+- Data protection compliance certification
+- ITIL Foundation
+- CompTIA Server+
 - HPE SimpliVity solutions certification, VMware Certified Professional - Data Center Virtualisation (VCP-DCV), ITIL 4 Foundation, and CompTIA Server+
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HPE SimpliVity documentation and support portal, HPE education portal (education.hpe.com), VMware documentation, Server Fault backup/recovery community, and backup fundamentals training content

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -178,6 +178,8 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - HPE SimpliVity certifications
 - VMware certifications
@@ -191,6 +193,6 @@ The SimpliVity Backup Product Owner manages the development and lifecycle of the
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, Certified Business Continuity Professional (CBCP), and HPE SimpliVity overview certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - BCI.org business continuity resources, HPE SimpliVity documentation and community, Scrum.org product owner resources, Gartner backup and recovery research, and DRII.org disaster recovery standards

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -163,6 +163,8 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - HPE Master ASE - Storage Solutions
 - HPE ASE - SimpliVity Solutions
 - Veeam Certified Engineer (VMCE)
@@ -176,6 +178,6 @@ The SimpliVity Backup Senior Engineer leads the implementation and optimization 
 
 - HPE Master ASE - SimpliVity Solutions, VMware Certified Professional - Data Center Virtualisation (VCP-DCV), Certified Business Continuity Professional (CBCP), ITIL 4 Foundation, and scripting certifications (Python/PowerShell)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HPE SimpliVity documentation and support portal, HPE education portal (education.hpe.com), VMware documentation, BCI.org business continuity resources, and Veeam technical blog for cross-platform backup engineering references

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -170,6 +170,8 @@ The Database Architect designs comprehensive data management strategies and arch
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Oracle Certified Master
 - Microsoft Certified: Azure Database Administrator Associate
 - MongoDB Certified Solutions Architect
@@ -179,17 +181,16 @@ The Database Architect designs comprehensive data management strategies and arch
 - CDMP (Certified Data Management Professional)
 - IBM Certified Database Administrator
 - Google Professional Cloud Database Engineer
-- Complementary certifications:
-  - Certified Information Security Manager (CISM)
-  - Certified Data Privacy Solutions Engineer (CDPSE)
-  - ITIL 4 Foundation
-  - Certified Cloud Security Professional (CCSP)
-  - Red Hat Certified Specialist in OpenShift Data Foundation
 
 **Complementary Certifications:**
 
+- Certified Information Security Manager (CISM)
+- Certified Data Privacy Solutions Engineer (CDPSE)
+- ITIL 4 Foundation
+- Certified Cloud Security Professional (CCSP)
+- Red Hat Certified Specialist in OpenShift Data Foundation
 - TOGAF for enterprise architecture alignment, CISSP for data security governance, CDMP (Certified Data Management Professional), and cloud database certifications (AWS Database Specialty, Azure Database Administrator)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - dba.stackexchange.com community, SQLServerCentral (sqlservercentral.com), use-the-index-luke.com (SQL tuning), PostgreSQL documentation, Oracle DBA community, MongoDB developer resources, and VLDB conference content

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -177,6 +177,8 @@ The Database Engineer implements and maintains database systems across the organ
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Oracle Certified Associate (OCA)
 - Microsoft Certified: Azure Database Administrator Associate
 - AWS Database Specialty
@@ -190,6 +192,6 @@ The Database Engineer implements and maintains database systems across the organ
 
 - ITIL Foundation, CompTIA Server+, cloud fundamentals (AZ-900 or AWS Cloud Practitioner), Linux fundamentals (RHCSA/LPIC-1), and scripting basics (Python/PowerShell)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - SQLServerCentral (sqlservercentral.com), use-the-index-luke.com, PostgreSQL documentation (postgresql.org/docs), Oracle Learning Library (education.oracle.com), dba.stackexchange.com, and MySQL documentation

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -186,6 +186,8 @@ The Database Product Owner manages the portfolio of database platforms and data 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - AWS Certified Database - Specialty
 - Microsoft Certified: Azure Database Administrator
@@ -199,6 +201,6 @@ The Database Product Owner manages the portfolio of database platforms and data 
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, CDMP (Certified Data Management Professional), and cloud database associate certifications (AWS/Azure)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - DAMA International (dama.org), TDWI community, Gartner database research, Scrum.org Product Owner resources, and AWS re:Post database track

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -170,6 +170,8 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - AWS Certified Database - Specialty
 - Microsoft Certified: Azure Database Administrator Associate
 - MongoDB Database Administrator
@@ -183,6 +185,6 @@ The Database Reliability Engineer focuses on ensuring the availability, performa
 
 - Cloud database certifications (AWS/GCP/Azure DB Specialty), Prometheus Certified Associate, Certified Kubernetes Administrator (CKA), and chaos engineering practitioner certifications (Gremlin, LitmusChaos)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google SRE books (sre.google), use-the-index-luke.com for SQL performance, pgBadger and pg_activity documentation, dba.stackexchange.com, Percona database blog, and SREcon database-track sessions

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -173,6 +173,8 @@ The Database Senior Engineer leads the implementation and optimization of comple
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Oracle Certified Master (OCM)
 - Microsoft Certified: Azure Database Administrator Associate
 - AWS Certified Database - Specialty
@@ -186,6 +188,6 @@ The Database Senior Engineer leads the implementation and optimization of comple
 
 - Cloud database specialist certifications (AWS Database Specialty, Azure Database Administrator), NoSQL certifications (MongoDB, Cassandra), CDMP (Certified Data Management Professional), and cloud security certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - use-the-index-luke.com (SQL performance), SQLServerCentral (sqlservercentral.com), dba.stackexchange.com, PostgreSQL documentation, Oracle DBA blog, MongoDB developer docs, and DB-Engines ranking and trend analysis (db-engines.com)

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -173,6 +173,8 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - DevOps Institute Architect certification
 - AWS DevOps Professional / Azure DevOps Expert (AZ-400)
 - Certified Kubernetes Administrator (CKA) / Certified Kubernetes Security Specialist (CKS)
@@ -188,6 +190,6 @@ The DevOps Architect designs comprehensive strategies and architectures for enab
 
 - DORA DevOps Research practitioner resources, FinOps Certified Practitioner (pipeline cost awareness), and vendor-specific platform certifications (GitLab Professional, Harness Continuous Delivery Architect).
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - DORA (dora.dev) State of DevOps reports, DevOps Enterprise Summit talks, Thoughtworks Technology Radar, Cloud Native Computing Foundation (CNCF) webinars, Continuous Delivery Foundation (cd.foundation) resources.

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -176,6 +176,8 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - GitHub Actions / GitHub Advanced Security certifications
 - Microsoft Certified: Azure DevOps Engineer Expert (AZ-400)
 - Docker Certified Associate
@@ -189,6 +191,6 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 
 - CompTIA Linux+, Python Institute PCEP (automation scripting), and cloud-specific developer associate certifications (AWS, Azure, GCP).
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - GitHub Learning Lab, Microsoft Learn (AZ-400 DevOps path), KodeKloud (hands-on labs for Kubernetes, Terraform, Ansible), TechWorld with Nana (YouTube), Pluralsight DevOps fundamentals tracks.

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -175,6 +175,8 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - SAFe DevOps Practitioner
 - AWS Certified DevOps Engineer - Professional
@@ -188,6 +190,6 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 
 - FinOps Certified Practitioner (DevOps tooling cost management), ITIL 4 Specialist: Drive Stakeholder Value, and GitHub for Business / Azure DevOps administrator certifications.
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - DORA (dora.dev) research and Four Keys metrics guidance, Continuous Delivery Foundation (cd.foundation), DevOps Enterprise Summit talks (itrevolution.com), Scrum.org PSPO learning paths, Thoughtworks Technology Radar.

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -180,6 +180,8 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - AWS Certified DevOps Engineer - Professional
 - Microsoft Certified: DevOps Engineer Expert
 - Google Professional Cloud DevOps Engineer
@@ -193,6 +195,6 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 
 - Certified Kubernetes Security Specialist (CKS), AWS Certified Security - Specialty (pipeline security), and Harness Continuous Delivery certifications.
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Continuous Delivery Foundation resources (cd.foundation), CNCF KubeCon sessions, GitHub Universe talks, Thoughtworks Technology Radar, DevOps Toolkit YouTube channel (Viktor Farcic), Pluralsight DevOps learning paths.

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -164,6 +164,8 @@ The Windows Active Directory Architect designs AD structure, security models, an
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Identity and Access Administrator
 - Microsoft 365 Certified: Enterprise Administrator Expert
 - Microsoft Certified: Windows Server Hybrid Administrator Associate
@@ -177,6 +179,6 @@ The Windows Active Directory Architect designs AD structure, security models, an
 
 - TOGAF, Microsoft Certified: Azure Solutions Architect Expert, and Certified Information Systems Security Professional (CISSP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), Active Directory security community resources (adsecurity.org), SpectreOps BloodHound community, and Microsoft Tech Community identity and security blogs

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -168,6 +168,8 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Windows Server
 - Microsoft Certified: Identity and Access Management Fundamentals
 - CompTIA Security+
@@ -181,6 +183,6 @@ The Windows Active Directory Engineer maintains directory services and all Tier 
 
 - Microsoft Certified: Identity and Access Administrator Associate, CompTIA Security+, and ITIL 4 Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), Microsoft TechNet library for AD documentation, PowerShell Gallery for AD automation scripts, and Microsoft Tech Community identity and directory services forums

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -164,6 +164,8 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Microsoft Certified: Identity and Access Administrator
 - Microsoft 365 Certified: Enterprise Administrator Expert
@@ -177,6 +179,6 @@ The Windows Active Directory Product Owner manages the service roadmap and plann
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, and Microsoft Security Fundamentals training
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), Microsoft Tech Community (techcommunity.microsoft.com), Scrum.org professional development resources, and Active Directory security community resources (adsecurity.org)

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -163,6 +163,8 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Windows Server Hybrid Administrator Associate
 - Microsoft 365 Certified: Identity and Access Administrator Associate
 - Microsoft Certified: Security, Compliance, and Identity Fundamentals
@@ -176,6 +178,6 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 
 - Microsoft 365 Certified: Enterprise Administrator Expert, Certified Information Systems Security Professional (CISSP), and CompTIA Security+
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), adsecurity.org, SpectreOps BloodHound documentation, Microsoft Tech Community identity and security blogs, and PowerShell Gallery for AD automation modules

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -175,6 +175,8 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft 365 Certified: Modern Desktop Administrator Associate
 - Microsoft Certified: Windows Server
 - Microsoft Certified: Azure Administrator Associate
@@ -188,6 +190,6 @@ The SCCM Engineer implements and maintains Microsoft System Center Configuration
 
 - Microsoft 365 Certified: Modern Desktop Administrator Associate, CompTIA A+, and ITIL 4 Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn ConfigMgr documentation (learn.microsoft.com/mem/configmgr), Microsoft Tech Community SCCM/ConfigMgr forums, Patch My PC blog, Deployment Research blog (deploymentresearch.com), and PowerShell Gallery for ConfigMgr automation modules

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -171,6 +171,8 @@ The Enterprise Architect develops and maintains the overall technological vision
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - TOGAF certification
 - AWS/Azure/GCP Enterprise Architecture certifications
 - ArchiMate certification
@@ -185,6 +187,6 @@ The Enterprise Architect develops and maintains the overall technological vision
 
 - Certified Information Systems Security Professional (CISSP), Open Group Certified Architect (Open CA), and major cloud provider Solutions Architect certifications (AWS/Azure/GCP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - The Open Group (opengroup.org), Gartner architecture research, InfoQ enterprise architecture content, MIT CISR digital transformation research, and IASA global IT architect community (iasaglobal.org)

--- a/Roles/finops/cloud_cost_optimization_engineer.md
+++ b/Roles/finops/cloud_cost_optimization_engineer.md
@@ -177,6 +177,8 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - FinOps Certified Practitioner (FCP) — FinOps Foundation
 - AWS Certified Cloud Practitioner
 - Microsoft Azure Fundamentals (AZ-900)
@@ -188,6 +190,6 @@ The Cloud Cost Optimization Engineer is responsible for the hands-on implementat
 
 - HashiCorp Terraform Associate, AWS Certified SysOps Administrator – Associate, and Microsoft Azure Administrator (AZ-104) for engineering depth alongside FinOps specialisation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - FinOps Foundation (finops.org), AWS Cost Management documentation and Well-Architected Cost Optimisation pillar, Microsoft Azure Cost Management and Billing documentation, Google Cloud Cost Optimisation best practices, and the FinOps Foundation community Slack workspace

--- a/Roles/finops/cloud_economics_analyst.md
+++ b/Roles/finops/cloud_economics_analyst.md
@@ -180,6 +180,8 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - FinOps Certified Practitioner (FCP) — FinOps Foundation
 - Microsoft Power BI Data Analyst Associate (PL-300)
 - Google Data Analytics Professional Certificate
@@ -191,6 +193,6 @@ The Cloud Economics Analyst is the business-facing analytical capability within 
 
 - Tableau Desktop Specialist, Microsoft Azure Data Fundamentals (DP-900), and CIMA Certificate in Business Accounting for analysts seeking broader financial management credibility alongside FinOps specialisation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - FinOps Foundation (finops.org), Microsoft Power BI documentation and learning paths (learn.microsoft.com), AWS Cost and Usage Report developer guide, Google Cloud BigQuery Billing Export documentation, and the FinOps Foundation community Slack workspace

--- a/Roles/finops/finops_engineer.md
+++ b/Roles/finops/finops_engineer.md
@@ -184,6 +184,8 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - FinOps Certified Practitioner (FCP)
 - AWS Certified Cloud Practitioner
 - Microsoft Azure Fundamentals (AZ-900)
@@ -197,6 +199,6 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 - FinOps Certified Practitioner (FCP), AWS Certified Cloud Practitioner or Microsoft Azure Fundamentals (AZ-900), and ITIL 4 Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - FinOps Foundation (finops.org), AWS Cost Management User Guide (docs.aws.amazon.com), Microsoft Azure Cost Management documentation (learn.microsoft.com), Google Cloud Billing documentation, and FinOps Foundation community Slack workspace

--- a/Roles/finops/finops_product_owner.md
+++ b/Roles/finops/finops_product_owner.md
@@ -188,6 +188,8 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - FinOps Certified Practitioner (FCP)
 - Professional Scrum Product Owner (PSPO)
 - AWS Certified Cloud Practitioner
@@ -201,6 +203,6 @@ The FinOps Product Owner manages the backlog of cloud cost optimization initiati
 
 - SAFe Product Owner/Product Manager (SAFe POPM), FinOps Certified Practitioner (FCP), and ITIL 4 Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - FinOps Foundation (finops.org), Scrum.org product owner resources, Technology Business Management Council (tbmcouncil.org), and cloud provider billing documentation (AWS, Azure, GCP)

--- a/Roles/finops/finops_senior_engineer.md
+++ b/Roles/finops/finops_senior_engineer.md
@@ -178,6 +178,8 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - FinOps Certified Practitioner (FCP)
 - FinOps Certified Engineer (FCE)
 - AWS Certified Solutions Architect - Professional
@@ -191,6 +193,6 @@ The FinOps Senior Engineer leads complex cloud financial optimization projects, 
 
 - FinOps Certified Engineer (FCE), AWS Certified Solutions Architect - Professional or Microsoft Azure Solutions Architect Expert, and HashiCorp Terraform Associate
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - FinOps Foundation (finops.org), AWS Cost Management advanced documentation, Microsoft Azure Cost Management and Billing documentation, Google Cloud Cost Management documentation, and FinOps Foundation community Slack workspace

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -170,6 +170,8 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - TOGAF or other enterprise architecture certification
 - IT4IT certification
 - ITIL Expert or Master
@@ -183,6 +185,6 @@ The Enterprise Infrastructure Onboarding Architect designs comprehensive strateg
 
 - TOGAF, HashiCorp Terraform Associate or Professional, and ITIL 4 Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HashiCorp Learn (developer.hashicorp.com), ITIL Foundation documentation, The Open Group (opengroup.org), DevOps Enterprise Forum resources, and Thoughtworks Technology Radar

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -171,6 +171,8 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL Foundation
 - ServiceNow Certified System Administrator
 - Entry-level automation certifications
@@ -184,6 +186,6 @@ The Enterprise Infrastructure Onboarding Engineer implements and maintains provi
 
 - ITIL 4 Foundation, HashiCorp Terraform Associate, and ServiceNow Certified System Administrator
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HashiCorp Learn (developer.hashicorp.com), Ansible documentation (docs.ansible.com), ServiceNow community forums, GitHub Actions documentation, and ITIL Foundation learning resources

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -173,6 +173,8 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - ITIL 4 Foundation or higher
 - ServiceNow Certified Implementation Specialist
@@ -186,6 +188,6 @@ The Enterprise Infrastructure Onboarding Product Owner manages the infrastructur
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, and ServiceNow Certified Implementation Specialist
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Scrum.org resources, ITIL Foundation documentation, ServiceNow community (community.servicenow.com), HashiCorp community resources, and DevOps Enterprise Forum

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -171,6 +171,8 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL Service Management certifications
 - Multi-platform cloud certifications
 - HashiCorp Terraform certifications
@@ -184,6 +186,6 @@ The Enterprise Infrastructure Onboarding Senior Engineer leads the implementatio
 
 - HashiCorp Terraform Professional, ITIL 4 Foundation or Specialist, and GitHub Actions or Azure DevOps certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HashiCorp Learn (developer.hashicorp.com), Ansible documentation (docs.ansible.com), ServiceNow developer resources, ITIL community resources, and DevOps Enterprise Summit recordings

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -170,6 +170,8 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL Expert or Master
 - TOGAF with ITSM focus
 - ServiceNow Certified Application Architect
@@ -185,6 +187,6 @@ The Application Configuration Management Architect designs comprehensive strateg
 
 - TOGAF, ServiceNow Certified Application Architect, and ITIL 4 Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HashiCorp Vault documentation (developer.hashicorp.com), ITIL 4 Foundation resources, ServiceNow developer portal (developer.servicenow.com), OWASP secure configuration guides, and DevOps Enterprise Forum

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -171,6 +171,8 @@ The Application Configuration Management Engineer implements and maintains confi
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL Foundation
 - ServiceNow Certified System Administrator
 - Configuration Management certification
@@ -184,6 +186,6 @@ The Application Configuration Management Engineer implements and maintains confi
 
 - ITIL 4 Foundation, ServiceNow Certified System Administrator, and HashiCorp Vault Associate
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - ITIL Foundation resources, ServiceNow community (community.servicenow.com), Ansible documentation (docs.ansible.com), HashiCorp Learn (developer.hashicorp.com), and Git source control community documentation

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -171,6 +171,8 @@ The Application Configuration Management Senior Engineer leads the implementatio
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL Service Management certifications
 - Configuration Management certifications
 - DevOps Institute certifications
@@ -184,6 +186,6 @@ The Application Configuration Management Senior Engineer leads the implementatio
 
 - ServiceNow Certified Application Developer, HashiCorp Vault Professional, and ITIL 4 Foundation or Specialist
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - HashiCorp Vault documentation (developer.hashicorp.com), ServiceNow developer portal (developer.servicenow.com), OWASP secure configuration guides, Ansible and Chef documentation, and ITIL community resources

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -184,6 +184,8 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure AI Engineer Associate (AI-102)
 - Microsoft Certified: Azure Solutions Architect Expert (AZ-305)
 - AWS Certified Machine Learning Specialty
@@ -199,6 +201,6 @@ The GenAI Platform Architect designs and governs the organization's artificial i
 
 - FinOps Certified Practitioner (for AI/LLM cost governance), IAPP AI Governance Professional (AIGP), CISSP for AI security context, and cloud solutions architect certifications (AWS/Azure/GCP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Hugging Face community (huggingface.co), CNCF AI working groups, Microsoft AI research blog, AWS Machine Learning blog, LangChain and LlamaIndex documentation, ArXiv AI preprints, NVIDIA developer blog, and the AI Alignment Forum

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -179,6 +179,8 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Azure AI Engineer Associate (AI-102)
 - AWS Certified AI Practitioner
 - Google Cloud Professional Machine Learning Engineer
@@ -192,6 +194,6 @@ The GenAI Platform Engineer implements and maintains the infrastructure, tooling
 
 - FinOps Certified Practitioner (for AI cost governance), IAPP AI Governance Professional (AIGP), GitOps certifications (ArgoCD), and cloud security associate certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Hugging Face community (huggingface.co), LangChain documentation, LlamaIndex documentation, vLLM GitHub, NVIDIA developer blog, Microsoft AI blog, AWS Machine Learning blog, and Google DeepMind technical blog

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -184,6 +184,8 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Certified Kubernetes Application Developer (CKAD)
 - AWS Certified Machine Learning - Specialty
 - Google Professional Machine Learning Engineer
@@ -199,6 +201,6 @@ The MLOps Engineer implements and maintains platforms and pipelines that enable 
 
 - FinOps Certified Practitioner (for ML cost governance), cloud ML specialty certifications (AWS Machine Learning Specialty, GCP Professional ML Engineer, Azure AI Engineer), and Databricks certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - MLflow documentation (mlflow.org), Papers with Code (paperswithcode.com), Hugging Face community, Made With ML (madewithml.com), Neptune.ai blog, Evidently AI blog, and NVIDIA developer blog

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -181,6 +181,8 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - TOGAF Certified Enterprise Architect
 - AWS Solutions Architect Professional
 - Microsoft Certified: Azure Solutions Architect Expert
@@ -197,6 +199,6 @@ The Platform Engineering Architect designs comprehensive internal developer plat
 
 - Certified Kubernetes Administrator (CKA) or CKS, TOGAF, HashiCorp Vault and Terraform certifications, DORA DevOps Leader certification, and CNCF Kubernetes and Cloud Native Associate (KCNA)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - platformengineering.org, CNCF community (cncf.io), Backstage community (backstage.io), DORA research publications (dora.dev), Kelsey Hightower talks, KubeCon + CloudNativeCon content, and DevEx conference resources

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -174,6 +174,8 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Kubernetes certifications (CKA, CKAD)
 - Cloud platform certifications (AWS, Azure, Google Cloud)
 - DevOps certifications
@@ -187,6 +189,6 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 - CKA/CKAD, Docker Certified Associate, cloud associate certifications (AWS/Azure/GCP), ITIL Foundation, and GitHub Actions certification
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - CNCF documentation (cncf.io), Backstage getting started guides (backstage.io/docs), GitHub Actions documentation, HashiCorp Terraform getting started, KubeCon YouTube channel, and kubectl docs (kubectl.docs.kubernetes.io)

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -173,6 +173,8 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - SAFe Product Owner/Product Manager
 - Project Management Professional (PMP)
@@ -186,6 +188,6 @@ The Platform Engineering Product Owner manages the roadmap and development of in
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, CKAD (for developer context), digital product management certifications, and DORA DevOps Leader certification
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - platformengineering.org, DORA research publications (dora.dev), Gartner DevOps research, InnerSource Commons community (innersourcecommons.org), Thoughtworks Technology Radar, and Team Topologies community (teamtopologies.com)

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -175,6 +175,8 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Kubernetes certifications (CKA, CKAD)
 - Cloud platform certifications (AWS, Azure, Google Cloud)
 - Terraform or other IaC certifications
@@ -188,6 +190,6 @@ The Platform Engineering Senior Engineer leads the implementation and optimizati
 
 - CKA/CKAD, DORA metrics practitioner, HashiCorp Terraform and Vault certifications, GitHub Advanced Security, and cloud platform developer certifications (AWS/Azure/GCP)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - platformengineering.org, CNCF blog (cncf.io/blog), Backstage community (backstage.io), DevOpsDays conference talks, DORA DevOps research (dora.dev), Thoughtworks Technology Radar, and KubeCon + CloudNativeCon recordings

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -174,6 +174,8 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Google SRE certification
 - Linux Foundation SRE certification
 - Certified Kubernetes Administrator (CKA)
@@ -188,6 +190,6 @@ The Site Reliability Engineer (SRE) focuses on creating reliable, scalable, and 
 
 - Certified Kubernetes Administrator (CKA), cloud reliability certifications (AWS/Azure/GCP), Prometheus Certified Associate, chaos engineering practitioner certifications (Gremlin, LitmusChaos), and ITIL Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Google SRE books (sre.google), SREcon archives (usenix.org/srecon), Honeycomb engineering blog (honeycomb.io), DORA research (dora.dev), Prometheus documentation, and PagerDuty operational runbook guides

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -177,6 +177,8 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Cisco Certified Architect (CCAr)
 - Cisco Certified Design Expert (CCDE)
 - Juniper Networks Certified Design Expert (JNCDE)
@@ -192,6 +194,6 @@ The Network Architect designs comprehensive enterprise network strategies and ar
 
 - AWS Certified Advanced Networking - Specialty, Microsoft Certified: Azure Network Engineer Associate (AZ-700), and vendor-specific SD-WAN certifications (Cisco Viptela, Fortinet SD-WAN, VMware VeloCloud).
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Cisco Live sessions and DevNet learning library, Juniper Networks Learning Portal, Network to Code (networktocode.com), ipSpace.net (Ivan Pepelnjak), NANOG and RIPE NCC community resources, Packet Pushers podcast.

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -172,6 +172,8 @@ The Network Automation Engineer specializes in developing and implementing autom
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Cisco Certified DevNet Professional
 - Cisco Certified DevNet Associate
 - Red Hat Certified Specialist in Ansible Automation
@@ -185,6 +187,6 @@ The Network Automation Engineer specializes in developing and implementing autom
 
 - [Certifications that complement and broaden the core skill set]
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - [Relevant training platforms, vendor learning paths, or professional communities]

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -172,6 +172,8 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Cisco Certified Network Associate (CCNA)
 - Juniper Networks Certified Associate (JNCIA)
 - CompTIA Network+
@@ -185,6 +187,6 @@ The Network Engineer implements and maintains enterprise network infrastructure 
 
 - CompTIA Security+ (network security awareness), Python for Network Engineers (CBT Nuggets / Udemy), Palo Alto PCNSA, and Fortinet NSE 2/3.
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Cisco DevNet Learning Labs, CBT Nuggets (CCNA/CCNP tracks), Packet Pushers podcast, NetworkChuck (YouTube), INE and Udemy network engineering courses.

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -171,6 +171,8 @@ The Network Product Owner manages the development and lifecycle of the organizat
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - SAFe Product Owner/Product Manager
 - ITIL 4 Foundation
@@ -184,6 +186,6 @@ The Network Product Owner manages the development and lifecycle of the organizat
 
 - FinOps Certified Practitioner, ITIL 4 Specialist: Drive Stakeholder Value, and vendor business/partner certifications from Cisco, Juniper, or Palo Alto.
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Scrum.org PSPO learning paths, LinkedIn Learning (Product Management and Technology Leadership tracks), Gartner IT networking research, NetworkWorld.com, Cisco Customer Success community resources.

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -172,6 +172,8 @@ The Network Senior Engineer leads the implementation and optimization of complex
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Cisco Certified Network Professional (CCNP)
 - Cisco Certified Internetwork Expert (CCIE)
 - Juniper Networks Certified Professional (JNCP)
@@ -185,6 +187,6 @@ The Network Senior Engineer leads the implementation and optimization of complex
 
 - HashiCorp Certified: Terraform Associate (network IaC), Python Institute PCEP/PCAP (automation scripting), Fortinet NSE 4/5, and Palo Alto Networks PCNSE.
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Cisco Learning Network and DevNet, Juniper Learning Portal, Network to Code (networktocode.com), Packet Pushers podcast and community, ipSpace.net, INE network engineering courses.

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -161,6 +161,8 @@ The Security Architect designs and implements security systems and frameworks th
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Certified Information Systems Security Professional (CISSP)
 - SABSA Chartered Security Architect
 - Certified Cloud Security Professional (CCSP)

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -170,6 +170,8 @@ The Security Engineer implements and maintains security controls and technologie
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - CompTIA Security+
 - Certified Information Systems Security Professional (CISSP) Associate
 - Certified Ethical Hacker (CEH)
@@ -183,6 +185,6 @@ The Security Engineer implements and maintains security controls and technologie
 
 - CompTIA CySA+ (threat detection and analysis), Microsoft Certified: Security Operations Analyst Associate (SC-200), and vendor-specific certifications (Palo Alto PCNSA, CrowdStrike, Qualys).
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - TryHackMe and HackTheBox (practical security labs), SANS Cyber Aces (free foundational content), Microsoft Learn (SC-200 path), OWASP Foundation (owasp.org), r/netsec and r/cybersecurity communities.

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -184,6 +184,8 @@ The Security Product Owner manages the development and lifecycle of the organiza
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Certified Information Security Manager (CISM)
 - Certified Information Systems Security Professional (CISSP)
@@ -198,6 +200,6 @@ The Security Product Owner manages the development and lifecycle of the organiza
 
 - FinOps Certified Practitioner (security investment ROI), NIST Cybersecurity Framework, IEC 62443 practitioner training, DORA / NIS2 compliance practitioner programmes, and ISO 27001 Lead Auditor.
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - ISC2 community and leadership webinars, ISACA resources and CISM study groups, Gartner security research, NCSC (ncsc.gov.uk) guidance publications, Scrum.org PSPO learning paths.

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -170,6 +170,8 @@ The Security Senior Engineer leads the implementation and optimization of comple
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Certified Information Systems Security Professional (CISSP)
 - Certified Information Security Manager (CISM)
 - GIAC Security Expert (GSE)
@@ -183,6 +185,6 @@ The Security Senior Engineer leads the implementation and optimization of comple
 
 - GIAC Cloud Security Essentials (GCSE), GIAC Cyber Threat Intelligence (GCTI), Microsoft Certified: Cybersecurity Architect Expert (SC-100), and Palo Alto Networks Certified Security Engineer (PCNSE).
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - SANS Institute courses and reading room, MITRE ATT&CK Navigator (attack.mitre.org), Darknet Diaries podcast, TryHackMe and HackTheBox (practical labs), Microsoft Security blog, Krebs on Security.

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -176,6 +176,8 @@ The Access Management Architect designs and oversees the organization's access m
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Certified Information Systems Security Professional (CISSP)
 - SailPoint IdentityIQ Architect
 - CyberArk Certified Architect
@@ -189,7 +191,7 @@ The Access Management Architect designs and oversees the organization's access m
 
 - CISM (Certified Information Security Manager), CCSP (cloud security), ITIL Foundation for service framing, and Agile/SAFe certifications for product-aligned delivery environments
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - IDPro Body of Knowledge (idpro.org), Gartner IAM Summit, KuppingerCole IAM research, SailPoint University, CyberArk training portal, and SANS Identity and Access Management courses
 - [Relevant training platforms, vendor learning paths, or professional communities]

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -171,6 +171,8 @@ The Access Management Engineer implements and maintains access management system
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Certified Identity & Access Manager (CIAM)
 - SailPoint IdentityIQ certification
 - CyberArk Certified Administrator
@@ -184,6 +186,6 @@ The Access Management Engineer implements and maintains access management system
 
 - ITIL Foundation for service management alignment, CompTIA CySA+ for broader security analyst skills, Microsoft 365 certifications, and PowerShell scripting proficiency for access automation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (Entra ID and identity), SailPoint and CyberArk vendor training, LinkedIn Learning access management paths, IDPro introductory resources, and vendor community forums

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -199,6 +199,8 @@ The Access Management Product Owner manages the development and lifecycle of the
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Certified Identity & Access Manager (CIAM)
 - ITIL Service Management certifications
@@ -212,6 +214,6 @@ The Access Management Product Owner manages the development and lifecycle of the
 
 - SAFe Product Owner/Product Manager (SAFe POPM), CISM, ITIL Service Management certifications, and CRISC (Certified in Risk and Information Systems Control) for risk-aligned product decisions
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - IDPro Body of Knowledge (idpro.org), Gartner IAM research, KuppingerCole IAM reports, Scrum.org Product Owner community, and vendor thought leadership from SailPoint, CyberArk, and Microsoft

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -171,6 +171,8 @@ The Identity Management Architect designs and oversees the organization's identi
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Identity and Access Administrator
 - Certified Identity Management Professional (CIMP)
 - IDPro CIDPRO certification
@@ -186,6 +188,6 @@ The Identity Management Architect designs and oversees the organization's identi
 
 - TOGAF (enterprise architecture framework), SABSA (security architecture methodology), CCSP (cloud security), CISM, and advanced vendor certifications (Microsoft Entra ID, Okta Consultant)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - IDPro Body of Knowledge (idpro.org), Gartner IAM Summit, KuppingerCole IAM research, Microsoft Learn (Entra ID), SailPoint University, and SANS Institute identity management courses

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -202,6 +202,8 @@ The Identity Management Product Owner manages the development and lifecycle of t
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Certified Identity Management Professional (CIMP)
 - Microsoft Certified: Identity and Access Administrator Associate
@@ -215,6 +217,6 @@ The Identity Management Product Owner manages the development and lifecycle of t
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL Service Management certifications, CISM for security product leadership context, and CRISC (Certified in Risk and Information Systems Control)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - IDPro Body of Knowledge (idpro.org), Gartner IAM research, Microsoft Learn (Entra ID), Scrum.org Product Owner community, and vendor thought leadership from Microsoft, Okta, and SailPoint

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -170,6 +170,8 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Dell EMC Certified Master Enterprise Architect
 - HPE ASE - Data Center and Cloud Architect
 - Cisco CCDE (Certified Design Expert)
@@ -185,6 +187,6 @@ The Server Hardware Architect designs comprehensive server infrastructure strate
 
 - BICSI Certified Data Centre Design Professional (CDCDP), TOGAF, HPE ASE - Data Centre and Cloud Architect, and Uptime Institute Accredited Tier Designer
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Uptime Institute resources (uptimeinstitute.com), BICSI education content, Data Centre Knowledge blog (datacenterfrontier.com), server vendor technical white papers (Dell, HPE, Lenovo), and ASHRAE TC 9.9 thermal management guides

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -166,6 +166,8 @@ The HPE Server Hardware Product Owner manages the development and lifecycle of t
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - HPE Product Certified - Server Solutions
 - HPE Technical Certified - Server Solutions

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -158,6 +158,8 @@ The HPE Server Hardware Senior Engineer leads the implementation and optimizatio
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - HPE ASE - Server Solutions Architect
 - HPE Master ASE - Server Solutions Architect
 - HPE Product Certified - OneView

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -171,6 +171,8 @@ The Linux Server Architect designs and defines the strategic direction for the o
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Red Hat Certified Architect (RHCA)
 - SUSE Certified Architect
 - Linux Foundation Certified Engineer (LFCE)

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -178,6 +178,8 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Red Hat Certified System Administrator (RHCSA)
 - Linux Foundation Certified System Administrator (LFCS)
 - CompTIA Linux+
@@ -191,6 +193,6 @@ The Linux Server Engineer implements and maintains Tier 1 Linux Server environme
 
 - CompTIA Linux+, Microsoft Azure Fundamentals (AZ-900), ITIL 4 Foundation, and CompTIA Security+
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Red Hat documentation, Linux Foundation training (training.linuxfoundation.org), Linux man pages, linux.die.net reference, and Server Fault Linux community

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -189,6 +189,8 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - Red Hat Certified Architect (RHCA)
 - Linux Foundation certifications
@@ -202,6 +204,6 @@ The Linux Server Product Owner manages the product backlog and roadmap for all T
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, Red Hat overview fundamentals, and Linux Foundation overview certifications
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Linux Foundation (linuxfoundation.org), Red Hat Developer blog, Scrum.org product owner resources, Gartner Linux and server management research, and CNCF blog for cloud-native context

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -175,6 +175,8 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Red Hat Certified Engineer (RHCE)
 - Linux Foundation Certified Engineer (LFCE)
 - Linux Professional Institute LPIC-2 or LPIC-3
@@ -188,6 +190,6 @@ The Linux Server Senior Engineer leads complex implementations and optimizations
 
 - Red Hat Certified Engineer (RHCE), Linux Foundation Certified Engineer (LFCE), Certified Kubernetes Administrator (CKA) for container host expertise, and CISSP or CompTIA Security+ for security depth
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Red Hat blog and developer documentation, Linux Foundation training (training.linuxfoundation.org), Ansible documentation, Julia Evans Linux blog (jvns.ca), and kernel.org for deep technical content

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -170,6 +170,8 @@ The Windows Server Architect designs and defines the strategic direction for the
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Windows Server Hybrid Administrator Associate
 - Microsoft Certified: Azure Solutions Architect Expert
 - Microsoft Certified: Identity and Access Administrator Associate

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -178,6 +178,8 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Microsoft Certified: Windows Server
 - CompTIA Server+
 - Microsoft 365 Certified: Modern Desktop Administrator Associate
@@ -191,6 +193,6 @@ The Windows Server Engineer implements and maintains Tier 1 Windows Server envir
 
 - CompTIA Server+, Microsoft Azure Fundamentals (AZ-900), ITIL 4 Foundation, and CompTIA Security+ (foundational security knowledge for server hardening)
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - Microsoft Learn (learn.microsoft.com), Windows Server documentation, Petri.com Windows Server content, Spiceworks Windows community, and Microsoft Tech Community

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -170,6 +170,8 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL 4 Master
 - TOGAF Certified with ITSM focus
 - ServiceNow Certified Technical Architect
@@ -184,6 +186,6 @@ The Service Management Architect designs comprehensive strategies and architectu
 
 - TOGAF, IT4IT certification (The Open Group), and ServiceNow Certified Technical Architect
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AXELOS ITIL resources (axelos.com), ServiceNow community and developer portal (community.servicenow.com), The Open Group IT4IT resources, and HDI (Help Desk Institute) professional community

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -171,6 +171,8 @@ The Service Management Engineer implements and maintains IT service management p
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL 4 Foundation
 - ServiceNow Certified System Administrator
 - BMC Certified Administrator (or equivalent)
@@ -184,6 +186,6 @@ The Service Management Engineer implements and maintains IT service management p
 
 - ITIL 4 Foundation, ServiceNow Certified System Administrator, and Knowledge-Centered Service (KCS) Foundation
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AXELOS ITIL learning resources (axelos.com), ServiceNow community (community.servicenow.com), ServiceNow developer portal, HDI certifications and community (thinkhdi.com), and Microsoft Power Platform documentation

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -170,6 +170,8 @@ The Service Management Product Owner manages the development and lifecycle of th
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - Professional Scrum Product Owner (PSPO)
 - ITIL 4 Strategic Leader
 - ITIL 4 Managing Professional
@@ -183,6 +185,6 @@ The Service Management Product Owner manages the development and lifecycle of th
 
 - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Managing Professional, and VeriSM Professional
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - AXELOS ITIL resources (axelos.com), Scrum.org resources, ServiceNow community (community.servicenow.com), VeriSM learning materials, and HDI community resources (thinkhdi.com)

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -170,6 +170,8 @@ The Service Management Senior Engineer leads the implementation and optimization
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL 4 Managing Professional
 - ServiceNow Certified Implementation Specialist
 - ServiceNow Certified Application Developer
@@ -183,6 +185,6 @@ The Service Management Senior Engineer leads the implementation and optimization
 
 - ServiceNow Certified Application Developer, ITIL 4 Managing Professional, and Microsoft Power Platform Developer Associate
 
-**Learning Resources and Communities:**
+**Learning Resources & Communities:**
 
 - ServiceNow developer portal (developer.servicenow.com), AXELOS ITIL resources (axelos.com), ServiceNow community (community.servicenow.com), HDI certifications and community (thinkhdi.com), and Microsoft Power Platform documentation

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -193,6 +193,8 @@ The VMware Product Owner manages the development and lifecycle of the organizati
 
 ## Recommended Certifications & Learning Paths
 
+**Core Certifications:**
+
 - ITIL or other service management framework certification
 - Professional Scrum Product Owner (PSPO) or similar
 - VMware Technical Sales Professional (VTSP)

--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -292,4 +292,4 @@ function report() {
 
 if (require.main === module) report();
 
-module.exports = { certificationSection, inventoryRole, aliasKey, classifyEntry, sectionShape, buildInventory };
+module.exports = { certificationSection, stripComments, inventoryRole, aliasKey, classifyEntry, sectionShape, buildInventory };

--- a/scripts/normalise-certification-sections.js
+++ b/scripts/normalise-certification-sections.js
@@ -16,6 +16,8 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+const { stripComments } = require('./credential-inventory.js');
+
 const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
 
 const CORE = 'Core Certifications';
@@ -57,7 +59,10 @@ function readGroups(section) {
     const seen = new Map();
     let current = CORE;
 
-    const claimOf = entry => entry.replace(/<!--[\s\S]*?-->/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+    // Reuses the inventory's scanner rather than a local pattern: a lazy
+    // `<!--[\s\S]*?-->` leaves the outer opener behind on a nested comment, so
+    // two spellings of one claim would stop matching (#248).
+    const claimOf = entry => stripComments(entry).replace(/\s+/g, ' ').trim().toLowerCase();
 
     const add = (group, entry) => {
         if (!groups.has(group)) groups.set(group, []);

--- a/scripts/normalise-certification-sections.js
+++ b/scripts/normalise-certification-sections.js
@@ -1,0 +1,189 @@
+'use strict';
+
+// Puts every role's certification section into one shape (#227), so a later
+// domain batch is not reconciling two lists and guessing which is authoritative.
+//
+// 97 roles carry a leading flat list *and* subhead groups naming credentials
+// again; 8 more use a flat list with no subheads; 24 write "Complementary
+// certifications:" as a bullet rather than a subhead.
+//
+// The transform relocates and de-duplicates text. It never adds or removes a
+// credential claim: a leading flat list is labelled, not re-sorted, and where a
+// role prioritised its certifications by position that ordering is preserved.
+// Whether an entry truly belongs in Core rather than Complementary is a content
+// judgement, and belongs to the domain batch that audits the role.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
+
+const CORE = 'Core Certifications';
+const COMPLEMENTARY = 'Complementary Certifications';
+const LEARNING = 'Learning Resources & Communities';
+
+// The catalogue spells the learning subhead two ways; both mean this group.
+function canonicalGroup(name) {
+    const value = String(name).replace(/:$/, '').trim();
+    if (/learning|resource|communit/i.test(value)) return LEARNING;
+    if (/complementary/i.test(value)) return COMPLEMENTARY;
+    if (/core/i.test(value)) return CORE;
+    return value;
+}
+
+function splitDocument(text) {
+    const heading = text.match(/^## [^\n]*Certification[^\n]*$/mi);
+    if (!heading) return null;
+
+    const start = heading.index;
+    const afterHeading = start + heading[0].length;
+    const rest = text.slice(afterHeading);
+    const next = rest.search(/\n## /);
+
+    return {
+        before: text.slice(0, start),
+        heading: heading[0],
+        section: next === -1 ? rest : rest.slice(0, next),
+        after: next === -1 ? '' : rest.slice(next),
+    };
+}
+
+// Reads a section into ordered groups, whatever shape it arrived in.
+function readGroups(section) {
+    const groups = new Map();
+    // Where a recommendation is kept, so a repeat can be dropped and a marker
+    // can still win. Keyed on the credential name, so "X" and
+    // "X <!-- credential: id -->" are recognised as the same claim.
+    const seen = new Map();
+    let current = CORE;
+
+    const claimOf = entry => entry.replace(/<!--[\s\S]*?-->/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+
+    const add = (group, entry) => {
+        if (!groups.has(group)) groups.set(group, []);
+
+        const claim = claimOf(entry);
+        const previous = seen.get(claim);
+
+        // A credential listed in the flat list and again under a subhead is the
+        // duplication this change exists to remove. The first position wins,
+        // since it is the more prominent one the role already chose.
+        if (previous) {
+            // ...unless the repeat is the one carrying the registry marker.
+            if (/<!--\s*credential:/.test(entry) && !/<!--\s*credential:/.test(previous.entry)) {
+                const list = groups.get(previous.group);
+                list[list.indexOf(previous.entry)] = entry;
+                previous.entry = entry;
+            }
+            return;
+        }
+
+        groups.get(group).push(entry);
+        seen.set(claim, { group, entry });
+    };
+
+    for (const line of section.split('\n')) {
+        const subhead = line.match(/^\*\*(.+?):?\*\*\s*$/);
+        if (subhead) { current = canonicalGroup(subhead[1]); continue; }
+
+        const bullet = line.match(/^(\s*)[-*]\s+(.*\S)\s*$/);
+        if (!bullet) continue;
+
+        const [, indent, raw] = bullet;
+        const label = raw.replace(/\*\*/g, '').trim();
+
+        // "Complementary certifications:" written as a bullet introduces the
+        // bullets nested beneath it.
+        if (/^[^:]+:$/.test(label) && !indent) { current = canonicalGroup(label); continue; }
+
+        add(current, raw.trim());
+    }
+
+    return groups;
+}
+
+function renderSection(groups) {
+    const order = [CORE, COMPLEMENTARY, LEARNING];
+    const named = [...groups.keys()].filter(g => !order.includes(g));
+    const parts = [];
+
+    for (const group of [...order, ...named]) {
+        const entries = groups.get(group);
+        if (!entries || !entries.length) continue;
+        parts.push(`**${group}:**`, '', ...entries.map(e => `- ${e}`), '');
+    }
+
+    return `\n\n${parts.join('\n').trimEnd()}\n`;
+}
+
+function normaliseSection(text) {
+    const parts = splitDocument(text);
+    if (!parts) return text;
+
+    const groups = readGroups(parts.section);
+    if (!groups.size) return text;
+
+    return parts.before + parts.heading + renderSection(groups) + parts.after;
+}
+
+// --- application ------------------------------------------------------------
+
+function roleFiles(dir = ROLES_DIR, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) roleFiles(full, out);
+        else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(full);
+    }
+    return out;
+}
+
+function run({ write }) {
+    const { inventoryRole, sectionShape } = require('./credential-inventory.js');
+    let changed = 0;
+    let deduped = 0;
+    const unsafe = [];
+
+    for (const file of roleFiles()) {
+        const original = fs.readFileSync(file, 'utf8');
+        // Only the shapes #227 is about. An already-grouped role would otherwise
+        // be rewritten just to respell its learning-resources subhead, turning a
+        // 105-file change into a 198-file one for no gain in this issue.
+        const shape = sectionShape(original);
+        if (shape !== 'mixed' && shape !== 'flat') continue;
+        const hadBom = original.startsWith('﻿');
+        const hadCrlf = original.includes('\r\n');
+        const body = original.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+        const updated = normaliseSection(body);
+        if (updated === body) continue;
+
+        // Safety gate: the transform may drop an exact duplicate, but it must
+        // never lose a distinct claim or invent one.
+        const before = inventoryRole(body).map(e => e.name);
+        const after = inventoryRole(updated).map(e => e.name);
+        const lost = before.filter(n => !after.includes(n));
+        const gained = after.filter(n => !before.includes(n));
+        if (lost.length || gained.length) {
+            unsafe.push({ file, lost, gained });
+            continue;
+        }
+        deduped += before.length - after.length;
+        changed++;
+
+        if (write) {
+            const out = (hadBom ? '﻿' : '') + (hadCrlf ? updated.replace(/\n/g, '\r\n') : updated);
+            fs.writeFileSync(file, out, 'utf8');
+        }
+    }
+
+    console.log(`${write ? 'Normalised' : 'Would normalise'} ${changed} role file(s); ${deduped} duplicate recommendation(s) removed.`);
+    if (unsafe.length) {
+        console.error(`\nRefused ${unsafe.length} file(s) that would change a claim:`);
+        for (const u of unsafe) console.error(`  ${u.file}\n    lost: ${u.lost.join(' | ')}\n    gained: ${u.gained.join(' | ')}`);
+        process.exitCode = 1;
+    }
+}
+
+if (require.main === module) run({ write: process.argv.includes('--write') });
+
+module.exports = { normaliseSection, readGroups, canonicalGroup };

--- a/test/normalise-certification-sections.test.js
+++ b/test/normalise-certification-sections.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normaliseSection } = require('../scripts/normalise-certification-sections.js');
+const { inventoryRole } = require('../scripts/credential-inventory.js');
+
+// #227 makes every certification section use one shape, so a later domain batch
+// is not reconciling two lists and guessing which is authoritative.
+//
+// The transform moves and de-duplicates text. It must never add or remove a
+// credential claim — that is the property every test here is really checking.
+
+const HEADING = '## Recommended Certifications & Learning Paths';
+
+function doc(...lines) {
+    return `# Role\n\n${HEADING}\n\n${lines.join('\n')}\n`;
+}
+
+test('a leading flat list becomes the core certifications group', () => {
+    const out = normaliseSection(doc(
+        '- Certified Kubernetes Administrator (CKA)',
+        '- CompTIA Security+',
+    ));
+
+    assert.match(out, /\*\*Core Certifications:\*\*/);
+    assert.match(out, /- Certified Kubernetes Administrator \(CKA\)/);
+    assert.match(out, /- CompTIA Security\+/);
+});
+
+test('an existing grouped section is left unchanged', () => {
+    const already = doc(
+        '**Core Certifications:**',
+        '',
+        '- Certified Kubernetes Administrator (CKA)',
+        '',
+        '**Learning Resources & Communities:**',
+        '',
+        '- Kubernetes docs',
+    );
+
+    assert.equal(normaliseSection(already), already);
+});
+
+test('a nested complementary bullet merges into the complementary group', () => {
+    const out = normaliseSection(doc(
+        '- Certified Kubernetes Administrator (CKA)',
+        '- Complementary certifications:',
+        '  - Docker Certified Associate',
+        '',
+        '**Complementary Certifications:**',
+        '',
+        '- CompTIA Security+',
+    ));
+
+    // The label bullet is gone, and both complementary entries sit in one group.
+    assert.doesNotMatch(out, /- Complementary certifications:/);
+    const complementary = out.split('**Complementary Certifications:**')[1];
+    assert.match(complementary, /- Docker Certified Associate/);
+    assert.match(complementary, /- CompTIA Security\+/);
+    // Exactly one complementary group survives the merge.
+    assert.equal(out.split('**Complementary Certifications:**').length - 1, 1);
+});
+
+test('a duplicated recommendation is kept once', () => {
+    const out = normaliseSection(doc(
+        '- CompTIA Security+',
+        '- Complementary certifications:',
+        '  - CompTIA Security+',
+    ));
+
+    assert.equal(out.split('CompTIA Security+').length - 1, 1);
+});
+
+test('the learning resources heading is spelled one way', () => {
+    const out = normaliseSection(doc(
+        '**Learning Resources and Communities:**',
+        '',
+        '- Kubernetes docs',
+    ));
+
+    assert.match(out, /\*\*Learning Resources & Communities:\*\*/);
+    assert.doesNotMatch(out, /Resources and Communities/);
+});
+
+test('a credential marker survives normalisation', () => {
+    const out = normaliseSection(doc(
+        '- Certified Kubernetes Administrator (CKA) <!-- credential: cncf-cka -->',
+    ));
+
+    assert.match(out, /<!-- credential: cncf-cka -->/);
+});
+
+test('no credential claim is added or removed', () => {
+    const before = doc(
+        '- AWS Certified Solutions Architect Professional (SAP-C02)',
+        '- FinOps Certified Practitioner',
+        '- Complementary certifications:',
+        '  - Docker Certified Associate',
+        '',
+        '**Complementary Certifications:**',
+        '',
+        '- CompTIA Security+',
+        '',
+        '**Learning Resources and Communities:**',
+        '',
+        '- AWS Well-Architected Framework documentation',
+    );
+
+    const namesBefore = inventoryRole(before).map(e => e.name).sort();
+    const namesAfter = inventoryRole(normaliseSection(before)).map(e => e.name).sort();
+    assert.deepEqual(namesAfter, namesBefore);
+});
+
+test('content outside the certification section is untouched', () => {
+    const source = `# Role\n\n## Key Technologies\n\n- Kubernetes\n\n${HEADING}\n\n- CompTIA Security+\n\n## Career Development Path\n\n- Senior engineer\n`;
+    const out = normaliseSection(source);
+
+    assert.match(out, /## Key Technologies\n\n- Kubernetes/);
+    assert.match(out, /## Career Development Path\n\n- Senior engineer/);
+});
+
+test('a role with no certification section is returned unchanged', () => {
+    const source = '# Role\n\n## Key Technologies\n\n- Kubernetes\n';
+    assert.equal(normaliseSection(source), source);
+});

--- a/test/normalise-certification-sections.test.js
+++ b/test/normalise-certification-sections.test.js
@@ -71,6 +71,20 @@ test('a duplicated recommendation is kept once', () => {
     assert.equal(out.split('CompTIA Security+').length - 1, 1);
 });
 
+// The dedup key strips markers so "X" and "X <!-- credential: id -->" count as
+// one claim. Stripping with a single lazy pass leaves the outer opener behind
+// on a nested comment, so the two keys stop matching and the duplicate
+// survives — the same defect class as #248.
+test('a duplicate is still recognised when its comment is nested', () => {
+    const out = normaliseSection(doc(
+        '- CompTIA Security+',
+        '- Complementary certifications:',
+        '  - CompTIA Security+ <!--<!-- stray -->-->',
+    ));
+
+    assert.equal(out.split('CompTIA Security+').length - 1, 1);
+});
+
 test('the learning resources heading is spelled one way', () => {
     const out = normaliseSection(doc(
         '**Learning Resources and Communities:**',


### PR DESCRIPTION
Closes #227. Prerequisite for the 16 domain batches — with one criterion deliberately left unmet, explained below.

## Problem

97 roles carried a leading flat list **and** subhead groups naming credentials again; 8 more used a flat list with no subheads; 24 wrote `Complementary certifications:` as a bullet rather than a subhead. A domain batch migrating one of those was reconciling two lists and guessing which was authoritative.

## Change

All 226 role sections are now grouped:

```
grouped  226      mixed  0      flat  0
```

The leading flat list is **labelled** `Core Certifications`, not re-sorted. Whether an entry truly belongs in Core rather than Complementary is a content judgement, and belongs to the batch that audits the role — so this change asserts nothing about priority beyond the ordering each role already had.

## Safety

The transform relocates text; it must not change what a role recommends. Three guards:

1. `scripts/normalise-certification-sections.js` **refuses** any file where the set of credential claims would differ, reporting what would have been lost or gained rather than writing it.
2. The inventory total is unchanged: **2,166 legacy entries before and after**.
3. 33 files carrying a BOM keep it; CRLF endings are preserved. Verified by comparing raw bytes against `HEAD` for all 105 files — 0 BOMs lost.

Scoped to the `mixed` and `flat` shapes on purpose. Normalising every role would also respell the `Learning Resources and Communities` subhead, turning a 105-file change into a 198-file one for no gain in this issue.

## One criterion left unchecked

> - [ ] Duplicated recommendations are reconciled, with the resolution visible in the diff.

**Not met, and not mechanically meetable.** The duplication in these roles is semantic, not textual. From `api_platform_engineer.md` after normalisation:

```
**Complementary Certifications:**

- Docker and container basics
- CI/CD pipeline certifications
- Cloud platform associate certifications
- Web security fundamentals
- Microservices fundamentals
- Docker and container basics, cloud platform associate certifications (AWS/Azure/GCP), web security fundamentals (OWASP), and CI/CD pipeline certifications
```

The last bullet restates the five above it in comma-joined prose. Nothing de-duplicates exactly — the run removed **0** duplicates across all 105 files — and merging them means rewriting prose, which is judgement, not normalisation.

This needs no new issue: ADR-0003 already requires those prose bullets to be expanded into named credentials during each domain batch, which dissolves the duplication as a side effect. I have left the box unchecked and recorded the reasoning on #227 rather than checking it as delivered.

## Verification

- `npm test` — 327/327 pass (was 318); 9 new tests written first, including one asserting the claim set is identical before and after
- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `npm run check-counts` — 226 roles / 34 domains / 7 chapters, README matches
- Inventory shapes: `mixed 0`, `flat 0`

## Review note

105 of the 107 changed files are mechanical. The two worth reading are the script and its tests; the role files are all the same shape of change, and `Roles/security/security_architect.md` is representative — two added lines.
