### PR TITLE
fix: keep certification levels apart when grouping aliases

### DIFF
--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -105,10 +105,20 @@ function splitJoined(value) {
 // Administrator", its "Associate" spelling, and its "(SC-300)" spelling group
 // together.
 function aliasKey(name) {
+    // Level words — associate, professional, expert, foundation — are kept.
+    // For a certification scheme the level *is* the credential: Terraform
+    // Associate and Terraform Expert are separate exams, and merging them would
+    // produce one registry record where two credentials exist, with whichever
+    // spelling came first supplying the official name and issuer URL (#252).
+    //
+    // The cost is over-splitting, since a level word is sometimes just part of
+    // one credential's official name. That is the safer error: an over-split
+    // pair becomes two audit candidates the auditor merges on seeing the issuer
+    // page, whereas an over-merged pair hides a credential for good.
     const normalized = String(name)
         .toLowerCase()
         .replace(/\([^)]*\)/g, ' ')
-        .replace(/\b(certification|certifications|certificate|certified|associate|professional|expert|fundamentals|foundation)\b/g, ' ')
+        .replace(/\b(certification|certifications|certificate|certified)\b/g, ' ')
         .replace(/[^a-z0-9]+/g, ' ')
         .trim();
 

--- a/test/credential-inventory.test.js
+++ b/test/credential-inventory.test.js
@@ -145,10 +145,47 @@ test('a comment closed with --!> is stripped as well', () => {
     assert.deepEqual(entries.map(e => e.name), ['CompTIA Security+']);
 });
 
-test('aliasKey groups the spellings of one credential', () => {
-    const key = aliasKey('Microsoft Certified: Identity and Access Administrator Associate (SC-300)');
-    assert.equal(aliasKey('Microsoft Certified: Identity and Access Administrator'), key);
-    assert.equal(aliasKey('Microsoft Certified: Identity and Access Administrator Associate'), key);
+// Grouping deliberately prefers over-splitting to over-merging (#252). For a
+// certification scheme the level *is* the credential — Terraform Associate and
+// Terraform Expert are separate exams — and no string rule can tell that from a
+// level word that is merely part of one credential's official name.
+//
+// The failure modes are not symmetric. An over-split pair becomes two audit
+// candidates that the auditor merges on seeing the issuer page; an over-merged
+// pair silently hides a credential and nothing later reveals it.
+//
+// So this asserts less grouping than it used to: "... Administrator" and
+// "... Administrator Associate" are both SC-300, and the audit in #229 is what
+// resolves them onto one ID.
+test('aliasKey groups spellings that differ only by a parenthesised code', () => {
+    assert.equal(
+        aliasKey('Microsoft Certified: Identity and Access Administrator Associate (SC-300)'),
+        aliasKey('Microsoft Certified: Identity and Access Administrator Associate'),
+    );
+});
+
+test('aliasKey groups spellings that differ only by punctuation or issuer wording', () => {
+    assert.equal(
+        aliasKey('AWS Certified Solutions Architect – Professional'),
+        aliasKey('AWS Certified Solutions Architect - Professional'),
+    );
+    assert.equal(
+        aliasKey('HashiCorp Certified: Terraform Associate'),
+        aliasKey('HashiCorp Terraform Associate'),
+    );
+});
+
+test('aliasKey keeps certification levels apart', () => {
+    const distinct = [
+        ['AWS Certified Solutions Architect - Associate', 'AWS Certified Solutions Architect - Professional'],
+        ['HashiCorp Certified: Terraform Associate', 'HashiCorp Certified: Terraform Expert'],
+        ['ITIL Foundation', 'ITIL Expert'],
+        ['Certified Information Systems Security Professional (CISSP)', 'Certified Information Systems Security Professional (CISSP) Associate'],
+    ];
+
+    for (const [a, b] of distinct) {
+        assert.notEqual(aliasKey(a), aliasKey(b), `${a} must not group with ${b}`);
+    }
 });
 
 test('aliasKey keeps genuinely different credentials apart', () => {


### PR DESCRIPTION
Closes #252. Unblocks #229 — the audit must not run from a candidate list that conflates AWS SAA with SAP.

## Problem

`aliasKey` stripped `associate`, `professional`, `expert`, and `foundation` when grouping spelling variants. For a certification scheme **the level is the credential**, so separate exams were merged:

```
MERGED | AWS Certified Solutions Architect - Associate  VS  ... - Professional
MERGED | HashiCorp Certified: Terraform Associate       VS  ... Terraform Expert
MERGED | ITIL Foundation                                VS  ITIL Expert
MERGED | CISSP                                          VS  CISSP Associate
```

Auditing from those groups would have produced **one registry record where two credentials exist**, with whichever spelling came first supplying the official name and issuer URL. That record would then look verified — the failure mode that matters most here, because nothing downstream reveals it.

## Fix

Keep the level words when building the key.

The cost is over-splitting: `Microsoft Certified: Identity and Access Administrator` and its `Associate` spelling are both SC-300, and now appear as two candidates.

That is deliberate, because **the failure modes are not symmetric**:

- an over-split pair becomes two audit candidates that the auditor merges on seeing the issuer page;
- an over-merged pair hides a credential, and no later step reveals it.

No string rule separates "level word that distinguishes two credentials" from "level word that is part of one credential's name" — it needs the issuer page. So the resolution belongs to #229, not to a cleverer heuristic here.

## Test change, called out explicitly

`aliasKey groups the spellings of one credential` asserted the old merging behaviour for exactly the Microsoft example above. It is replaced by three tests that assert the safer direction:

- spellings differing only by a parenthesised code still group;
- spellings differing only by punctuation or issuer wording still group (`–` vs `-`, `HashiCorp Certified:` vs `HashiCorp`);
- the four level pairs above stay apart.

The rationale is recorded in the test file, so a future contributor does not "fix" the over-splitting back into over-merging.

## Effect on published figures

| | Was | Now |
|---|---|---|
| Distinct credentials after grouping | 1,157 | **1,198** |
| Cross-cutting audit candidates (3+ domains) | 61 | **63** |

The 2,166 entry total, the per-domain counts, and the batch scoping in #230–#245 are all unchanged. #210 is updated with the corrected figure.

## Verification

- `npm test` — 330/330 pass (was 328)
- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `node scripts/normalise-certification-sections.js` — 0 files, so #227's normalisation is unaffected
