### PR TITLE
feat: register the cross-cutting credentials (fourth tranche)

### DIFF
--- a/data/credentials.json
+++ b/data/credentials.json
@@ -607,6 +607,18 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "Based on IT4IT Standard Version 3.0. The Open Group also still offers IT4IT Foundation based on Version 2.1, so an unqualified \"IT4IT certification\" does not resolve to this record automatically."
+    },
+    {
+      "id": "vmware-vcp-dcv",
+      "name": "VMware Certified Professional - Data Center Virtualization",
+      "issuer": "VMware (Broadcom)",
+      "type": "certification",
+      "url": "https://www.broadcom.com/support/education/vmware/certification/vcp-dcv",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Listed on Broadcom's current VMware certification pages. The page states only the certification title: it did not give a version, year, or exam code, and Broadcom versions VCP credentials by release year (for example VCP-DCV 2024). Confirm the current version at review before citing a specific one."
     }
   ]
 }

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -487,6 +487,66 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "RETIRED - AWS states the last day to take this exam was 31 March 2026, which has passed. It can no longer be earned. Certifications already held stay valid three years from the date earned. Roles recommending it need a replacement."
+    },
+    {
+      "id": "redhat-rhcsa",
+      "name": "Red Hat Certified System Administrator (RHCSA)",
+      "issuer": "Red Hat",
+      "type": "certification",
+      "url": "https://www.redhat.com/en/services/certification/rhcsa",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Performance-based exam EX200. Red Hat states credentials require ongoing renewal but does not publish a validity period on the certification page."
+    },
+    {
+      "id": "aws-developer-associate",
+      "name": "AWS Certified Developer - Associate",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-developer-associate/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam DVA-C02, valid three years."
+    },
+    {
+      "id": "aws-sysops-administrator-associate",
+      "name": "AWS Certified SysOps Administrator - Associate",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-sysops-admin-associate/",
+      "status": "superseded",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "SUPERSEDED - the last day to take this exam was 29 September 2025. AWS renamed the latest exam version to AWS Certified CloudOps Engineer - Associate (SOA-C03); see aws-cloudops-engineer-associate. The rename is not retroactive, so existing holders keep this title and it stays valid three years from issue. Roles should recommend the CloudOps name."
+    },
+    {
+      "id": "aws-cloudops-engineer-associate",
+      "name": "AWS Certified CloudOps Engineer - Associate",
+      "issuer": "Amazon Web Services",
+      "type": "certification",
+      "url": "https://aws.amazon.com/certification/certified-cloudops-engineer-associate/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Exam SOA-C03. The current name of what the catalogue calls AWS Certified SysOps Administrator - Associate; AWS renamed the latest exam version rather than issuing a new credential."
+    },
+    {
+      "id": "redhat-rhce-enterprise-linux",
+      "name": "Red Hat Certified Engineer in Enterprise Linux",
+      "issuer": "Red Hat",
+      "type": "certification",
+      "url": "https://www.redhat.com/en/services/certifications",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires EX200 plus EX342. Red Hat has reorganised the former single RHCE into pathway-specific engineer credentials - in Enterprise Linux, in OpenShift, in Ansible and others - so an unqualified \"Red Hat Certified Engineer (RHCE)\" in a role does not resolve to this record automatically and must name its pathway per ADR-0003. Note Red Hat's older blog announcing the RHCE evolution still describes a single unified RHCE earned via EX294; the current certifications page supersedes it, and EX294 is now the Red Hat Certified Advanced System Administrator in Ansible exam."
     }
   ]
 }

--- a/data/credentials.json
+++ b/data/credentials.json
@@ -306,7 +306,7 @@
       "verified_on": "2026-08-14",
       "owner": "catalogue-maintainers",
       "review_months": 12,
