### PR TITLE
feat: register the cross-cutting credentials (second tranche)

### DIFF
--- a/data/credentials.json
+++ b/data/credentials.json
@@ -162,7 +162,7 @@
       "verified_on": "2026-08-14",
       "owner": "catalogue-maintainers",
       "review_months": 12,
-      "notes": "PeopleCert owns and issues ITIL following its acquisition of AXELOS. Distinct from the earlier ITIL Foundation (v3), which the catalogue also references separately."
+      "notes": "PeopleCert owns and issues ITIL following its acquisition of AXELOS. Still offered, but no longer the current scheme: PeopleCert now also sells ITIL Foundation (Version 5), with a Bridge route for ITIL 4 holders. PeopleCert lists only ITIL 4 and Version 5; ITIL v3 is not offered, so an unqualified \"ITIL Foundation\" in a role resolves to no specific credential and must name its version per ADR-0003."
     },
     {
       "id": "isc2-cissp",
@@ -379,6 +379,54 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "TOGAF Standard 10th Edition. The Open Group states there is no \"TOGAF 10 Foundation\" or \"TOGAF 10 Certified\"; the 9.2-based TOGAF 9 Foundation and TOGAF 9 Certified remain separate credentials."
+    },
+    {
+      "id": "aws-security-specialty",
+      "name": "AWS Certified Security - Specialty",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-security-specialty/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam SCS-C03, valid three years."
+    },
+    {
+      "id": "microsoft-windows-server-hybrid-administrator-associate",
+      "name": "Microsoft Certified: Windows Server Hybrid Administrator Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/windows-server-hybrid-administrator/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires both exams AZ-800 and AZ-801; Microsoft also references an AZ-802 exam page in its January 2026 update note, so confirm the required exams at review."
+    },
+    {
+      "id": "microsoft-azure-ai-engineer-associate",
+      "name": "Microsoft Certified: Azure AI Engineer Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/azure-ai-engineer/",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "RETIRED - Microsoft marks this certification and its renewal assessment retired. Formerly exam AI-102. Retained because roles still reference it; those recommendations need replacing rather than the record deleting."
+    },
+    {
+      "id": "peoplecert-itil-foundation-v5",
+      "name": "ITIL Foundation (Version 5)",
+      "issuer": "PeopleCert",
+      "type": "certification",
+      "url": "https://www.peoplecert.org/browse-certifications/it-governance-and-service-management/ITIL-1",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Current ITIL scheme. PeopleCert also offers an ITIL Foundation Bridge (Version 5) for ITIL 4 certified professionals to upgrade. ITIL 4 Foundation remains available alongside it."
     }
   ]
 }

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -134,11 +134,12 @@
       "name": "TOGAF Enterprise Architecture Practitioner",
       "issuer": "The Open Group",
       "type": "certification",
-      "url": "https://www.opengroup.org/certifications/togaf",
+      "url": "https://www.opengroup.org/certifications/togaf-certification-portfolio",
       "status": "active",
-      "verified_on": "2026-08-08",
+      "verified_on": "2026-08-14",
       "owner": "catalogue-maintainers",
-      "review_months": 12
+      "review_months": 12,
+      "notes": "TOGAF Standard 10th Edition. The Open Group offers several TOGAF credentials in parallel - EA Foundation, EA Practitioner, Business Architecture Foundation, plus the 9.2-based TOGAF 9 Foundation and TOGAF 9 Certified - so an unqualified \"TOGAF certification\" in a role does not resolve to this record automatically. Each role must name the credential it means, per ADR-0003."
     },
     {
       "id": "redhat-openshift-administrator",
@@ -294,6 +295,90 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "Requires three or more years of experience leading projects plus formal training, and is maintained through PMI continuing certification requirements. PMI updated the exam in July 2026."
+    },
+    {
+      "id": "microsoft-devops-engineer-expert",
+      "name": "Microsoft Certified: DevOps Engineer Expert",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/devops-engineer/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam AZ-400. Requires either the Azure Administrator Associate or Azure Developer Associate certification first."
+    },
+    {
+      "id": "aws-cloud-practitioner",
+      "name": "AWS Certified Cloud Practitioner",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-cloud-practitioner/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam CLF-C02. Valid for three years from the date achieved."
+    },
+    {
+      "id": "aws-solutions-architect-professional",
+      "name": "AWS Certified Solutions Architect - Professional",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-solutions-architect-professional/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam SAP-C02, valid three years. AWS also issues a separate Associate-level Solutions Architect certification, so a role saying only \"AWS Certified Solutions Architect\" must name the level it means."
+    },
+    {
+      "id": "microsoft-m365-fundamentals",
+      "name": "Microsoft 365 Certified: Fundamentals",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/microsoft-365-fundamentals/",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "RETIRED - Microsoft marks this certification retired. Formerly exam MS-900. Retained because roles still reference it; those recommendations need replacing rather than the record deleting."
+    },
+    {
+      "id": "microsoft-m365-endpoint-administrator-associate",
+      "name": "Microsoft 365 Certified: Endpoint Administrator Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/modern-desktop/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam MD-102. The catalogue writes it as \"Microsoft Certified: Endpoint Administrator Associate\"; the official prefix is \"Microsoft 365 Certified:\". Renewal frequency 12 months."
+    },
+    {
+      "id": "isaca-cism",
+      "name": "Certified Information Security Manager (CISM)",
+      "issuer": "ISACA",
+      "type": "certification",
+      "url": "https://www.isaca.org/credentialing/cism",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires a separate experience application after passing the exam, plus continuing professional education to maintain."
+    },
+    {
+      "id": "opengroup-togaf-ea-foundation",
+      "name": "TOGAF Enterprise Architecture Foundation",
+      "issuer": "The Open Group",
+      "type": "certification",
+      "url": "https://www.opengroup.org/certifications/togaf-certification-portfolio",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "TOGAF Standard 10th Edition. The Open Group states there is no \"TOGAF 10 Foundation\" or \"TOGAF 10 Certified\"; the 9.2-based TOGAF 9 Foundation and TOGAF 9 Certified remain separate credentials."
     }
   ]
 }


