### PR TITLE
feat: register the cross-cutting credentials (first tranche)

### DIFF
--- a/data/credentials.json
+++ b/data/credentials.json
@@ -113,9 +113,10 @@
       "type": "certification",
       "url": "https://www.scrum.org/assessments/professional-scrum-product-owner-i-certification",
       "status": "active",
-      "verified_on": "2026-08-08",
+      "verified_on": "2026-08-14",
       "owner": "catalogue-maintainers",
-      "review_months": 12
+      "review_months": 12,
+      "notes": "Lifetime certification with no renewal fee. Scrum.org issues Product Owner certifications at three separate levels - I, II and III - so an unqualified \"PSPO\" in a role does not resolve to this record automatically. Each role must name the level it means, per ADR-0003."
     },
     {
       "id": "finops-certified-practitioner",
@@ -281,6 +282,18 @@
       "owner": "catalogue-maintainers",
       "review_months": 3,
       "notes": "RETIRES OCTOBER 2026 - Microsoft states this certification and its exam retire in October 2026, after which it can no longer be earned or renewed. Also renamed: the catalogue references the former name \"Microsoft 365 Certified: Enterprise Administrator Expert\". Exam MS-102. Short review interval set deliberately so the retirement is revisited before it lands."
+    },
+    {
+      "id": "pmi-pmp",
+      "name": "Project Management Professional (PMP)",
+      "issuer": "Project Management Institute (PMI)",
+      "type": "certification",
+      "url": "https://www.pmi.org/certifications/project-management-pmp",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires three or more years of experience leading projects plus formal training, and is maintained through PMI continuing certification requirements. PMI updated the exam in July 2026."
     }
   ]
 }

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -233,6 +233,54 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "Exam AZ-900. Catalogue spellings such as \"Microsoft Azure Fundamentals (AZ-900)\" and \"Azure Fundamentals\" are this credential, not a subject."
+    },
+    {
+      "id": "isc2-ccsp",
+      "name": "Certified Cloud Security Professional (CCSP)",
+      "issuer": "ISC2",
+      "type": "certification",
+      "url": "https://www.isc2.org/certifications/ccsp",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires five years of relevant work experience."
+    },
+    {
+      "id": "scaledagile-popm",
+      "name": "SAFe Product Owner/Product Manager (POPM)",
+      "issuer": "Scaled Agile, Inc.",
+      "type": "certification",
+      "url": "https://scaledagile.com/training/safe-product-owner-product-manager/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Scaled Agile writes the credential as both \"SAFe Product Owner/Product Manager\" and \"SAFe Certified Product Owner/Product Manager\"; POPM is the abbreviation used throughout. Requires 12 continuing education units annually to maintain."
+    },
+    {
+      "id": "microsoft-azure-administrator-associate",
+      "name": "Microsoft Certified: Azure Administrator Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/azure-administrator/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam AZ-104. Prerequisite for the Azure Solutions Architect Expert certification. Renewal frequency 12 months."
+    },
+    {
+      "id": "microsoft-m365-administrator-expert",
+      "name": "Microsoft 365 Certified: Administrator Expert",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/m365-administrator-expert/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 3,
+      "notes": "RETIRES OCTOBER 2026 - Microsoft states this certification and its exam retire in October 2026, after which it can no longer be earned or renewed. Also renamed: the catalogue references the former name \"Microsoft 365 Certified: Enterprise Administrator Expert\". Exam MS-102. Short review interval set deliberately so the retirement is revisited before it lands."
     }
   ]
 }

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -149,6 +149,90 @@
       "verified_on": "2026-08-08",
       "owner": "catalogue-maintainers",
       "review_months": 12
+    },
+    {
+      "id": "peoplecert-itil4-foundation",
+      "name": "ITIL 4 Foundation",
+      "issuer": "PeopleCert",
+      "type": "certification",
+      "url": "https://www.peoplecert.org/browse-certifications/it-governance-and-service-management/ITIL-1/itil-4-foundation-2565",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "PeopleCert owns and issues ITIL following its acquisition of AXELOS. Distinct from the earlier ITIL Foundation (v3), which the catalogue also references separately."
+    },
+    {
+      "id": "isc2-cissp",
+      "name": "Certified Information Systems Security Professional (CISSP)",
+      "issuer": "ISC2",
+      "type": "certification",
+      "url": "https://www.isc2.org/certifications/cissp",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires five years of relevant experience. Candidates who pass without the experience hold the Associate of ISC2 designation, which is a status on the way to CISSP rather than a separate certification."
+    },
+    {
+      "id": "comptia-security-plus",
+      "name": "CompTIA Security+",
+      "issuer": "CompTIA",
+      "type": "certification",
+      "url": "https://www.comptia.org/en-us/certifications/security/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Current exam SY0-701 (V7). CompTIA retires an exam version roughly three years after launch, so confirm the current code at review."
+    },
+    {
+      "id": "comptia-server-plus",
+      "name": "CompTIA Server+",
+      "issuer": "CompTIA",
+      "type": "certification",
+      "url": "https://www.comptia.org/en-us/certifications/server/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Current exam SK0-005 (V5)."
+    },
+    {
+      "id": "microsoft-azure-solutions-architect-expert",
+      "name": "Microsoft Certified: Azure Solutions Architect Expert",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/azure-solutions-architect/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam AZ-305. Requires the Azure Administrator Associate certification as a prerequisite. Microsoft role-based certifications expire unless renewed annually."
+    },
+    {
+      "id": "microsoft-identity-access-administrator-associate",
+      "name": "Microsoft Certified: Identity and Access Administrator Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/identity-and-access-administrator/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam SC-300. The catalogue spellings without \"Associate\", and with \"(SC-300)\" appended, are the same credential. Renewal frequency 12 months."
+    },
+    {
+      "id": "microsoft-azure-fundamentals",
+      "name": "Microsoft Certified: Azure Fundamentals",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/azure-fundamentals/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam AZ-900. Catalogue spellings such as \"Microsoft Azure Fundamentals (AZ-900)\" and \"Azure Fundamentals\" are this credential, not a subject."
     }
   ]
 }


