### PR TITLE
feat: register the cross-cutting credentials (third tranche)

### DIFF
--- a/data/credentials.json
+++ b/data/credentials.json
@@ -427,6 +427,66 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "Current ITIL scheme. PeopleCert also offers an ITIL Foundation Bridge (Version 5) for ITIL 4 certified professionals to upgrade. ITIL 4 Foundation remains available alongside it."
+    },
+    {
+      "id": "aws-advanced-networking-specialty",
+      "name": "AWS Certified Advanced Networking - Specialty",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-advanced-networking-specialty/",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "RETIRING 25 AUGUST 2026 - AWS states the last day to take exam ANS-C01 is 25 August 2026, after which no new certifications are issued. Certifications already earned stay valid for three years. Recorded retired because it cannot be newly earned after that date; roles recommending it need a replacement."
+    },
+    {
+      "id": "aws-devops-engineer-professional",
+      "name": "AWS Certified DevOps Engineer - Professional",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-devops-engineer-professional/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam DOP-C02, valid three years."
+    },
+    {
+      "id": "google-professional-cloud-architect",
+      "name": "Professional Cloud Architect",
+      "issuer": "Google Cloud",
+      "type": "certification",
+      "url": "https://cloud.google.com/learn/certification/cloud-architect",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Google Cloud names the credential \"Professional Cloud Architect\"; the catalogue also writes it as \"Google Cloud Professional Cloud Architect\" and \"Google Professional Cloud Architect\". Valid two years, shorter than most."
+    },
+    {
+      "id": "microsoft-security-compliance-identity-fundamentals",
+      "name": "Microsoft Certified: Security, Compliance, and Identity Fundamentals",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/security-compliance-and-identity-fundamentals/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam SC-900. A certification despite the \"Fundamentals\" name."
+    },
+    {
+      "id": "aws-machine-learning-specialty",
+      "name": "AWS Certified Machine Learning - Specialty",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-machine-learning-specialty/",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "RETIRED - AWS states the last day to take this exam was 31 March 2026, which has passed. It can no longer be earned. Certifications already held stay valid three years from the date earned. Roles recommending it need a replacement."
     }
   ]
 }


### PR DESCRIPTION
Refs #229 — **third tranche, not `Closes`.** 34 of the 63 cross-cutting candidates remain.

Registry records only. **No role file, marker, or `audited_roles` entry changes here.**

## Progress

| | |
|---|---|
| Registry records | 36 → **41** |
| Candidates matched | **29 of 63**, covering **471 of the 657** cross-cutting entries |
| Remaining | 34 candidates, ~186 entries |

## Two more dead credentials, both AWS specialties

| Credential | Last exam date | Entries |
|---|---|---|
| `AWS Certified Machine Learning - Specialty` | **31 March 2026** — already passed | 5 across 3 domains |
| `AWS Certified Advanced Networking - Specialty` | **25 August 2026** — 11 days after this audit | 6 across 3 domains |

Advanced Networking is recorded `retired` rather than `active` on purpose. It is technically still earnable today, but the exam is gone before any domain batch could plausibly act on the record, and `active` would be true on the day it was written and misleading by the time it mattered. The note states the exact date so the judgement is visible rather than implied.

**That makes five dead-or-dying credentials across 37 entries** found so far by this audit:

| Credential | Status |
|---|---|
| `Microsoft 365 Certified: Fundamentals` (MS-900) | retired |
| `Microsoft Certified: Azure AI Engineer Associate` (AI-102) | retired |
| `AWS Certified Machine Learning - Specialty` | retired |
| `AWS Certified Advanced Networking - Specialty` | retiring 25 Aug 2026 |
| `Microsoft 365 Certified: Administrator Expert` | retiring Oct 2026 |

None was discoverable from inside the repository.

## Two candidates deliberately left unregistered

**Docker Certified Associate** — 5 entries across 4 domains.

- `docker.com/certification` returns **404** in both a plain fetch and a real browser
- Docker's current training page does not mention DCA, and promotes a different credential — **Docker Foundations Professional Certificate**, delivered through LinkedIn Learning
- Docker's own deprecated-and-retired products page does **not** list DCA

Everything points to DCA being discontinued, but no Docker page says so, and **a missing page is not an issuer statement**. Recording it `retired` would be inference presented as verification — precisely what this registry exists to prevent.

Its apparent successor also raises a question for ADR-0003: a professional certificate delivered *by LinkedIn Learning* may belong under **Learning Resources & Communities** rather than as a credential at all.

**ServiceNow Certified System Administrator** — 7 entries across 3 domains. ServiceNow has rebranded to **ServiceNow University** with AI-prefixed role tracks ("AI System Administrator", "AI Application Developer"). No page found names a "Certified System Administrator" credential.

Both are written up on #229 with their evidence so the next session does not re-derive the same dead ends. Neither can be closed by more fetching — they need a maintainer decision or an issuer page that states a status.

## Records added

`aws-advanced-networking-specialty` (retired), `aws-machine-learning-specialty` (retired), `aws-devops-engineer-professional` (DOP-C02), `google-professional-cloud-architect`, `microsoft-security-compliance-identity-fundamentals` (SC-900).

Two details worth noting: Google Professional Cloud Architect is valid **two years**, shorter than the three-year AWS and Microsoft norms; and SC-900 is a certification despite its "Fundamentals" name, the same trap #248 fixed in the classifier.

## Verification

- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `npm test` — 330/330 pass
- Every source is the issuer's own page
- `verified_on: 2026-08-14` records that I fetched each page on that date