### PR DESCRIPTION
Refs #229 — **second tranche, not `Closes`.** 38 of the 63 cross-cutting candidates still need auditing.

Registry records only. **No role file, marker, or `audited_roles` entry changes here.**

## Progress

| | |
|---|---|
| Registry records | 25 → **36** |
| Candidates matched | **25 of 63**, covering **449 of the 657** cross-cutting entries |
| Remaining | 38 candidates, ~208 entries |

## Three recommended certifications are dead or dying

This is the finding that justifies #229 as a prerequisite. None of it is discoverable from inside the repository, and all of it affects live role recommendations.

| Credential | Status | Entries affected |
|---|---|---|
| `Microsoft 365 Certified: Fundamentals` (MS-900) | **Retired** | 9 across 4 domains |
| `Microsoft Certified: Azure AI Engineer Associate` (AI-102) | **Retired** — certification *and* renewal assessment | 6 across 3 domains |
| `Microsoft 365 Certified: Enterprise Administrator Expert` | **Retires October 2026**, and renamed to `Administrator Expert` | 11 across 6 domains |

That is **26 entries recommending credentials that cannot be earned, or soon will not be.**

Both retired records are kept rather than deleted, per the registry's lifecycle rule: roles still reference them, and the record is what explains why those recommendations must change. The retiring one carries a **3-month** review interval instead of 12, so it resurfaces before the date rather than after.

## ITIL has moved a version — 94 entries affected

PeopleCert now sells **`ITIL Foundation (Version 5)`** as the current scheme, with a Bridge route for ITIL 4 holders, and its version filter lists only ITIL 4 and Version 5 — **v3 is gone**.

So:

- the catalogue's **67** `ITIL 4 Foundation` references are **a version behind** — still valid and still sold, but no longer current;
- its **27** unqualified `ITIL Foundation` references resolve to **no specific credential at all**.

Both records state this rather than letting either spelling absorb the other. This is the largest single credential exposure in the catalogue.

## Ambiguity is the dominant pattern, not error

Four of the heaviest-used references name a *scheme*, not a credential, because the issuer runs several in parallel:

| Reference | Entries | Issuer offers |
|---|---|---|
| `Professional Scrum Product Owner (PSPO)` | 30 | PSPO I, II, III |
| `TOGAF certification` | 9 | EA Foundation, EA Practitioner, Business Architecture Foundation, TOGAF 9 Foundation, TOGAF 9 Certified |
| `AWS Certified Solutions Architect` | 6 | Associate and Professional |
| `ITIL Foundation` | 27 | ITIL 4, Version 5 |

Each record says explicitly that the unqualified form does **not** resolve to it automatically. Mapping them would have been a guess dressed as an audit; which one a role means is a content judgement for its domain batch under ADR-0003.

**This changes the shape of #230–#245.** Roughly 72 entries need a *level or version decision*, not just a marker swap — worth knowing before those batches are estimated.

## Naming corrections found

- MD-102 is officially `Microsoft 365 Certified: Endpoint Administrator Associate` — the catalogue writes `Microsoft Certified:`
- The Open Group states there is **no** "TOGAF 10 Foundation" or "TOGAF 10 Certified", despite the 10th Edition existing

## Records added

`aws-cloud-practitioner` (CLF-C02), `aws-solutions-architect-professional` (SAP-C02), `aws-security-specialty` (SCS-C03), `microsoft-devops-engineer-expert` (AZ-400), `microsoft-m365-fundamentals` (retired), `microsoft-m365-endpoint-administrator-associate` (MD-102), `microsoft-windows-server-hybrid-administrator-associate` (AZ-800/AZ-801), `microsoft-azure-ai-engineer-associate` (retired), `isaca-cism`, `opengroup-togaf-ea-foundation`, `peoplecert-itil-foundation-v5`.

`opengroup-togaf-ea-practitioner` and `peoplecert-itil4-foundation` are refreshed with their ambiguity and version notes.

## One deliberate non-assertion

The Windows Server Hybrid Administrator record asks for its exam list to be reconfirmed at review rather than stating it flatly. Microsoft's January 2026 update note references an **AZ-802** page alongside AZ-800 and AZ-801, and I could not establish from the page whether AZ-802 replaces or supplements them. Recording two exams as settled fact would have been the kind of quiet inaccuracy this registry exists to prevent.

## Verification

- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `npm test` — 330/330 pass
- Every source is the issuer's own page. No training vendor, aggregator, or search summary.
- `verified_on: 2026-08-14` records that I fetched each page on that date; reviewing this PR is the reviewer half of that attestation.