### PR DESCRIPTION
Refs #229 — **first tranche, deliberately not `Closes`.** 47 of the 63 cross-cutting candidates still need auditing.

Registry records only. **No role file, marker, or `audited_roles` entry changes here** — roles pick these IDs up in their own domain batch.

## Progress

| | |
|---|---|
| Registry records | 13 → **25** |
| Cross-cutting candidates matched to a record | **16 of 63**, covering **359 of the 657** cross-cutting entries |
| Remaining | 47 candidates, ~298 entries |

The four most-used credentials in the catalogue — ITIL 4 Foundation (67 entries), SAFe POPM (45), PMP (34), PSPO (30) — are all resolved, which is why 16 candidates cover more than half the entries.

## What the audit caught

These are the findings that justify #229 existing as a separate prerequisite. None is discoverable from inside the repository.

**A recommended certification retires in about two months.** Microsoft states that `Microsoft 365 Certified: Enterprise Administrator Expert` and its MS-102 exam **retire in October 2026**, after which it can neither be earned nor renewed. The catalogue recommends it in **11 entries across 6 domains**. It has also been **renamed** — Microsoft now calls it `Microsoft 365 Certified: Administrator Expert`. Recorded `active` with a **3-month** review interval instead of the usual 12, so it resurfaces before retirement rather than after. The 11 role recommendations need a decision in their domain batches.

**"PSPO" is not one credential.** Scrum.org issues Product Owner certifications at three separate levels, I / II / III. The catalogue uses unqualified `Professional Scrum Product Owner (PSPO)` **30 times across 21 domains**. The `scrumorg-pspo-i` record now states explicitly that unqualified "PSPO" does **not** resolve to it automatically — mapping all 30 would have been a guess dressed as an audit. Which level each role means is a content judgement for its batch under ADR-0003.

**Two open questions from earlier issues are now answered by evidence rather than heuristics:**

- `SC-300`'s official name is `Microsoft Certified: Identity and Access Administrator Associate`, so the catalogue's three spellings — with `Associate`, without it, and with the code appended — are one credential. This is #252's deliberate over-splitting resolving exactly as intended.
- `AZ-900`'s official name is `Microsoft Certified: Azure Fundamentals`. It is a certification, not a subject, confirming the residue flagged in #248 needed an issuer page rather than a cleverer rule.

**`CISSP Associate` is a status**, not a separate certification — candidates who pass without the required five years hold Associate of ISC2 on the way to CISSP. It gets no record of its own.

## Records added

`peoplecert-itil4-foundation`, `isc2-cissp`, `isc2-ccsp`, `comptia-security-plus` (SY0-701), `comptia-server-plus` (SK0-005), `scaledagile-popm`, `pmi-pmp`, `microsoft-azure-fundamentals` (AZ-900), `microsoft-azure-administrator-associate` (AZ-104), `microsoft-azure-solutions-architect-expert` (AZ-305), `microsoft-identity-access-administrator-associate` (SC-300), `microsoft-m365-administrator-expert` (MS-102).

`scrumorg-pspo-i` is refreshed against its issuer page and gains the level-ambiguity note.

## On `verified_on`

Every record carries `verified_on: 2026-08-14` and `owner: catalogue-maintainers`. That records that **I fetched each issuer page on that date** — `docs/CREDENTIAL_REGISTRY.md` defines the field as the day a contributor or reviewer checked the page. Reviewing this PR is the reviewer half of that. If you would rather the attestation not be mine, say so and I will strip the dates for you to fill.

Sources are the issuer's own pages in every case. No training vendor, aggregator, or search summary was used.

## Method note worth keeping

`pmi.org` returns HTTP 403 to a plain fetch, and `scrum.org` renders its content with JavaScript so a fetch-and-convert sees an empty document. Both load correctly in a real browser. I had initially reported these two as unverifiable, which was wrong — **blocked by one fetch path is not the same as unverifiable**, and the remaining 47 should be checked the same way before being written off.

## Verification

- `npm run validate` — 0 errors, including registry structure and marker resolution; 199 KPI warnings unchanged (#140)
- `npm test` — 330/330 pass
- Diff is append-only apart from the intentional `scrumorg-pspo-i` refresh; no existing record reordered
