### PR TITLE
feat: record review provenance on every role

### DIFF
--- a/Roles/ai_governance/ai_governance_architect.md
+++ b/Roles/ai_governance/ai_governance_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors AI Governance Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/ai_governance/ai_governance_engineer.md
+++ b/Roles/ai_governance/ai_governance_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | AI Governance Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/ai_governance/ai_governance_product_owner.md
+++ b/Roles/ai_governance/ai_governance_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | AI Governance Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/ai_governance/ai_platform_architect.md
+++ b/Roles/ai_governance/ai_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors AI Platform Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | AI Platform Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/ai_governance/responsible_ai_engineer.md
+++ b/Roles/ai_governance/responsible_ai_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | AI Governance Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors API Platform Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | API Platform Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | API Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/api_strategy_architect.md
+++ b/Roles/app_platforms/api_strategy_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (sets API governance strategy; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors .NET Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | .NET Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | .NET Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Java Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Java Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | Java Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/c_suite/chief_executive_officer.md
+++ b/Roles/c_suite/chief_executive_officer.md
@@ -7,6 +7,8 @@
 | **Role Level** | CEO |
 | **Reports To** | Board of Directors |
 | **Direct Reports** | CTO, CIO, or SVP of Technology (equivalent titles — org uses one); CFO; CISO (in direct-reporting governance models) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/c_suite/chief_financial_officer.md
+++ b/Roles/c_suite/chief_financial_officer.md
@@ -7,6 +7,8 @@
 | **Role Level** | CFO |
 | **Reports To** | CEO |
 | **Direct Reports** | None (no subordinate finance roles modelled in this catalog) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/c_suite/chief_information_officer.md
+++ b/Roles/c_suite/chief_information_officer.md
@@ -7,6 +7,8 @@
 | **Role Level** | CIO |
 | **Reports To** | CEO |
 | **Direct Reports** | Product Area Lead, Technical Area Lead (equivalent title to CTO/SVP of Technology — org uses one) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/c_suite/chief_technology_officer.md
+++ b/Roles/c_suite/chief_technology_officer.md
@@ -7,6 +7,8 @@
 | **Role Level** | CTO |
 | **Reports To** | CEO |
 | **Direct Reports** | Product Area Lead, Technical Area Lead (equivalent title to CIO/SVP of Technology — org uses one) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/client_platform/client_platform_architect.md
+++ b/Roles/client_platform/client_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/client_platform/client_platform_engineer.md
+++ b/Roles/client_platform/client_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Client Platform Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/client_platform/client_platform_product_owner.md
+++ b/Roles/client_platform/client_platform_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/client_platform/client_platform_senior_engineer.md
+++ b/Roles/client_platform/client_platform_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | Client Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors AWS Cloud Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | AWS Cloud Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | AWS Cloud Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Azure Cloud Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Azure Cloud Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Azure Cloud Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Lead Architect |
 | **Reports To** | Cloud Principal Architect |
 | **Direct Reports** | None (provides technical oversight and mentorship to the AWS, Azure, and GCP Cloud Architects; formal line management sits with the Cloud, Platform & Infrastructure Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Principal Architect |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | None (sets multi-cloud strategy; the Cloud Lead Architect and platform architects execute against it) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors GCP Cloud Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | GCP Cloud Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | GCP Cloud Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Data Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction on data mesh standards; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Data Senior Engineers and Data Platform Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Data Platform Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/data_senior_engineer.md
+++ b/Roles/data_engineering/data_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | Data Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/data_governance_lead.md
+++ b/Roles/data_management/data_governance_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/data_management/data_privacy_officer.md
+++ b/Roles/data_management/data_privacy_officer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Chief Information Security Officer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Qumulo Storage Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Qumulo Storage Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | Qumulo Storage Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Storage Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Storage Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | Storage Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Commvault Senior Engineer or SimpliVity Backup Senior Engineer (depending on platform assignment) |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/business_continuity_disaster_recovery_manager.md
+++ b/Roles/data_protection/business_continuity_disaster_recovery_manager.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Commvault Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Commvault Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | Commvault Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors SimpliVity Backup Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | SimpliVity Backup Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | SimpliVity Backup Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Database Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Database Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Database Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Data & AI Chapter Lead |
 | **Direct Reports** | Database Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | DevOps Senior Engineer or DevOps Architect (depending on team structure) |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/developer_experience_engineer.md
+++ b/Roles/devops/developer_experience_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | DevOps Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors DevOps Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | DevOps Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | DevOps Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | DevOps Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Windows Active Directory Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Windows Active Directory Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | Windows Active Directory Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/endpoint_management/endpoint_management_architect.md
+++ b/Roles/endpoint_management/endpoint_management_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Endpoint Management Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/endpoint_management/endpoint_management_product_owner.md
+++ b/Roles/endpoint_management/endpoint_management_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/endpoint_management/endpoint_management_senior_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | Endpoint Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Endpoint Management Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | Solution Architect; Enterprise Architecture Senior Engineer |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/enterprise_architecture/enterprise_architecture_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Enterprise Architecture Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Enterprise Architect |
 | **Direct Reports** | Enterprise Architecture Engineer (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Enterprise Architect |
 | **Direct Reports** | None (technical direction role, not a people manager) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/finops/cloud_cost_optimization_engineer.md
+++ b/Roles/finops/cloud_cost_optimization_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | FinOps Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/finops/cloud_economics_analyst.md
+++ b/Roles/finops/cloud_economics_analyst.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | FinOps Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/finops/finops_architect.md
+++ b/Roles/finops/finops_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors FinOps Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/finops/finops_engineer.md
+++ b/Roles/finops/finops_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | FinOps Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/finops/finops_product_owner.md
+++ b/Roles/finops/finops_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/finops/finops_senior_engineer.md
+++ b/Roles/finops/finops_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | FinOps Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Infrastructure Onboarding Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | Infrastructure Onboarding Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/integration_middleware/integration_architect.md
+++ b/Roles/integration_middleware/integration_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Integration Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Integration Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | Integration Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Configuration Management Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | Configuration Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Kubernetes Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Kubernetes Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Kubernetes Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -7,6 +7,8 @@
 | **Role Level** | CISO |
 | **Reports To** | SVP of Technology (or CTO/CIO equivalent); CEO or Board in independent governance models |
 | **Direct Reports** | None (strategic direction over the Security & Identity Chapter Lead and senior security architects — not formal line management; see the org chart / #71) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Chapter Lead |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | Domain Architects and Senior Engineers across all eleven infrastructure chapter domains (Cloud Platforms, Kubernetes, Modern Infrastructure, Virtualisation, Specialised Computing, Server Hardware ×2, Linux/Windows Server OS, Network, FinOps) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Chapter Lead |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | Domain Architects and Senior Engineers across Data Engineering, Data Management, Database Management, and AI Governance domains |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Chapter Lead |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | Domain Architects and Senior Engineers across DevOps, App Platforms, and Integration & Middleware domains |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Chapter Lead |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | Domain Architects and Senior Engineers across Client Platform, Endpoint Management, Modern Workplace, and Service Desk domains |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Engineering Director or Technical Area Lead (PAL/TAL pair for the relevant product area or cross-cutting engineering enablement function) |
 | **Direct Reports** | None (individual contributor and internal consultant — no line management authority; drives change through coaching influence) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Area Lead |
 | **Reports To** | CTO/CIO (or SVP of Technology) |
 | **Direct Reports** | Chapter Leads (jointly with the Technical Area Lead, as the PAL/TAL leadership pair); Product Owners within the area |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Chapter Lead |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | Domain Architects and Senior Engineers across Security, Security Cross-Platform, Security & Identity, Data Protection, and Directory Services domains |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Chapter Lead |
 | **Reports To** | Technical Area Lead (TAL) or Product Area Lead (PAL) |
 | **Direct Reports** | Domain Architects and Senior Engineers across ITSM & Configuration, Service Management, Infrastructure Onboarding, and Enterprise Architecture domains |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -7,6 +7,8 @@
 | **Role Level** | SVP of Technology |
 | **Reports To** | CEO |
 | **Direct Reports** | Product Area Leads, Technical Area Lead (equivalent title to CTO/CIO — org uses one) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Technical Area Lead |
 | **Reports To** | SVP of Technology (or CTO/CIO) |
 | **Direct Reports** | Chapter Leads (jointly with the Product Area Lead, as the PAL/TAL leadership pair); Engineering Practices Champion; Technical Community Leader |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Engineering Director or Technical Area Lead (PAL/TAL pair for the relevant product area or organisation-wide engineering function) |
 | **Direct Reports** | None (individual contributor — leads through influence, curation, and connection rather than line management) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Site Reliability Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors the GenAI Platform Engineer; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | GenAI Platform Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/modern_infrastructure/infrastructure_automation_architect.md
+++ b/Roles/modern_infrastructure/infrastructure_automation_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | GenAI Platform Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Observability Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Observability Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Observability Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Platform Engineering Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Platform Engineering Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Site Reliability Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_workplace/modern_workplace_architect.md
+++ b/Roles/modern_workplace/modern_workplace_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Modern Workplace Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/modern_workplace/modern_workplace_senior_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | Modern Workplace Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Network Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/network/network_automation_architect.md
+++ b/Roles/network/network_automation_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors the Network Automation Engineer; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Network Automation Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Network Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Network Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/quality_engineering/quality_engineer.md
+++ b/Roles/quality_engineering/quality_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Quality Engineering Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/quality_engineering/quality_engineering_architect.md
+++ b/Roles/quality_engineering/quality_engineering_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (technical direction role, not a people manager) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/quality_engineering/quality_engineering_product_owner.md
+++ b/Roles/quality_engineering/quality_engineering_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/quality_engineering/quality_engineering_senior_engineer.md
+++ b/Roles/quality_engineering/quality_engineering_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | DevOps & Delivery Chapter Lead |
 | **Direct Reports** | Quality Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/security/devsecops_architect.md
+++ b/Roles/security/devsecops_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors the DevSecOps Engineer; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | DevSecOps Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security/grc_risk_compliance_analyst.md
+++ b/Roles/security/grc_risk_compliance_analyst.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Security Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Security Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | Security Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Security Cross-Platform Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_cross_platform/security_cross_platform_architect.md
+++ b/Roles/security_cross_platform/security_cross_platform_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Security Cross-Platform Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Security Cross-Platform Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | Security Cross-Platform Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Access Management Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Access Management Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | Access Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Identity Management Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Identity Management Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | Identity Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/privileged_access_management_architect.md
+++ b/Roles/security_identity/privileged_access_management_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Security & Identity Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors the Privileged Access Management Engineer; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/security_identity/privileged_access_management_engineer.md
+++ b/Roles/security_identity/privileged_access_management_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Privileged Access Management Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Server Hardware Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Server Hardware Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Server Hardware Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors HPE Server Hardware Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | HPE Server Hardware Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | HPE Server Hardware Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Linux Server Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Linux Server Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Linux Server Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Windows Server Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Windows Server Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Windows Server Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/service_desk/service_desk_analyst.md
+++ b/Roles/service_desk/service_desk_analyst.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Service Desk Senior Analyst |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/service_desk/service_desk_lead.md
+++ b/Roles/service_desk/service_desk_lead.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | Service Desk Senior Analysts, Service Desk Analysts (full line management, including hiring and career progression — a deliberate exception to the catalogue's usual model, see Role Scope & Boundaries) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/service_desk/service_desk_product_owner.md
+++ b/Roles/service_desk/service_desk_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | End User & Workplace Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-08 |
 
 ---

--- a/Roles/service_desk/service_desk_senior_analyst.md
+++ b/Roles/service_desk/service_desk_senior_analyst.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service Desk Lead |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/service_management/change_release_manager.md
+++ b/Roles/service_management/change_release_manager.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service Management Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/service_management/major_incident_manager.md
+++ b/Roles/service_management/major_incident_manager.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service Management Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Service Management Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service & Governance Chapter Lead |
 | **Direct Reports** | Service Management Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/service_management/technical_program_manager.md
+++ b/Roles/service_management/technical_program_manager.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service Management Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/service_management/vendor_supplier_it_asset_manager.md
+++ b/Roles/service_management/vendor_supplier_it_asset_manager.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Service Management Architect |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-07 |
 
 ---

--- a/Roles/specialized_computing/hpc_architect.md
+++ b/Roles/specialized_computing/hpc_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors HPC Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | HPC Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | HPC Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Hyper-V Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Hyper-V Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Hyper-V Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors Nutanix Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | Nutanix Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | Nutanix Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -7,6 +7,8 @@
 | **Role Level** | Architect |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (sets technical direction and mentors VMware Senior Engineers; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Engineer |
 | **Reports To** | VMware Senior Engineer |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -7,6 +7,8 @@
 | **Role Level** | Product Owner |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | None (owns backlog and roadmap; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -7,6 +7,8 @@
 | **Role Level** | Senior Engineer |
 | **Reports To** | Cloud, Platform & Infrastructure Chapter Lead |
 | **Direct Reports** | VMware Engineers (day-to-day technical guidance and mentoring; formal line management sits with the Chapter Lead) |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | mechanical |
 | **Last Reviewed** | 2026-03 |
 
 ---

--- a/docs/adr/0004-record-review-provenance-with-durable-owner-identifiers.md
+++ b/docs/adr/0004-record-review-provenance-with-durable-owner-identifiers.md
@@ -1,0 +1,52 @@
+# ADR-0004: Record review provenance with durable owner identifiers
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Issue/PR:** #179
+
+## Context
+
+Every role carried a syntactically valid `Last Reviewed` month, and **206 of 226 shared `2026-03`**. One month across 91% of the catalogue is a bulk stamp, not 206 reviews.
+
+That made the field actively misleading. It recorded when a file was last touched — which git already knows — while implying a review that had not happened. Exactly **one** role of 226 named an owner or reviewer anywhere in its body, and the metadata table had no field for it.
+
+The gap matters more now than when it was filed. Issues #230 to #245 will rewrite every role's certification section, and #227 already rewrote 105 role files mechanically. Under any rule where touching a file refreshes its review date, the credential rollout would leave all 226 roles looking freshly reviewed by an owner who never read them.
+
+`credentialRegistry.js` already solves the same problem for credentials, with `verified_on`, a durable `owner`, a per-record `review_months`, and a staleness warning that does not fail CI.
+
+## Decision
+
+**Two fields, and a rule about who may set them.**
+
+### `Content Owner` holds a durable role identifier, never a person
+
+The value is `catalogue-maintainers` in this repository. An organisation adopting the catalogue maps it to the accountable chapter lead for each domain.
+
+Identifiers rather than names, for two reasons: the catalogue is meant to be shared and copied, so it should not carry personal data; and an identifier survives someone changing jobs, where a name turns every departure into a catalogue-wide edit.
+
+### `Review Status` says what the date means
+
+| Status | Meaning |
+|---|---|
+| `reviewed` | An owner read the content and stands behind it as of `Last Reviewed`. |
+| `mechanical` | The file was edited, but nobody reviewed the content. |
+| `unreviewed` | New or migrated content with no review yet. |
+
+### A bulk pass may not claim a review
+
+A mechanical rewrite leaves `Last Reviewed` untouched and sets `Review Status` to `mechanical`. Only a human reading the content may set `reviewed`. Tooling can observe that a file changed; it cannot observe that anyone read it.
+
+### The existing dates are kept, and labelled
+
+The 206 stamped dates are not deleted. They truthfully record that the file was touched and only untruthfully imply review, so the honest fix is the label, not the deletion. Every role starts at `mechanical` and is promoted as it is genuinely reviewed.
+
+The validator raises a **warning**, not an error, for any status other than `reviewed` — the gap stays countable without failing CI, matching how the KPI target gap (#140) and credential staleness already behave.
+
+## Consequences
+
+- Provenance is now visible: 226 roles report `mechanical`, so the true review debt is countable from day one instead of hidden behind a populated date. The catalogue looks worse, accurately.
+- The credential rollout in #230 to #245 can rewrite every role without laundering review status.
+- Adopting organisations get a mapping point — one identifier per domain to reassign — rather than having to strip personal names.
+- Promoting a role to `reviewed` is deliberate manual work. That is the cost of the field meaning anything.
+- A future contributor who refreshes `Last Reviewed` during a formatting pass is now contradicting a recorded decision rather than following an unwritten habit.
+- `Review Status` is not a cadence. Per-role review intervals, and warning when a review falls due, remain open — the credential registry's `review_months` is the model when that is picked up.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ Allowed statuses are `Proposed`, `Accepted`, `Deprecated`, and `Superseded by AD
 | [0001](0001-organise-domains-into-seven-capability-chapters.md) | Accepted | Organise domains into seven capability chapters |
 | [0002](0002-separate-technical-product-and-people-leadership-tracks.md) | Accepted | Separate technical, product, and people-leadership tracks |
 | [0003](0003-name-credentials-explicitly-rather-than-families-or-topics.md) | Accepted | Name credentials explicitly rather than families or topics |
+| [0004](0004-record-review-provenance-with-durable-owner-identifiers.md) | Accepted | Record review provenance with durable owner identifiers |

--- a/docs/role_template.md
+++ b/docs/role_template.md
@@ -6,6 +6,8 @@
 | **Role Level** | [Engineer / Senior Engineer / Product Owner / Architect / Lead Architect / Principal Architect / Chapter Lead / Technical Area Lead / Product Area Lead / SVP / CISO / CFO / CIO / CTO / CEO] |
 | **Reports To** | [Role title this position reports to, e.g., Cloud Platform Architect] |
 | **Direct Reports** | [Role titles managed by this position, or "None" for individual-contributor roles] |
+| **Content Owner** | [Durable role identifier accountable for this content, e.g. `catalogue-maintainers` or the owning chapter. Not a person's name — see below.] |
+| **Review Status** | [reviewed / mechanical / unreviewed] |
 | **Last Reviewed** | [YYYY-MM] |
 
 ---
@@ -189,5 +191,17 @@
 - [Training platform, community, or learning path, e.g., A Cloud Guru, CNCF community, vendor learning paths]
 
 ---
+
+> **Review provenance note:** `Content Owner` holds a **durable role identifier**, never a person's name — `catalogue-maintainers` in this repository, and the owning chapter lead in an organisation that adopts the catalogue. Identifiers survive people changing jobs, and keep personal data out of a document intended to be shared.
+>
+> `Review Status` says what the `Last Reviewed` date actually means:
+>
+> | Status | Meaning |
+> |---|---|
+> | `reviewed` | An owner read the content and stands behind it as of that date. |
+> | `mechanical` | The file was edited — a bulk rewrite, a formatting pass — but nobody reviewed the content. |
+> | `unreviewed` | New or migrated content with no review yet. |
+>
+> A bulk pass across many roles must leave `Last Reviewed` alone and set `Review Status` to `mechanical`. Only a human reading the content may set `reviewed`. See [ADR-0004](adr/0004-record-review-provenance-with-durable-owner-identifiers.md).
 
 > **Compliance frameworks note:** For roles with regulatory or security scope, reference applicable frameworks inline within Key Responsibilities or Required Skills — do not create a separate section. Standard set: `ISO/IEC 27001, NIST CSF, GDPR, NIS2, SOC 2, DORA`. Add `IEC 62443` for OT/ICS-relevant roles. Add `NIST SP 800-53` or `NIST SP 800-218` where more precise than CSF.

--- a/roleMeta.js
+++ b/roleMeta.js
@@ -104,6 +104,11 @@ function parseMeta(content) {
     reportsTo:      parseField(content, 'Reports To'),
     directReports:  parseField(content, 'Direct Reports'),
     lastReviewed:   parseField(content, 'Last Reviewed'),
+    // Review provenance (#179). Last Reviewed alone records only that the file
+    // was touched; these say who stands behind the content and whether the date
+    // reflects a subject-matter review or a bulk edit.
+    contentOwner:   parseField(content, 'Content Owner'),
+    reviewStatus:   parseField(content, 'Review Status'),
   };
 }
 

--- a/scripts/backfill-review-provenance.js
+++ b/scripts/backfill-review-provenance.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// Adds the review-provenance fields from #179 to every role.
+//
+// Before this, the only governance metadata was Last Reviewed, and 206 of 226
+// roles shared 2026-03 — a bulk stamp rather than 206 reviews. The field
+// therefore recorded when the file was last touched, which git already knows,
+// and implied a review that had not happened.
+//
+// Two fields fix that. Content Owner names who stands behind the content, as a
+// durable role identifier rather than a person so the catalogue stays portable
+// when another organisation adopts it. Review Status says whether the date
+// reflects subject-matter review or a mechanical edit.
+//
+// The backfill claims "mechanical", never "reviewed": it can see that the files
+// were edited, not that anyone read them. Promoting a role is a human act.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
+
+const OWNER = 'catalogue-maintainers';
+const STATUS = 'mechanical';
+
+function addProvenanceFields(text) {
+    if (/\|\s*\*\*Content Owner\*\*/.test(text) && /\|\s*\*\*Review Status\*\*/.test(text)) return text;
+
+    const lines = text.split('\n');
+    const at = lines.findIndex(l => /^\|\s*\*\*Last Reviewed\*\*/.test(l));
+    if (at === -1) return text;
+
+    // Above the date, so a reader meets the owner and the status before the
+    // value they qualify.
+    lines.splice(at, 0,
+        `| **Content Owner** | ${OWNER} |`,
+        `| **Review Status** | ${STATUS} |`);
+
+    return lines.join('\n');
+}
+
+function roleFiles(dir = ROLES_DIR, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) roleFiles(full, out);
+        else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(full);
+    }
+    return out;
+}
+
+function run({ write }) {
+    let changed = 0;
+    let skipped = 0;
+
+    for (const file of roleFiles()) {
+        const original = fs.readFileSync(file, 'utf8');
+        const hadBom = original.startsWith('﻿');
+        const hadCrlf = original.includes('\r\n');
+        const body = original.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+        const updated = addProvenanceFields(body);
+        if (updated === body) { skipped++; continue; }
+        changed++;
+
+        if (write) {
+            const out = (hadBom ? '﻿' : '') + (hadCrlf ? updated.replace(/\n/g, '\r\n') : updated);
+            fs.writeFileSync(file, out, 'utf8');
+        }
+    }
+
+    console.log(`${write ? 'Updated' : 'Would update'} ${changed} role file(s); ${skipped} already carried the fields or had no metadata table.`);
+}
+
+if (require.main === module) run({ write: process.argv.includes('--write') });
+
+module.exports = { addProvenanceFields, OWNER, STATUS };

--- a/test/backfill-review-provenance.test.js
+++ b/test/backfill-review-provenance.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { addProvenanceFields } = require('../scripts/backfill-review-provenance.js');
+
+// #179 adds Content Owner and Review Status to every role. The backfill states
+// the honest position rather than a flattering one: 206 of 226 roles shared a
+// single Last Reviewed month, so their dates record a bulk edit and the status
+// says so. An owner promotes a role to "reviewed" by actually reviewing it.
+
+const META = [
+    '# Test Role',
+    '',
+    '| Field | Value |',
+    '|---|---|',
+    '| **Domain** | Kubernetes |',
+    '| **Role Level** | Engineer |',
+    '| **Reports To** | Senior Engineer |',
+    '| **Direct Reports** | None |',
+    '| **Last Reviewed** | 2026-03 |',
+    '',
+    '---',
+    '',
+    '## Role Overview',
+    '',
+    'Text.',
+    '',
+].join('\n');
+
+test('the provenance fields are added above Last Reviewed', () => {
+    const out = addProvenanceFields(META);
+    const lines = out.split('\n');
+    const owner = lines.findIndex(l => l.includes('**Content Owner**'));
+    const status = lines.findIndex(l => l.includes('**Review Status**'));
+    const reviewed = lines.findIndex(l => l.includes('**Last Reviewed**'));
+
+    assert.ok(owner !== -1 && status !== -1, 'both fields should be present');
+    assert.ok(owner < reviewed && status < reviewed, 'provenance fields belong above the date they qualify');
+});
+
+test('the owner is a durable identifier, not a person', () => {
+    assert.match(addProvenanceFields(META), /\|\s*\*\*Content Owner\*\*\s*\|\s*catalogue-maintainers\s*\|/);
+});
+
+test('an existing bulk-stamped date is labelled mechanical, not reviewed', () => {
+    assert.match(addProvenanceFields(META), /\|\s*\*\*Review Status\*\*\s*\|\s*mechanical\s*\|/);
+});
+
+test('a role that already has the fields is left untouched', () => {
+    const once = addProvenanceFields(META);
+    assert.equal(addProvenanceFields(once), once);
+});
+
+test('nothing outside the metadata table changes', () => {
+    const out = addProvenanceFields(META);
+    assert.match(out, /## Role Overview\n\nText\./);
+    assert.match(out, /\|\s*\*\*Reports To\*\*\s*\|\s*Senior Engineer\s*\|/);
+    assert.equal(out.split('\n').length, META.split('\n').length + 2);
+});
+
+test('a document with no metadata table is returned unchanged', () => {
+    const plain = '# Doc\n\nNo table here.\n';
+    assert.equal(addProvenanceFields(plain), plain);
+});

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -52,6 +52,8 @@ function completeRole({ except = null, transform = null } = {}) {
 | **Role Level** | Engineer |
 | **Reports To** | Test Chapter Lead |
 | **Direct Reports** | None |
+| **Content Owner** | catalogue-maintainers |
+| **Review Status** | reviewed |
 | **Last Reviewed** | 2026-07 |
 
 ${sections}`;
@@ -155,6 +157,50 @@ test('missing Direct Reports metadata is an error', () => {
   const file = writeFixture('no-direct-reports.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Direct Reports\*\*.*\n/, '') }));
   const r = validateFile(file, tmpRoot);
   assert.deepEqual(r.errors, ['Missing **Direct Reports** metadata field']);
+});
+
+// ── review provenance (#179) ──
+//
+// A populated Last Reviewed date shows only that the file was touched. These
+// fields record who stands behind the content and whether the date reflects a
+// subject-matter review or a bulk edit — the distinction that matters while
+// #230 to #245 rewrite every role's certification section.
+
+test('missing Content Owner metadata is an error', () => {
+    const file = writeFixture('no-owner.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Content Owner\*\*.*\n/, '') }));
+    const r = validateFile(file, tmpRoot);
+    assert.deepEqual(r.errors, ['Missing **Content Owner** metadata field']);
+});
+
+test('missing Review Status metadata is an error', () => {
+    const file = writeFixture('no-review-status.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Review Status\*\*.*\n/, '') }));
+    const r = validateFile(file, tmpRoot);
+    assert.deepEqual(r.errors, ['Missing **Review Status** metadata field']);
+});
+
+test('Review Status outside the vocabulary is an error', () => {
+    const file = writeFixture('bad-review-status.md', completeRole({ transform: c => c.replace(/(\*\*Review Status\*\* \| )reviewed/, '$1current') }));
+    const r = validateFile(file, tmpRoot);
+    assert.equal(r.errors.length, 1);
+    assert.match(r.errors[0], /Review Status "current"/);
+});
+
+test('every value in the review status vocabulary is accepted', () => {
+    for (const status of ['reviewed', 'mechanical', 'unreviewed']) {
+        const file = writeFixture(`status-${status}.md`, completeRole({ transform: c => c.replace(/(\*\*Review Status\*\* \| )reviewed/, `$1${status}`) }));
+        const r = validateFile(file, tmpRoot);
+        assert.deepEqual(r.errors, [], `${status} should be accepted`);
+    }
+});
+
+// A role whose date is a bulk stamp must not read as reviewed content. The
+// warning keeps the gap countable without failing CI, the same way the KPI
+// and credential-staleness warnings do.
+test('a mechanical review status warns that provenance is unestablished', () => {
+    const file = writeFixture('mechanical.md', completeRole({ transform: c => c.replace(/(\*\*Review Status\*\* \| )reviewed/, '$1mechanical') }));
+    const r = validateFile(file, tmpRoot);
+    assert.equal(r.errors.length, 0);
+    assert.ok(r.warnings.some(w => /not been reviewed/i.test(w)), `expected a provenance warning, got ${JSON.stringify(r.warnings)}`);
 });
 
 test('"None" is a valid Direct Reports value for individual contributors', () => {

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -27,6 +27,11 @@ const STRICT     = process.argv.includes('--strict');
 // now also raises a canonical-heading warning (#121) so the drift is visible
 // and countable; #122 normalises the files, after which the alternates can be
 // dropped and CI can move to `--strict`.
+// Review provenance vocabulary (#179). "mechanical" is the honest default for
+// a role whose date came from a bulk edit rather than a review; "reviewed" is
+// claimed only when an owner has actually read the content.
+const REVIEW_STATUSES = new Set(['reviewed', 'mechanical', 'unreviewed']);
+
 const REQUIRED_SECTIONS = [
   { name: 'Role Overview',                          patterns: [/^##\s+Role Overview/im] },
   { name: 'Role Scope & Boundaries',                patterns: [/^##\s+Role Scope (&|and) Boundaries/im] },
@@ -150,6 +155,23 @@ function validateFile(filePath, rolesDir = ROLES_DIR, credentialContext = null) 
     errors.push('Missing **Last Reviewed** metadata field');
   } else if (!/^\d{4}-\d{2}$/.test(meta.lastReviewed)) {
     warnings.push(`Last Reviewed "${meta.lastReviewed}" is not in YYYY-MM format`);
+  }
+
+  // Review provenance (#179). A populated Last Reviewed date shows only that
+  // the file was touched -- 206 roles shared one month before this was added.
+  // Content Owner names who stands behind the content, as a durable role
+  // identifier rather than a person so the catalogue stays portable; Review
+  // Status says whether the date reflects subject-matter review or a bulk edit.
+  if (!meta.contentOwner) errors.push('Missing **Content Owner** metadata field');
+
+  if (!meta.reviewStatus) {
+    errors.push('Missing **Review Status** metadata field');
+  } else if (!REVIEW_STATUSES.has(meta.reviewStatus)) {
+    errors.push(`Review Status "${meta.reviewStatus}" is not one of: ${[...REVIEW_STATUSES].join(', ')}`);
+  } else if (meta.reviewStatus !== 'reviewed') {
+    // A warning, not an error: the gap stays countable without failing CI,
+    // the same way the KPI target gap does.
+    warnings.push(`Review Status is "${meta.reviewStatus}" — the content has not been reviewed by its owner, so Last Reviewed records only when the file was last touched`);
   }
 
   for (const section of REQUIRED_SECTIONS) {


### PR DESCRIPTION
Refs #179 — implements the decision you recorded on the issue. Viewer display (acceptance criterion 4) is deliberately out of scope, so the metadata lands before #230–#245 rewrite these files.

## Why now rather than later

#227 already rewrote 105 role files mechanically, and #230–#245 will rewrite every role's certification section. Under any rule where touching a file refreshes its review date, **the credential rollout would leave all 226 roles looking freshly reviewed** by an owner who never read them. Adding a metadata row while those batches are already touching every file costs nothing; a separate pass later means touching all 226 again.

## The problem, measured

- **206 of 226** roles shared `Last Reviewed: 2026-03` — one month across 91% of the catalogue is a bulk stamp, not 206 reviews
- Exactly **1** role of 226 named an owner or reviewer anywhere in its body
- The metadata table had **no owner field at all**

So the field recorded when a file was last touched — which git already knows — while implying a review that had not happened.

## The decision, per your call on the issue

> "I am the owner of the entire website and docs — and the reviewer... For a company implementing this, then I guess chapter leads would stand as reviewers or similar."

**`Content Owner` holds a durable role identifier, never a person.** `catalogue-maintainers` here; the accountable chapter lead in an adopting organisation. The catalogue is meant to be shared and copied, so it should not carry personal data, and an identifier survives someone changing jobs where a name turns every departure into a catalogue-wide edit.

**`Review Status` says what the date means** — `reviewed`, `mechanical`, or `unreviewed`.

**A bulk pass may not claim a review.** A mechanical rewrite leaves `Last Reviewed` alone and sets `mechanical`. Only a human reading the content may set `reviewed`. Tooling can observe that a file changed; it cannot observe that anyone read it.

Recorded as [ADR-0004](docs/adr/0004-record-review-provenance-with-durable-owner-identifiers.md).

## The existing dates are kept and labelled, not deleted

They truthfully record a touch and only untruthfully imply a review, so the honest fix is the label.

**All 226 roles start at `mechanical`, so `npm run validate` now warns on all 226** — up from 199. That is the intended outcome: the review debt is countable from day one instead of hidden behind a populated date. The catalogue looks worse, accurately. Warning not error, matching how the KPI gap (#140) and credential staleness already behave.

## Changes

| | |
|---|---|
| `roleMeta.js` | parses the two new fields |
| `validate-roles.js` | requires both; validates the status vocabulary; warns when not `reviewed` |
| `scripts/backfill-review-provenance.js` | adds the fields; reports and applies separately |
| `docs/role_template.md` | documents the fields and the identifier rule |
| `docs/adr/0004-…` | the decision record, indexed |
| 226 role files | two metadata rows each |

## Verification

- `npm test` — **341/341** pass (was 330); 11 new tests, all written first
- `npm run validate` — **0 errors**, 226 warnings (the intended provenance gap)
- `npm run check-counts` — 226 roles / 34 domains / 7 chapters, README matches
- `markdownlint-cli2 docs/**/*.md` — 0 issues
- Backfill is **idempotent** — a re-run reports 0 files
- **0 BOMs lost** across all 226 files, verified by byte comparison against `HEAD`; CRLF preserved

## Review note

224 of the 229 changed files are the same two-line insertion. `Roles/kubernetes/kubernetes_engineer.md` is representative. The files worth reading are the validator, the backfill script, and the ADR.