-      "notes": "Exam AZ-400. Requires either the Azure Administrator Associate or Azure Developer Associate certification first."
+      "notes": "Exam AZ-400. Requires either the Azure Administrator Associate or Azure Developer Associate certification first - but Azure Developer Associate retired on 31 July 2026, so in practice the Administrator route is the remaining one. Confirm the prerequisite list at review."
     },
     {
       "id": "aws-cloud-practitioner",
@@ -547,6 +547,66 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "Requires EX200 plus EX342. Red Hat has reorganised the former single RHCE into pathway-specific engineer credentials - in Enterprise Linux, in OpenShift, in Ansible and others - so an unqualified \"Red Hat Certified Engineer (RHCE)\" in a role does not resolve to this record automatically and must name its pathway per ADR-0003. Note Red Hat's older blog announcing the RHCE evolution still describes a single unified RHCE earned via EX294; the current certifications page supersedes it, and EX294 is now the Red Hat Certified Advanced System Administrator in Ansible exam."
+    },
+    {
+      "id": "microsoft-azure-developer-associate",
+      "name": "Microsoft Certified: Azure Developer Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/retired-certifications",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "RETIRED 31 JULY 2026 - listed on Microsoft's credential retirement page. Formerly exam AZ-204. Roles recommending it need a replacement. Note it was also one of the two prerequisite routes into the DevOps Engineer Expert certification."
+    },
+    {
+      "id": "microsoft-azure-security-engineer-associate",
+      "name": "Microsoft Certified: Azure Security Engineer Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/retired-certifications",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 3,
+      "notes": "RETIRES 31 AUGUST 2026 - listed on Microsoft's credential retirement page, roughly two weeks after this audit. Formerly exam AZ-500. Recorded retired rather than active because the date falls before any domain batch could act on it."
+    },
+    {
+      "id": "microsoft-azure-data-scientist-associate",
+      "name": "Microsoft Certified: Azure Data Scientist Associate",
+      "issuer": "Microsoft",
+      "type": "certification",
+      "url": "https://learn.microsoft.com/en-us/credentials/certifications/retired-certifications",
+      "status": "retired",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "RETIRED 1 JUNE 2026 - listed on Microsoft's credential retirement page. Formerly exam DP-100."
+    },
+    {
+      "id": "scrumalliance-cspo",
+      "name": "Certified Scrum Product Owner (CSPO)",
+      "issuer": "Scrum Alliance",
+      "type": "certification",
+      "url": "https://www.scrumalliance.org/get-certified/product-owner-track/certified-scrum-product-owner",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Requires renewal every two years with Scrum Education Units, unlike the Scrum.org PSPO certifications which are lifetime. Distinct from PSPO - different issuer, different renewal model."
+    },
+    {
+      "id": "opengroup-it4it-3-foundation",
+      "name": "IT4IT 3 Foundation",
+      "issuer": "The Open Group",
+      "type": "certification",
+      "url": "https://www.opengroup.org/certifications/it4it",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "Based on IT4IT Standard Version 3.0. The Open Group also still offers IT4IT Foundation based on Version 2.1, so an unqualified \"IT4IT certification\" does not resolve to this record automatically."
     }
   ]
 }


### PR DESCRIPTION
Refs #229 — **fourth tranche, not `Closes`.** 30 of 63 candidates remain, though most are now alias variants of records that already exist rather than new audits.

Registry records only. **No role file, marker, or `audited_roles` entry changes here.**

## Progress

| | |
|---|---|
| Registry records | 41 → **52** |
| Candidates matched | **33 of 63**, covering **484 of the 657** cross-cutting entries |
| Remaining | 30 candidates, ~173 entries |

## Microsoft publishes a retirement page, and it changes the picture

`learn.microsoft.com/en-us/credentials/certifications/retired-certifications` lists both scheduled and recently-retired credentials. It should have been the first place I looked. Reading it found **three more the catalogue actively recommends**:

| Credential | Retired | Entries |
|---|---|---|
| `Microsoft Certified: Azure Developer Associate` (AZ-204) | **31 July 2026** — two weeks before this audit | 6 |
| `Microsoft Certified: Azure Security Engineer Associate` (AZ-500) | **31 August 2026** — two weeks after it | 8 |
| `Microsoft Certified: Azure Data Scientist Associate` (DP-100) | **1 June 2026** | 2 |

Azure Security Engineer is recorded `retired` rather than `active` for the same reason as AWS Advanced Networking: the date falls before any domain batch could act on the record.

**Nine dead-or-dying credentials across roughly 53 entries** have now been found by this audit. None was visible from inside the repository.

## A record written earlier this session was already wrong

The Azure Developer retirement invalidated the `microsoft-devops-engineer-expert` record added in the first tranche, which listed it as one of two prerequisite routes. That was accurate when Microsoft's page said it and false two weeks earlier. Corrected, with the prerequisite list flagged for reconfirmation at review.

Worth stating plainly because it is the argument for `verified_on` existing: a record can be true on the day it is written and stale within weeks.

## `superseded` earns its place in the schema

`AWS Certified SysOps Administrator - Associate` last ran on **29 September 2025**. AWS renamed the latest exam version to `AWS Certified CloudOps Engineer - Associate` (SOA-C03) rather than retiring the credential, and states the rename is **not retroactive** — existing holders keep the old title.

So it is recorded `superseded`, not `retired`, with the successor registered alongside. Both names are legitimately held today; only one can still be earned.

## RHCE has been reorganised, and Red Hat's own pages disagree

Red Hat now issues **pathway-specific** engineer credentials — in Enterprise Linux (EX200 + EX342), in OpenShift, in Ansible — so the catalogue's unqualified `Red Hat Certified Engineer (RHCE)` resolves to nothing.

Red Hat's **blog announcing the RHCE evolution still describes a single unified RHCE earned via EX294**, which the current certifications page contradicts; EX294 is now the *Red Hat Certified Advanced System Administrator in Ansible* exam. The record follows the current page and **notes the conflict**, so a future reviewer who finds that blog does not conclude the registry is wrong.

That makes six references naming a scheme rather than a credential: PSPO, ITIL Foundation, TOGAF, AWS Solutions Architect, RHCE, IT4IT.

## Also registered

`redhat-rhcsa` (EX200), `aws-developer-associate` (DVA-C02), `scrumalliance-cspo`, `opengroup-it4it-3-foundation`, `vmware-vcp-dcv`.

CSPO renews **every two years** with Scrum Education Units, unlike the *lifetime* Scrum.org PSPO — worth knowing, since the catalogue treats them as interchangeable in places.

## What I deliberately did not record

Two claims were available and rejected:

- **CASM** — a search result stated it retires (last exams 1 Feb 2026). DevOps Institute's own certification page does not say so, and does not list "Certified Agile Service Manager" at all; it lists **"Certified Agile Manager"**. Evidence of a rename, possibly a retirement, but the only explicit claim came from a search snippet.
- **TBM** — the TBM Council names a "2026 TBM Practitioner Course & Certification" and says the programme is mid-relaunch. Year-prefixed and course-shaped, which collides with the registry's rule that courses are not individually-held credentials.

`vmware-vcp-dcv` **is** recorded, but with its gaps stated: Broadcom's page confirms the name and that it is offered, and gives no version, year, or exam code. Broadcom versions VCP by release year, so the record asks for the version to be confirmed rather than inventing one.

Unresolved set is now Docker DCA, ServiceNow CSA, ServiceNow Implementation Specialist, CASM, TBM, MCSE: Core Infrastructure, and SABSA — roughly 34 entries, all written up on #229. **All but SABSA are blocked on a maintainer judgement, not on evidence-gathering.**

## Verification

- `npm run validate` — 0 errors; 199 KPI warnings unchanged (#140)
- `npm test` — 330/330 pass
- Every recorded source is the issuer's own page
