### PR TITLE
feat: give every role a stable identifier

### DIFF
--- a/Roles/ai_governance/ai_governance_architect.md
+++ b/Roles/ai_governance/ai_governance_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `ai-governance-architect` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/ai_governance/ai_governance_engineer.md
+++ b/Roles/ai_governance/ai_governance_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `ai-governance-engineer` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/ai_governance/ai_governance_product_owner.md
+++ b/Roles/ai_governance/ai_governance_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `ai-governance-product-owner` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |

--- a/Roles/ai_governance/ai_governance_senior_engineer.md
+++ b/Roles/ai_governance/ai_governance_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `ai-governance-senior-engineer` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/ai_governance/ai_platform_architect.md
+++ b/Roles/ai_governance/ai_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `ai-platform-architect` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/ai_governance/ai_platform_engineer.md
+++ b/Roles/ai_governance/ai_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `ai-platform-engineer` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/ai_governance/responsible_ai_engineer.md
+++ b/Roles/ai_governance/responsible_ai_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `responsible-ai-engineer` |
 | **Domain** | AI Governance |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/app_platforms/api_platform_architect.md
+++ b/Roles/app_platforms/api_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `api-platform-architect` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/app_platforms/api_platform_engineer.md
+++ b/Roles/app_platforms/api_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `api-platform-engineer` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/app_platforms/api_platform_product_owner.md
+++ b/Roles/app_platforms/api_platform_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `api-platform-product-owner` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |

--- a/Roles/app_platforms/api_platform_senior_engineer.md
+++ b/Roles/app_platforms/api_platform_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `api-platform-senior-engineer` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |

--- a/Roles/app_platforms/api_strategy_architect.md
+++ b/Roles/app_platforms/api_strategy_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `api-strategy-architect` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/app_platforms/dotnet_architect.md
+++ b/Roles/app_platforms/dotnet_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `net-architect` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/app_platforms/dotnet_engineer.md
+++ b/Roles/app_platforms/dotnet_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `net-engineer` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/app_platforms/dotnet_product_owner.md
+++ b/Roles/app_platforms/dotnet_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `net-platform-product-owner` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |

--- a/Roles/app_platforms/dotnet_senior_engineer.md
+++ b/Roles/app_platforms/dotnet_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `net-senior-engineer` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |

--- a/Roles/app_platforms/java_architect.md
+++ b/Roles/app_platforms/java_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `java-platform-architect` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/app_platforms/java_engineer.md
+++ b/Roles/app_platforms/java_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `java-engineer` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/app_platforms/java_product_owner.md
+++ b/Roles/app_platforms/java_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `java-platform-product-owner` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |

--- a/Roles/app_platforms/java_senior_engineer.md
+++ b/Roles/app_platforms/java_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `java-senior-engineer` |
 | **Domain** | App Platforms |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |

--- a/Roles/c_suite/chief_executive_officer.md
+++ b/Roles/c_suite/chief_executive_officer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `chief-executive-officer` |
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CEO |

--- a/Roles/c_suite/chief_financial_officer.md
+++ b/Roles/c_suite/chief_financial_officer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `chief-financial-officer` |
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CFO |

--- a/Roles/c_suite/chief_information_officer.md
+++ b/Roles/c_suite/chief_information_officer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `chief-information-officer` |
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CIO |

--- a/Roles/c_suite/chief_technology_officer.md
+++ b/Roles/c_suite/chief_technology_officer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `chief-technology-officer` |
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CTO |

--- a/Roles/client_platform/client_platform_architect.md
+++ b/Roles/client_platform/client_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `client-platform-architect` |
 | **Domain** | Client Platform |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Architect |

--- a/Roles/client_platform/client_platform_engineer.md
+++ b/Roles/client_platform/client_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `client-platform-engineer` |
 | **Domain** | Client Platform |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Engineer |

--- a/Roles/client_platform/client_platform_product_owner.md
+++ b/Roles/client_platform/client_platform_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `client-platform-product-owner` |
 | **Domain** | Client Platform |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Product Owner |

--- a/Roles/client_platform/client_platform_senior_engineer.md
+++ b/Roles/client_platform/client_platform_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `client-platform-senior-engineer` |
 | **Domain** | Client Platform |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Senior Engineer |

--- a/Roles/cloud_platforms/aws_cloud_architect.md
+++ b/Roles/cloud_platforms/aws_cloud_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `aws-cloud-architect` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `aws-cloud-engineer` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/cloud_platforms/aws_cloud_product_owner.md
+++ b/Roles/cloud_platforms/aws_cloud_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `aws-cloud-platform-product-owner` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/cloud_platforms/aws_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `aws-cloud-senior-engineer` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/cloud_platforms/azure_cloud_architect.md
+++ b/Roles/cloud_platforms/azure_cloud_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `azure-cloud-architect` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/cloud_platforms/azure_cloud_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `azure-cloud-engineer` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/cloud_platforms/azure_cloud_product_owner.md
+++ b/Roles/cloud_platforms/azure_cloud_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `azure-cloud-platform-product-owner` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/cloud_platforms/azure_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/azure_cloud_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `azure-cloud-senior-engineer` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/cloud_platforms/cloud_lead_architect.md
+++ b/Roles/cloud_platforms/cloud_lead_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-lead-architect` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Lead Architect |

--- a/Roles/cloud_platforms/cloud_principal_architect.md
+++ b/Roles/cloud_platforms/cloud_principal_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-principal-architect` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Principal Architect |

--- a/Roles/cloud_platforms/gcp_cloud_architect.md
+++ b/Roles/cloud_platforms/gcp_cloud_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `google-cloud-architect` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `google-cloud-engineer` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/cloud_platforms/gcp_cloud_product_owner.md
+++ b/Roles/cloud_platforms/gcp_cloud_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `google-cloud-product-owner` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `google-cloud-senior-engineer` |
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_engineering/data_engineer.md
+++ b/Roles/data_engineering/data_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-engineer` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/data_engineering/data_engineering_product_owner.md
+++ b/Roles/data_engineering/data_engineering_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-engineering-product-owner` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |

--- a/Roles/data_engineering/data_mesh_architect.md
+++ b/Roles/data_engineering/data_mesh_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-mesh-architect` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/data_engineering/data_platform_architect.md
+++ b/Roles/data_engineering/data_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-platform-architect` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/data_engineering/data_platform_engineer.md
+++ b/Roles/data_engineering/data_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-platform-engineer` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/data_engineering/data_senior_engineer.md
+++ b/Roles/data_engineering/data_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-senior-engineer` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_engineering/dataops_specialist.md
+++ b/Roles/data_engineering/dataops_specialist.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `dataops-specialist` |
 | **Domain** | Data Engineering |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_management/data_governance_lead.md
+++ b/Roles/data_management/data_governance_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-governance-lead` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_management/data_privacy_officer.md
+++ b/Roles/data_management/data_privacy_officer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-privacy-officer` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_management/qumulo_storage_architect.md
+++ b/Roles/data_management/qumulo_storage_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `qumulo-storage-architect` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/data_management/qumulo_storage_engineer.md
+++ b/Roles/data_management/qumulo_storage_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `qumulo-storage-engineer` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `qumulo-storage-product-owner` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |

--- a/Roles/data_management/qumulo_storage_senior_engineer.md
+++ b/Roles/data_management/qumulo_storage_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `qumulo-storage-senior-engineer` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_management/storage_architect.md
+++ b/Roles/data_management/storage_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `storage-architect` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/data_management/storage_engineer.md
+++ b/Roles/data_management/storage_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `storage-engineer` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/data_management/storage_product_owner.md
+++ b/Roles/data_management/storage_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `storage-product-owner` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |

--- a/Roles/data_management/storage_senior_engineer.md
+++ b/Roles/data_management/storage_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `storage-senior-engineer` |
 | **Domain** | Data Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_protection/backup_reliability_engineer.md
+++ b/Roles/data_protection/backup_reliability_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `backup-reliability-engineer` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/data_protection/business_continuity_disaster_recovery_manager.md
+++ b/Roles/data_protection/business_continuity_disaster_recovery_manager.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `business-continuity-disaster-recovery-manager` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_protection/commvault_architect.md
+++ b/Roles/data_protection/commvault_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `commvault-architect` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/data_protection/commvault_engineer.md
+++ b/Roles/data_protection/commvault_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `commvault-engineer` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/data_protection/commvault_product_owner.md
+++ b/Roles/data_protection/commvault_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `commvault-product-owner` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/data_protection/commvault_senior_engineer.md
+++ b/Roles/data_protection/commvault_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `commvault-senior-engineer` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/data_protection/simplivity_backup_architect.md
+++ b/Roles/data_protection/simplivity_backup_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `simplivity-backup-architect` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/data_protection/simplivity_backup_engineer.md
+++ b/Roles/data_protection/simplivity_backup_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `simplivity-backup-engineer` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/data_protection/simplivity_backup_product_owner.md
+++ b/Roles/data_protection/simplivity_backup_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `simplivity-backup-product-owner` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/data_protection/simplivity_backup_senior_engineer.md
+++ b/Roles/data_protection/simplivity_backup_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `simplivity-backup-senior-engineer` |
 | **Domain** | Data Protection |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/database_management/database_architect.md
+++ b/Roles/database_management/database_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `database-architect` |
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Architect |

--- a/Roles/database_management/database_engineer.md
+++ b/Roles/database_management/database_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `database-engineer` |
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/database_management/database_product_owner.md
+++ b/Roles/database_management/database_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `database-product-owner` |
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Product Owner |

--- a/Roles/database_management/database_reliability_engineer.md
+++ b/Roles/database_management/database_reliability_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `database-reliability-engineer` |
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Engineer |

--- a/Roles/database_management/database_senior_engineer.md
+++ b/Roles/database_management/database_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `database-senior-engineer` |
 | **Domain** | Database Management |
 | **Chapter:** | Data & AI |
 | **Role Level** | Senior Engineer |

--- a/Roles/devops/automation_framework_engineer.md
+++ b/Roles/devops/automation_framework_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `automation-framework-engineer` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/devops/developer_experience_engineer.md
+++ b/Roles/devops/developer_experience_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `developer-experience-engineer` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/devops/devops_architect.md
+++ b/Roles/devops/devops_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devops-architect` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devops-engineer` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devops-product-owner` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devops-senior-engineer` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |

--- a/Roles/devops/platform_reliability_engineer.md
+++ b/Roles/devops/platform_reliability_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `platform-reliability-engineer` |
 | **Domain** | DevOps |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/directory_services/windows_active_directory_architect.md
+++ b/Roles/directory_services/windows_active_directory_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-active-directory-architect` |
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/directory_services/windows_active_directory_engineer.md
+++ b/Roles/directory_services/windows_active_directory_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-active-directory-engineer` |
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/directory_services/windows_active_directory_product_owner.md
+++ b/Roles/directory_services/windows_active_directory_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-active-directory-product-owner` |
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-active-directory-senior-engineer` |
 | **Domain** | Directory Services |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/endpoint_management/endpoint_management_architect.md
+++ b/Roles/endpoint_management/endpoint_management_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `endpoint-management-architect` |
 | **Domain** | Endpoint Management |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Architect |

--- a/Roles/endpoint_management/endpoint_management_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `endpoint-management-engineer` |
 | **Domain** | Endpoint Management |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Engineer |

--- a/Roles/endpoint_management/endpoint_management_product_owner.md
+++ b/Roles/endpoint_management/endpoint_management_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `endpoint-management-product-owner` |
 | **Domain** | Endpoint Management |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Product Owner |

--- a/Roles/endpoint_management/endpoint_management_senior_engineer.md
+++ b/Roles/endpoint_management/endpoint_management_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `endpoint-management-senior-engineer` |
 | **Domain** | Endpoint Management |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Senior Engineer |

--- a/Roles/endpoint_management/sccm_engineer.md
+++ b/Roles/endpoint_management/sccm_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `sccm-engineer` |
 | **Domain** | Endpoint Management |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Engineer |

--- a/Roles/enterprise_architecture/enterprise_architect.md
+++ b/Roles/enterprise_architecture/enterprise_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-architect` |
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |

--- a/Roles/enterprise_architecture/enterprise_architecture_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-architecture-engineer` |
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |

--- a/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-architecture-product-owner` |
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |

--- a/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
+++ b/Roles/enterprise_architecture/enterprise_architecture_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-architecture-senior-engineer` |
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/enterprise_architecture/solution_architect.md
+++ b/Roles/enterprise_architecture/solution_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `solution-architect` |
 | **Domain** | Enterprise Architecture |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |

--- a/Roles/finops/cloud_cost_optimization_engineer.md
+++ b/Roles/finops/cloud_cost_optimization_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-cost-optimization-engineer` |
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/finops/cloud_cost_optimization_standards.md
+++ b/Roles/finops/cloud_cost_optimization_standards.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-cost-optimization-standards` |
 | **Domain** | FinOps |
 
 ## Overview

--- a/Roles/finops/cloud_economics_analyst.md
+++ b/Roles/finops/cloud_economics_analyst.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-economics-analyst` |
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/finops/finops_architect.md
+++ b/Roles/finops/finops_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `finops-architect` |
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/finops/finops_engineer.md
+++ b/Roles/finops/finops_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `finops-engineer` |
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/finops/finops_product_owner.md
+++ b/Roles/finops/finops_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `finops-product-owner` |
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/finops/finops_senior_engineer.md
+++ b/Roles/finops/finops_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `finops-senior-engineer` |
 | **Domain** | FinOps |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-infrastructure-onboarding-architect` |
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-infrastructure-onboarding-engineer` |
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-infrastructure-onboarding-product-owner` |
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `enterprise-infrastructure-onboarding-senior-engineer` |
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/integration_middleware/integration_architect.md
+++ b/Roles/integration_middleware/integration_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `integration-architect` |
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/integration_middleware/integration_engineer.md
+++ b/Roles/integration_middleware/integration_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `integration-engineer` |
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/integration_middleware/integration_product_owner.md
+++ b/Roles/integration_middleware/integration_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `integration-product-owner` |
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |

--- a/Roles/integration_middleware/integration_senior_engineer.md
+++ b/Roles/integration_middleware/integration_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `integration-senior-engineer` |
 | **Domain** | Integration & Middleware |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |

--- a/Roles/itsm_configuration/application_configuration_management_architect.md
+++ b/Roles/itsm_configuration/application_configuration_management_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `application-configuration-management-architect` |
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `application-configuration-management-engineer` |
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |

--- a/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `application-configuration-management-senior-engineer` |
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `itsm-product-owner` |
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |

--- a/Roles/kubernetes/kubernetes_architect.md
+++ b/Roles/kubernetes/kubernetes_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `kubernetes-architect` |
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/kubernetes/kubernetes_engineer.md
+++ b/Roles/kubernetes/kubernetes_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `kubernetes-engineer` |
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/kubernetes/kubernetes_product_owner.md
+++ b/Roles/kubernetes/kubernetes_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `kubernetes-product-owner` |
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/kubernetes/kubernetes_senior_engineer.md
+++ b/Roles/kubernetes/kubernetes_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `kubernetes-senior-engineer` |
 | **Domain** | Kubernetes |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/leadership/chief_information_security_officer.md
+++ b/Roles/leadership/chief_information_security_officer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `chief-information-security-officer` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CISO |

--- a/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
+++ b/Roles/leadership/cloud_platform_infrastructure_chapter_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-platform-and-infrastructure-chapter-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |

--- a/Roles/leadership/data_ai_chapter_lead.md
+++ b/Roles/leadership/data_ai_chapter_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `data-and-ai-chapter-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |

--- a/Roles/leadership/devops_delivery_chapter_lead.md
+++ b/Roles/leadership/devops_delivery_chapter_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devops-and-delivery-chapter-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |

--- a/Roles/leadership/end_user_workplace_chapter_lead.md
+++ b/Roles/leadership/end_user_workplace_chapter_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `end-user-and-workplace-chapter-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |

--- a/Roles/leadership/engineering_practices_champion.md
+++ b/Roles/leadership/engineering_practices_champion.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `engineering-practices-champion` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Senior Engineer |

--- a/Roles/leadership/product_area_lead.md
+++ b/Roles/leadership/product_area_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `product-area-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Product Area Lead |

--- a/Roles/leadership/security_identity_chapter_lead.md
+++ b/Roles/leadership/security_identity_chapter_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-and-identity-chapter-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |

--- a/Roles/leadership/service_governance_chapter_lead.md
+++ b/Roles/leadership/service_governance_chapter_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-and-governance-chapter-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Chapter Lead |

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `svp-of-technology` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | SVP of Technology |

--- a/Roles/leadership/technical_area_lead.md
+++ b/Roles/leadership/technical_area_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `technical-area-lead` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Technical Area Lead |

--- a/Roles/leadership/technical_community_leader.md
+++ b/Roles/leadership/technical_community_leader.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `technical-community-leader` |
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | Senior Engineer |

--- a/Roles/modern_infrastructure/chaos_engineer.md
+++ b/Roles/modern_infrastructure/chaos_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `chaos-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/modern_infrastructure/genai_platform_architect.md
+++ b/Roles/modern_infrastructure/genai_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `genai-platform-architect` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/modern_infrastructure/genai_platform_engineer.md
+++ b/Roles/modern_infrastructure/genai_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `genai-platform-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/modern_infrastructure/infrastructure_automation_architect.md
+++ b/Roles/modern_infrastructure/infrastructure_automation_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `infrastructure-automation-architect` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/modern_infrastructure/mlops_engineer.md
+++ b/Roles/modern_infrastructure/mlops_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `mlops-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/modern_infrastructure/observability_architect.md
+++ b/Roles/modern_infrastructure/observability_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `observability-architect` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/modern_infrastructure/observability_engineer.md
+++ b/Roles/modern_infrastructure/observability_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `observability-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/modern_infrastructure/observability_product_owner.md
+++ b/Roles/modern_infrastructure/observability_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `observability-product-owner` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/modern_infrastructure/observability_senior_engineer.md
+++ b/Roles/modern_infrastructure/observability_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `observability-senior-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/modern_infrastructure/platform_engineering_architect.md
+++ b/Roles/modern_infrastructure/platform_engineering_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `platform-engineering-architect` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `platform-engineering-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/modern_infrastructure/platform_engineering_product_owner.md
+++ b/Roles/modern_infrastructure/platform_engineering_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `platform-engineering-product-owner` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `platform-engineering-senior-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/modern_infrastructure/site_reliability_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `site-reliability-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/modern_infrastructure/site_reliability_senior_engineer.md
+++ b/Roles/modern_infrastructure/site_reliability_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `site-reliability-senior-engineer` |
 | **Domain** | Modern Infrastructure |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/modern_workplace/modern_workplace_architect.md
+++ b/Roles/modern_workplace/modern_workplace_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `modern-workplace-architect-microsoft-365` |
 | **Domain** | Modern Workplace |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Architect |

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `modern-workplace-engineer-microsoft-365` |
 | **Domain** | Modern Workplace |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Engineer |

--- a/Roles/modern_workplace/modern_workplace_product_owner.md
+++ b/Roles/modern_workplace/modern_workplace_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `modern-workplace-product-owner-microsoft-365` |
 | **Domain** | Modern Workplace |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Product Owner |

--- a/Roles/modern_workplace/modern_workplace_senior_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `modern-workplace-senior-engineer-microsoft-365` |
 | **Domain** | Modern Workplace |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Senior Engineer |

--- a/Roles/network/network_architect.md
+++ b/Roles/network/network_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `network-architect` |
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/network/network_automation_architect.md
+++ b/Roles/network/network_automation_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `network-automation-architect` |
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/network/network_automation_engineer.md
+++ b/Roles/network/network_automation_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `network-automation-engineer` |
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/network/network_engineer.md
+++ b/Roles/network/network_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `network-engineer` |
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `network-product-owner` |
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/network/network_senior_engineer.md
+++ b/Roles/network/network_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `network-senior-engineer` |
 | **Domain** | Network |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/quality_engineering/quality_engineer.md
+++ b/Roles/quality_engineering/quality_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `quality-engineer` |
 | **Domain** | Quality Engineering |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Engineer |

--- a/Roles/quality_engineering/quality_engineering_architect.md
+++ b/Roles/quality_engineering/quality_engineering_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `quality-engineering-architect` |
 | **Domain** | Quality Engineering |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Architect |

--- a/Roles/quality_engineering/quality_engineering_product_owner.md
+++ b/Roles/quality_engineering/quality_engineering_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `quality-engineering-product-owner` |
 | **Domain** | Quality Engineering |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Product Owner |

--- a/Roles/quality_engineering/quality_engineering_senior_engineer.md
+++ b/Roles/quality_engineering/quality_engineering_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `quality-engineering-senior-engineer` |
 | **Domain** | Quality Engineering |
 | **Chapter:** | DevOps & Delivery |
 | **Role Level** | Senior Engineer |

--- a/Roles/security/devsecops_architect.md
+++ b/Roles/security/devsecops_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devsecops-architect` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/security/devsecops_engineer.md
+++ b/Roles/security/devsecops_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `devsecops-engineer` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/security/grc_risk_compliance_analyst.md
+++ b/Roles/security/grc_risk_compliance_analyst.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `grc-risk-and-compliance-analyst` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security/security_architect.md
+++ b/Roles/security/security_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-architect` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/security/security_engineer.md
+++ b/Roles/security/security_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-engineer` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/security/security_product_owner.md
+++ b/Roles/security/security_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-product-owner` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/security/security_senior_engineer.md
+++ b/Roles/security/security_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-senior-engineer` |
 | **Domain** | Security |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security_cross_platform/cloud_security_posture_manager.md
+++ b/Roles/security_cross_platform/cloud_security_posture_manager.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `cloud-security-posture-manager` |
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security_cross_platform/security_automation_engineer.md
+++ b/Roles/security_cross_platform/security_automation_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-automation-engineer` |
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/security_cross_platform/security_cross_platform_architect.md
+++ b/Roles/security_cross_platform/security_cross_platform_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-cross-platform-architect` |
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/security_cross_platform/security_cross_platform_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-cross-platform-engineer` |
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/security_cross_platform/security_cross_platform_product_owner.md
+++ b/Roles/security_cross_platform/security_cross_platform_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-cross-platform-product-owner` |
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
+++ b/Roles/security_cross_platform/security_cross_platform_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `security-cross-platform-senior-engineer` |
 | **Domain** | Security Cross-Platform |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security_identity/access_management_architect.md
+++ b/Roles/security_identity/access_management_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `access-management-architect` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/security_identity/access_management_engineer.md
+++ b/Roles/security_identity/access_management_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `access-management-engineer` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/security_identity/access_management_product_owner.md
+++ b/Roles/security_identity/access_management_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `access-management-product-owner` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/security_identity/access_management_senior_engineer.md
+++ b/Roles/security_identity/access_management_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `access-management-senior-engineer` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security_identity/identity_governance_specialist.md
+++ b/Roles/security_identity/identity_governance_specialist.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `identity-and-access-governance-specialist` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security_identity/identity_management_architect.md
+++ b/Roles/security_identity/identity_management_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `identity-management-architect` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/security_identity/identity_management_engineer.md
+++ b/Roles/security_identity/identity_management_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `identity-management-engineer` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/security_identity/identity_management_product_owner.md
+++ b/Roles/security_identity/identity_management_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `identity-management-product-owner` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Product Owner |

--- a/Roles/security_identity/identity_management_senior_engineer.md
+++ b/Roles/security_identity/identity_management_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `identity-management-senior-engineer` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Senior Engineer |

--- a/Roles/security_identity/privileged_access_management_architect.md
+++ b/Roles/security_identity/privileged_access_management_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `privileged-access-management-architect` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Architect |

--- a/Roles/security_identity/privileged_access_management_engineer.md
+++ b/Roles/security_identity/privileged_access_management_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `privileged-access-management-engineer` |
 | **Domain** | Security & Identity |
 | **Chapter:** | Security & Identity |
 | **Role Level** | Engineer |

--- a/Roles/server_hardware/server_hardware_architect.md
+++ b/Roles/server_hardware/server_hardware_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `server-hardware-architect` |
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/server_hardware/server_hardware_engineer.md
+++ b/Roles/server_hardware/server_hardware_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `server-hardware-engineer` |
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/server_hardware/server_hardware_product_owner.md
+++ b/Roles/server_hardware/server_hardware_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `server-hardware-product-owner` |
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/server_hardware/server_hardware_senior_engineer.md
+++ b/Roles/server_hardware/server_hardware_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `server-hardware-senior-engineer` |
 | **Domain** | Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpe-server-hardware-architect` |
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpe-server-hardware-engineer` |
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpe-server-hardware-product-owner` |
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
+++ b/Roles/server_hardware_hpe/hpe_server_hardware_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpe-server-hardware-senior-engineer` |
 | **Domain** | HPE Server Hardware |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `linux-server-architect` |
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/server_os_linux/linux_server_engineer.md
+++ b/Roles/server_os_linux/linux_server_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `linux-server-engineer` |
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/server_os_linux/linux_server_product_owner.md
+++ b/Roles/server_os_linux/linux_server_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `linux-server-product-owner` |
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/server_os_linux/linux_server_senior_engineer.md
+++ b/Roles/server_os_linux/linux_server_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `linux-server-senior-engineer` |
 | **Domain** | Linux Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-server-architect` |
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/server_os_windows/windows_server_engineer.md
+++ b/Roles/server_os_windows/windows_server_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-server-engineer` |
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-server-product-owner` |
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `windows-server-senior-engineer` |
 | **Domain** | Windows Server OS |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_desk/service_desk_analyst.md
+++ b/Roles/service_desk/service_desk_analyst.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-desk-analyst` |
 | **Domain** | Service Desk |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Engineer |

--- a/Roles/service_desk/service_desk_lead.md
+++ b/Roles/service_desk/service_desk_lead.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-desk-lead` |
 | **Domain** | Service Desk |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_desk/service_desk_product_owner.md
+++ b/Roles/service_desk/service_desk_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-desk-product-owner` |
 | **Domain** | Service Desk |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Product Owner |

--- a/Roles/service_desk/service_desk_senior_analyst.md
+++ b/Roles/service_desk/service_desk_senior_analyst.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-desk-senior-analyst` |
 | **Domain** | Service Desk |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_management/change_release_manager.md
+++ b/Roles/service_management/change_release_manager.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `change-release-manager` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_management/major_incident_manager.md
+++ b/Roles/service_management/major_incident_manager.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `major-incident-manager` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_management/service_management_architect.md
+++ b/Roles/service_management/service_management_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-management-architect` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Architect |

--- a/Roles/service_management/service_management_engineer.md
+++ b/Roles/service_management/service_management_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-management-engineer` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |

--- a/Roles/service_management/service_management_product_owner.md
+++ b/Roles/service_management/service_management_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-management-product-owner` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Product Owner |

--- a/Roles/service_management/service_management_senior_engineer.md
+++ b/Roles/service_management/service_management_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `service-management-senior-engineer` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_management/technical_program_manager.md
+++ b/Roles/service_management/technical_program_manager.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `technical-program-manager-delivery-manager` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/service_management/vendor_supplier_it_asset_manager.md
+++ b/Roles/service_management/vendor_supplier_it_asset_manager.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `vendor-supplier-it-asset-manager` |
 | **Domain** | Service Management |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Senior Engineer |

--- a/Roles/specialized_computing/hpc_architect.md
+++ b/Roles/specialized_computing/hpc_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpc-architect` |
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/specialized_computing/hpc_engineer.md
+++ b/Roles/specialized_computing/hpc_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpc-engineer` |
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/specialized_computing/hpc_product_owner.md
+++ b/Roles/specialized_computing/hpc_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpc-product-owner` |
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/specialized_computing/hpc_senior_engineer.md
+++ b/Roles/specialized_computing/hpc_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hpc-senior-engineer` |
 | **Domain** | Specialized Computing |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/virtualization/hyperv_architect.md
+++ b/Roles/virtualization/hyperv_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hyper-v-architect` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/virtualization/hyperv_engineer.md
+++ b/Roles/virtualization/hyperv_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hyper-v-engineer` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/virtualization/hyperv_product_owner.md
+++ b/Roles/virtualization/hyperv_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hyper-v-product-owner` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `hyper-v-senior-engineer` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/virtualization/nutanix_architect.md
+++ b/Roles/virtualization/nutanix_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `nutanix-architect` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/virtualization/nutanix_engineer.md
+++ b/Roles/virtualization/nutanix_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `nutanix-engineer` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/virtualization/nutanix_product_owner.md
+++ b/Roles/virtualization/nutanix_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `nutanix-product-owner` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/virtualization/nutanix_senior_engineer.md
+++ b/Roles/virtualization/nutanix_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `nutanix-senior-engineer` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/Roles/virtualization/vmware_architect.md
+++ b/Roles/virtualization/vmware_architect.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `vmware-architect` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Architect |

--- a/Roles/virtualization/vmware_engineer.md
+++ b/Roles/virtualization/vmware_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `vmware-engineer` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |

--- a/Roles/virtualization/vmware_product_owner.md
+++ b/Roles/virtualization/vmware_product_owner.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `vmware-product-owner` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Product Owner |

--- a/Roles/virtualization/vmware_senior_engineer.md
+++ b/Roles/virtualization/vmware_senior_engineer.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | `vmware-senior-engineer` |
 | **Domain** | Virtualization |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Senior Engineer |

--- a/docs/adr/0005-identify-roles-by-a-stable-id-rather-than-by-title.md
+++ b/docs/adr/0005-identify-roles-by-a-stable-id-rather-than-by-title.md
@@ -1,0 +1,38 @@
+# ADR-0005: Identify roles by a stable ID rather than by title
+
+- **Status:** Accepted
+- **Date:** 2026-08-14
+- **Issue/PR:** #180
+
+## Context
+
+Reporting lines, direct reports, career paths, and interaction tables all reference roles by human-readable title. Titles change, and when one does the references to it break silently.
+
+That is not hypothetical. Checking every `Reports To` against every role title on `main` found **203 of 226 resolving** and 23 not — and the 23 are three different things:
+
+- **7 are correct**: `CEO`, `Board of Directors`, `SVP of Technology`. Destinations deliberately outside the catalogue, which the catalogue has no way to express.
+- **12 are a choice**, not an edge: `Technical Area Lead (TAL) or Product Area Lead (PAL)` and similar. One field holding an either/or cannot be validated or drawn.
+- **4 are drift**: `Infrastructure Onboarding Senior Engineer` should be *Enterprise* Infrastructure Onboarding Senior Engineer; `Configuration Management Senior Engineer` should be *Application* Configuration Management Senior Engineer; `Modern Workplace Senior Engineer` is missing its *(Microsoft 365)* qualifier; and `GCP Cloud Senior Engineer` names a role the catalogue does not contain at all.
+
+Nothing reports the last group, because a stale name is indistinguishable from a deliberate reference to something outside the catalogue. Validation cannot tell a typo from an intentional external destination when both are just free text that fails to match.
+
+## Decision
+
+**Every role carries a `Role ID`: lowercase kebab-case, unique across the catalogue, assigned once and never reused.**
+
+The id is seeded from the role title on first assignment and then **frozen**. It is deliberately not derived at read time — an id computed from the title would change when the title changes, which is the failure it exists to prevent. Renaming a role changes its title and leaves its id alone.
+
+Parenthesised qualifiers are preserved when seeding, so `Modern Workplace Senior Engineer (Microsoft 365)` and a plain `Modern Workplace Senior Engineer` cannot collide.
+
+The validator enforces presence, format, and catalogue-wide uniqueness. An id shared by two roles is not an identifier, so duplicates are an error, checked the same way duplicate titles already are.
+
+This mirrors `data/credentials.json`, where a stable id and a mutable display name are already separated. That separation has been exercised in practice: the credential registry survived a real vendor rename this session with the id untouched.
+
+## Consequences
+
+- Relationships gain something stable to point at. Migrating `Reports To`, `Direct Reports`, career paths, and interaction tables onto ids is follow-on work, not part of this decision.
+- Renaming a role becomes safe. Re-homing a role between domains becomes safe. Neither invalidates a reference.
+- The four drifted references above become detectable once relationships resolve against ids, rather than silently unresolvable.
+- Ids seeded from titles will look stale after a rename — `kubernetes-engineer` for a role later called something else. That is correct and intended: the id is an identifier, not a label. Anyone tempted to "fix" it is reintroducing the defect.
+- Two representation gaps remain open, and are deliberately **not** decided here: how a destination outside the catalogue is expressed, and how a genuine either/or is expressed. Both need a decision before relationships can migrate.
+- Ids are metadata, so the catalogue gains a third row in every role's table. This lands before the credential batches in #230–#245 rewrite these files, so the cost is paid once.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ Allowed statuses are `Proposed`, `Accepted`, `Deprecated`, and `Superseded by AD
 | [0002](0002-separate-technical-product-and-people-leadership-tracks.md) | Accepted | Separate technical, product, and people-leadership tracks |
 | [0003](0003-name-credentials-explicitly-rather-than-families-or-topics.md) | Accepted | Name credentials explicitly rather than families or topics |
 | [0004](0004-record-review-provenance-with-durable-owner-identifiers.md) | Accepted | Record review provenance with durable owner identifiers |
+| [0005](0005-identify-roles-by-a-stable-id-rather-than-by-title.md) | Accepted | Identify roles by a stable ID rather than by title |

--- a/docs/role_template.md
+++ b/docs/role_template.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| **Role ID** | [Stable lowercase kebab-case identifier, unique across the catalogue, e.g. `kubernetes-engineer`. Assigned once and never changed — see below.] |
 | **Domain** | [e.g., Cloud Platforms / Security / DevOps / Modern Infrastructure] |
 | **Role Level** | [Engineer / Senior Engineer / Product Owner / Architect / Lead Architect / Principal Architect / Chapter Lead / Technical Area Lead / Product Area Lead / SVP / CISO / CFO / CIO / CTO / CEO] |
 | **Reports To** | [Role title this position reports to, e.g., Cloud Platform Architect] |
@@ -191,6 +192,8 @@
 - [Training platform, community, or learning path, e.g., A Cloud Guru, CNCF community, vendor learning paths]
 
 ---
+
+> **Role ID note:** The id is seeded from the role title when the role is created and then **frozen**. Renaming a role changes its title and leaves its id alone — that is the whole point, since reporting lines and career paths resolve against the id. An id that looks stale after a rename is correct, not a defect to tidy up. Ids are never reused for a different role. See [ADR-0005](adr/0005-identify-roles-by-a-stable-id-rather-than-by-title.md).
 
 > **Review provenance note:** `Content Owner` holds a **durable role identifier**, never a person's name — `catalogue-maintainers` in this repository, and the owning chapter lead in an organisation that adopts the catalogue. Identifiers survive people changing jobs, and keep personal data out of a document intended to be shared.
 >

--- a/roleMeta.js
+++ b/roleMeta.js
@@ -98,6 +98,9 @@ function parseMeta(content) {
   const titleMatch = clean.match(/^#\s+(.+)/m);
   return {
     title:        titleMatch ? titleMatch[1].trim() : null,
+    // Stable identifier (#180). Written in backticks in the role files for
+    // readability; the backticks are presentation, not part of the id.
+    roleId:         (parseField(content, 'Role ID') || '').replace(/`/g, '').trim() || null,
     domain:         parseField(content, 'Domain'),
     chapter:        parseField(content, 'Chapter:') || parseField(content, 'Chapter'),
     levelRaw:       parseField(content, 'Role Level'),

--- a/scripts/backfill-role-ids.js
+++ b/scripts/backfill-role-ids.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// Gives every role the stable identifier decided in #180.
+//
+// Reporting lines, direct reports, career paths, and interaction tables all
+// reference roles by human-readable title today. Titles change, and when one
+// does the references to it fail silently: on main, four reporting lines name a
+// role that no longer exists under that name, and nothing reports it, because a
+// stale name is indistinguishable from a deliberate reference to something
+// outside the catalogue.
+//
+// The id is seeded from the title once and then frozen. It is deliberately not
+// derived at read time — an id computed from the title would change with the
+// title, which is the failure it exists to prevent. Re-running this script
+// never reassigns an existing id.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
+
+// Parenthesised qualifiers are kept: "Modern Workplace Senior Engineer
+// (Microsoft 365)" and a plain "Modern Workplace Senior Engineer" are different
+// roles, and dropping the bracket would collide them.
+function roleIdFromTitle(title) {
+    return String(title)
+        .toLowerCase()
+        .replace(/\(([^)]*)\)/g, ' $1 ')
+        .replace(/&/g, ' and ')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function addRoleId(text) {
+    if (/\|\s*\*\*Role ID\*\*/.test(text)) return text;
+
+    const title = (text.match(/^#\s+(.+)$/m) || [])[1];
+    if (!title) return text;
+
+    const lines = text.split('\n');
+    // First row of the metadata table, so the identifier precedes the
+    // descriptive fields rather than trailing them.
+    const at = lines.findIndex(l => /^\|\s*\*\*[A-Za-z]/.test(l));
+    if (at === -1) return text;
+
+    lines.splice(at, 0, `| **Role ID** | \`${roleIdFromTitle(title.trim())}\` |`);
+    return lines.join('\n');
+}
+
+function roleFiles(dir = ROLES_DIR, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) roleFiles(full, out);
+        else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(full);
+    }
+    return out;
+}
+
+function run({ write }) {
+    const seen = new Map();
+    let changed = 0;
+    let skipped = 0;
+    const collisions = [];
+
+    for (const file of roleFiles()) {
+        const original = fs.readFileSync(file, 'utf8');
+        const hadBom = original.startsWith('﻿');
+        const hadCrlf = original.includes('\r\n');
+        const body = original.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+        const updated = addRoleId(body);
+        const id = (updated.match(/\|\s*\*\*Role ID\*\*\s*\|\s*`([^`]+)`/) || [])[1];
+
+        if (id) {
+            // An id that is not unique is not an identifier.
+            if (seen.has(id)) collisions.push({ id, files: [seen.get(id), file] });
+            else seen.set(id, file);
+        }
+
+        if (updated === body) { skipped++; continue; }
+        changed++;
+
+        if (write) {
+            const out = (hadBom ? '﻿' : '') + (hadCrlf ? updated.replace(/\n/g, '\r\n') : updated);
+            fs.writeFileSync(file, out, 'utf8');
+        }
+    }
+
+    console.log(`${write ? 'Assigned' : 'Would assign'} ${changed} role id(s); ${skipped} already had one or had no metadata table.`);
+
+    if (collisions.length) {
+        console.error(`\n${collisions.length} id collision(s) — these must be resolved by hand:`);
+        for (const c of collisions) console.error(`  ${c.id}\n    ${c.files.join('\n    ')}`);
+        process.exitCode = 1;
+    }
+}
+
+if (require.main === module) run({ write: process.argv.includes('--write') });
+
+module.exports = { roleIdFromTitle, addRoleId };

--- a/scripts/relationship-report.js
+++ b/scripts/relationship-report.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// Reports the state of the catalogue's role relationships (#180).
+//
+// Reporting lines are still written as titles, so this resolves them against
+// role titles and classifies whatever fails to match. That classification is
+// the point: an unresolved reference is not automatically a defect. "CEO" is a
+// correct destination outside the catalogue, "X or Y" is a choice rather than an
+// edge, and "Infrastructure Onboarding Senior Engineer" is drift. Only the last
+// is broken, and today nothing tells them apart.
+//
+// This reports; it never edits. Re-run it before and after a migration so the
+// drift is measured rather than asserted.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
+
+function roleFiles(dir = ROLES_DIR, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) roleFiles(full, out);
+        else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(full);
+    }
+    return out;
+}
+
+function field(text, name) {
+    const m = text.match(new RegExp(`\\|\\s*\\*\\*${name}\\*\\*\\s*\\|\\s*([^|\\n]+)`));
+    return m ? m[1].trim() : null;
+}
+
+// Destinations that sit above or outside the catalogue on purpose.
+const EXTERNAL = /\b(CEO|Board of Directors|Board|CTO|CIO|CFO|CISO|SVP|Executive|Managing Director)\b/i;
+// A single field naming two acceptable destinations is a choice, not an edge.
+const ALTERNATIVE = /\bor\b|\//;
+
+// Token overlap, used only to suggest what a drifted reference probably meant.
+function similarity(a, b) {
+    const A = new Set(a.toLowerCase().split(/\s+/));
+    const B = new Set(b.toLowerCase().split(/\s+/));
+    let shared = 0;
+    for (const w of A) if (B.has(w)) shared++;
+    return shared / Math.max(A.size, B.size);
+}
+
+function buildGraph() {
+    const roles = [];
+    for (const file of roleFiles()) {
+        const rel = path.relative(path.dirname(ROLES_DIR), file).split(path.sep).join('/');
+        const text = fs.readFileSync(file, 'utf8').replace(/^﻿/, '').replace(/\r\n/g, '\n');
+        const title = (text.match(/^#\s+(.+)$/m) || [])[1];
+        if (!title) continue;
+        roles.push({
+            file: rel,
+            id: (field(text, 'Role ID') || '').replace(/`/g, '') || null,
+            title: title.trim(),
+            reportsTo: field(text, 'Reports To'),
+            directReports: field(text, 'Direct Reports'),
+        });
+    }
+
+    const byTitle = new Map(roles.map(r => [r.title, r]));
+    const resolved = [];
+    const external = [];
+    const alternatives = [];
+    const drift = [];
+
+    for (const role of roles) {
+        const target = role.reportsTo;
+        if (!target || /^(none|n\/a|-)$/i.test(target)) continue;
+
+        if (byTitle.has(target)) { resolved.push(role); continue; }
+        if (ALTERNATIVE.test(target)) { alternatives.push({ role, target }); continue; }
+        if (EXTERNAL.test(target)) { external.push({ role, target }); continue; }
+
+        const best = roles
+            .map(r => ({ score: similarity(target, r.title), title: r.title }))
+            .sort((a, b) => b.score - a.score)[0];
+        drift.push({ role, target, suggestion: best && best.score >= 0.5 ? best : null });
+    }
+
+    return { roles, resolved, external, alternatives, drift };
+}
+
+function report() {
+    const { roles, resolved, external, alternatives, drift } = buildGraph();
+
+    console.log(`Roles: ${roles.length}   with a Role ID: ${roles.filter(r => r.id).length}`);
+    console.log('');
+    console.log('Reporting lines:');
+    console.log(`  ${String(resolved.length).padStart(4)}  resolve to a catalogue role`);
+    console.log(`  ${String(external.length).padStart(4)}  name a destination outside the catalogue (correct, but unexpressible today)`);
+    console.log(`  ${String(alternatives.length).padStart(4)}  name a choice rather than one destination`);
+    console.log(`  ${String(drift.length).padStart(4)}  DRIFT — resolve to nothing and are not deliberately external`);
+
+    if (drift.length) {
+        console.log('\nDrifted references:');
+        for (const d of drift) {
+            console.log(`  ${d.role.file}`);
+            console.log(`     Reports To: "${d.target}"`);
+            console.log(d.suggestion
+                ? `     probably:   "${d.suggestion.title}"  (${Math.round(d.suggestion.score * 100)}% token overlap)`
+                : '     no similar role in the catalogue');
+        }
+    }
+
+    if (alternatives.length) {
+        console.log('\nAlternatives (need a representation decision before they can resolve):');
+        const seen = new Map();
+        for (const a of alternatives) seen.set(a.target, (seen.get(a.target) || 0) + 1);
+        for (const [target, n] of [...seen].sort((x, y) => y[1] - x[1])) {
+            console.log(`  ${String(n).padStart(3)}  ${target.slice(0, 84)}`);
+        }
+    }
+
+    process.exitCode = drift.length ? 1 : 0;
+}
+
+if (require.main === module) report();
+
+module.exports = { buildGraph, similarity };

--- a/test/relationship-report.test.js
+++ b/test/relationship-report.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildGraph, similarity } = require('../scripts/relationship-report.js');
+
+// #180's premise is that an unresolved reporting line is not automatically a
+// defect. "CEO" is a correct destination above the catalogue, "X or Y" is a
+// choice rather than an edge, and a stale name is drift. Only the last is
+// broken, and nothing distinguishes them today. These tests pin that
+// classification against the live catalogue, so a regression in either
+// direction — drift going unreported, or a legitimate external destination
+// being called drift — fails loudly.
+
+test('every role carries a Role ID', () => {
+    const { roles } = buildGraph();
+    const without = roles.filter(r => !r.id);
+    assert.deepEqual(without.map(r => r.file), [], 'roles missing a Role ID');
+});
+
+test('role ids are unique across the catalogue', () => {
+    const { roles } = buildGraph();
+    const seen = new Map();
+    for (const r of roles) {
+        if (seen.has(r.id)) assert.fail(`Role ID "${r.id}" is used by both ${seen.get(r.id)} and ${r.file}`);
+        seen.set(r.id, r.file);
+    }
+});
+
+test('the overwhelming majority of reporting lines resolve', () => {
+    const { roles, resolved } = buildGraph();
+    assert.ok(resolved.length > roles.length * 0.85,
+        `only ${resolved.length} of ${roles.length} reporting lines resolve`);
+});
+
+// A guard, not a target. The four known drifted references are recorded in
+// ADR-0005; this fails if that number grows, which is the silent regression
+// the whole issue is about.
+test('drifted reporting lines do not increase beyond the known four', () => {
+    const { drift } = buildGraph();
+    assert.ok(drift.length <= 4,
+        `drifted reporting lines rose to ${drift.length}:\n${drift.map(d => `  ${d.role.file}: "${d.target}"`).join('\n')}`);
+});
+
+test('a destination above the catalogue is not counted as drift', () => {
+    const { external, drift } = buildGraph();
+    assert.ok(external.length > 0, 'expected some external destinations');
+    assert.ok(!drift.some(d => /\bCEO\b|Board of Directors/i.test(d.target)),
+        'CEO and Board of Directors are deliberate, not drift');
+});
+
+test('an either/or destination is classified as a choice, not drift', () => {
+    const { alternatives, drift } = buildGraph();
+    assert.ok(alternatives.length > 0, 'expected some alternatives');
+    assert.ok(!drift.some(d => / or /i.test(d.target)), 'an either/or is a representation gap, not a typo');
+});
+
+test('similarity is symmetric and bounded', () => {
+    assert.equal(similarity('Cloud Engineer', 'Cloud Engineer'), 1);
+    assert.equal(similarity('Cloud Engineer', 'Data Analyst'), 0);
+    assert.equal(
+        similarity('Modern Workplace Engineer', 'Modern Workplace Senior Engineer'),
+        similarity('Modern Workplace Senior Engineer', 'Modern Workplace Engineer'),
+    );
+});

--- a/test/role-ids.test.js
+++ b/test/role-ids.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { roleIdFromTitle, addRoleId } = require('../scripts/backfill-role-ids.js');
+
+// #180 gives every role a stable identifier so reporting lines, career paths,
+// and interaction tables can reference something that survives a rename. The ID
+// is seeded from the title once and then frozen: it is not derived at read time,
+// because the whole point is that it outlives the title it came from.
+
+test('an id is lowercase kebab-case', () => {
+    assert.equal(roleIdFromTitle('Kubernetes Engineer'), 'kubernetes-engineer');
+    assert.equal(roleIdFromTitle('AWS Cloud Architect'), 'aws-cloud-architect');
+});
+
+// Titles in the catalogue carry qualifiers in brackets, and dropping them would
+// collide "Modern Workplace Senior Engineer (Microsoft 365)" with a plain
+// "Modern Workplace Senior Engineer".
+test('a parenthesised qualifier is kept, not dropped', () => {
+    assert.equal(
+        roleIdFromTitle('Modern Workplace Senior Engineer (Microsoft 365)'),
+        'modern-workplace-senior-engineer-microsoft-365',
+    );
+});
+
+test('an ampersand becomes a word rather than vanishing', () => {
+    assert.equal(roleIdFromTitle('Risk & Compliance Lead'), 'risk-and-compliance-lead');
+});
+
+test('punctuation and repeated separators collapse', () => {
+    assert.equal(roleIdFromTitle('  Data   Protection // Backup  Engineer  '), 'data-protection-backup-engineer');
+});
+
+const META = [
+    '# Kubernetes Engineer',
+    '',
+    '| Field | Value |',
+    '|---|---|',
+    '| **Domain** | Kubernetes |',
+    '| **Role Level** | Engineer |',
+    '| **Reports To** | Kubernetes Senior Engineer |',
+    '| **Direct Reports** | None |',
+    '| **Content Owner** | catalogue-maintainers |',
+    '| **Review Status** | mechanical |',
+    '| **Last Reviewed** | 2026-03 |',
+    '',
+    '## Role Overview',
+    '',
+    'Text.',
+    '',
+].join('\n');
+
+test('the id is inserted as the first metadata row', () => {
+    const lines = addRoleId(META).split('\n');
+    const id = lines.findIndex(l => l.includes('**Role ID**'));
+    const domain = lines.findIndex(l => l.includes('**Domain**'));
+    assert.ok(id !== -1, 'Role ID should be present');
+    assert.ok(id < domain, 'the identifier belongs above the descriptive fields');
+    assert.match(lines[id], /\|\s*\*\*Role ID\*\*\s*\|\s*`kubernetes-engineer`\s*\|/);
+});
+
+// Re-running the backfill must never reassign an id: a changed title after the
+// first pass is exactly the rename the id exists to survive.
+test('an existing id is never rewritten, even if the title changed', () => {
+    const withId = addRoleId(META);
+    const renamed = withId.replace('# Kubernetes Engineer', '# Kubernetes Platform Engineer');
+    assert.match(addRoleId(renamed), /`kubernetes-engineer`/);
+    assert.doesNotMatch(addRoleId(renamed), /`kubernetes-platform-engineer`/);
+});
+
+test('nothing outside the metadata table changes', () => {
+    const out = addRoleId(META);
+    assert.match(out, /## Role Overview\n\nText\./);
+    assert.equal(out.split('\n').length, META.split('\n').length + 1);
+});
+
+test('a document with no title or table is returned unchanged', () => {
+    const plain = 'No heading, no table.\n';
+    assert.equal(addRoleId(plain), plain);
+});

--- a/test/validate-roles.test.js
+++ b/test/validate-roles.test.js
@@ -7,7 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
-const { listRoleFiles, validateFile, findDuplicateTitles, REQUIRED_SECTIONS } = require('../validate-roles');
+const { listRoleFiles, validateFile, findDuplicateTitles, findDuplicateRoleIds, REQUIRED_SECTIONS } = require('../validate-roles');
 
 // All fixtures are generated into a temp tree at runtime — nothing under
 // Roles/ or test/ is touched, so `npm run validate` and markdownlint on the
@@ -48,6 +48,7 @@ function completeRole({ except = null, transform = null } = {}) {
 
 | Field | Value |
 |---|---|
+| **Role ID** | \`test-role\` |
 | **Domain** | testdomain |
 | **Role Level** | Engineer |
 | **Reports To** | Test Chapter Lead |
@@ -157,6 +158,32 @@ test('missing Direct Reports metadata is an error', () => {
   const file = writeFixture('no-direct-reports.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Direct Reports\*\*.*\n/, '') }));
   const r = validateFile(file, tmpRoot);
   assert.deepEqual(r.errors, ['Missing **Direct Reports** metadata field']);
+});
+
+// ── stable role identifiers (#180) ──
+//
+// Relationships reference roles by title today, so a rename breaks them
+// silently — on main, four reporting lines name a role that no longer exists
+// under that name and nothing reports it. The id is the anchor that survives
+// the rename, which only works if it is present, well-formed, and unique.
+
+test('missing Role ID metadata is an error', () => {
+    const file = writeFixture('no-role-id.md', completeRole({ transform: c => c.replace(/\|\s*\*\*Role ID\*\*.*\n/, '') }));
+    const r = validateFile(file, tmpRoot);
+    assert.deepEqual(r.errors, ['Missing **Role ID** metadata field']);
+});
+
+test('a Role ID outside lowercase kebab-case is an error', () => {
+    const file = writeFixture('bad-role-id.md', completeRole({ transform: c => c.replace('`test-role`', '`Test Role`') }));
+    const r = validateFile(file, tmpRoot);
+    assert.equal(r.errors.length, 1);
+    assert.match(r.errors[0], /Role ID "Test Role"/);
+});
+
+test('a Role ID reads the same with or without backticks', () => {
+    const file = writeFixture('plain-role-id.md', completeRole({ transform: c => c.replace('`test-role`', 'test-role') }));
+    const r = validateFile(file, tmpRoot);
+    assert.deepEqual(r.errors, []);
 });
 
 // ── review provenance (#179) ──
@@ -320,10 +347,13 @@ function runCli(rolesDir, args = [], env = {}) {
 test('CLI exits 0 on a clean tree, and warnings do not fail a normal run', () => {
   const cliRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'roles-cli-'));
   fs.mkdirSync(path.join(cliRoot, 'testdomain'));
+  // Distinct Role IDs as well as distinct titles: two roles sharing an id is
+  // itself an error now (#180), which would mask what this test is checking.
   fs.writeFileSync(path.join(cliRoot, 'testdomain', 'ok.md'),
-    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role') }));
+    completeRole({ transform: c => c.replace('# Test Role', '# Ok Role').replace('`test-role`', '`ok-role`') }));
   fs.writeFileSync(path.join(cliRoot, 'testdomain', 'warny.md'), completeRole({
     transform: c => c.replace('# Test Role', '# Warny Role')
+                     .replace('`test-role`', '`warny-role`')
                      .replace('| **Role Level** | Engineer |', '| **Role Level** | Grand Wizard |'),
   }));
   const normal = runCli(cliRoot);
@@ -418,6 +448,36 @@ test('CLI stale registry warnings exit 0 normally and 1 with --strict', () => {
   assert.equal(strict.status, 1, strict.stdout);
   assert.match(strict.stdout, /example-certification.*stale/i);
   fs.rmSync(cliRoot, { recursive: true, force: true });
+});
+
+// ── findDuplicateRoleIds (#180) ──────────────────────────
+//
+// An id that two roles share is not an identifier. Checked catalogue-wide
+// rather than per file, the same way duplicate titles are.
+
+test('findDuplicateRoleIds reports an id shared by two roles, with both paths', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dupe-ids-'));
+    const domain = path.join(dir, 'testdomain');
+    fs.mkdirSync(domain);
+    fs.writeFileSync(path.join(domain, 'one.md'), completeRole());
+    fs.writeFileSync(path.join(domain, 'two.md'), completeRole({ transform: c => c.replace('# Test Role', '# Other Role') }));
+
+    const dupes = findDuplicateRoleIds(dir);
+    assert.equal(dupes.length, 1);
+    assert.equal(dupes[0].id, 'test-role');
+    assert.equal(dupes[0].files.length, 2);
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('findDuplicateRoleIds reports nothing when every id is unique', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'unique-ids-'));
+    const domain = path.join(dir, 'testdomain');
+    fs.mkdirSync(domain);
+    fs.writeFileSync(path.join(domain, 'one.md'), completeRole());
+    fs.writeFileSync(path.join(domain, 'two.md'), completeRole({ transform: c => c.replace('`test-role`', '`other-role`') }));
+
+    assert.deepEqual(findDuplicateRoleIds(dir), []);
+    fs.rmSync(dir, { recursive: true, force: true });
 });
 
 // ── findDuplicateTitles (#67) ────────────────────────────

--- a/validate-roles.js
+++ b/validate-roles.js
@@ -32,6 +32,10 @@ const STRICT     = process.argv.includes('--strict');
 // claimed only when an owner has actually read the content.
 const REVIEW_STATUSES = new Set(['reviewed', 'mechanical', 'unreviewed']);
 
+// Stable role identifier (#180): lowercase kebab-case, matching the shape the
+// credential registry already uses for its ids.
+const ROLE_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 const REQUIRED_SECTIONS = [
   { name: 'Role Overview',                          patterns: [/^##\s+Role Overview/im] },
   { name: 'Role Scope & Boundaries',                patterns: [/^##\s+Role Scope (&|and) Boundaries/im] },
@@ -139,6 +143,16 @@ function validateFile(filePath, rolesDir = ROLES_DIR, credentialContext = null) 
     }
   }
 
+  // Stable identifier (#180). Relationships will resolve against this rather
+  // than against a title, so it has to exist and be well-formed before it can
+  // be trusted as an anchor. Uniqueness is checked catalogue-wide, in
+  // findDuplicateRoleIds.
+  if (!meta.roleId) {
+    errors.push('Missing **Role ID** metadata field');
+  } else if (!ROLE_ID_PATTERN.test(meta.roleId)) {
+    errors.push(`Role ID "${meta.roleId}" is not lowercase kebab-case (a-z, 0-9 and single hyphens)`);
+  }
+
   if (!meta.levelRaw) {
     errors.push('Missing **Role Level** metadata field');
   } else if (!KNOWN_LEVELS.has(normalizeLevel(meta.levelRaw))) {
@@ -239,6 +253,23 @@ function validateFile(filePath, rolesDir = ROLES_DIR, credentialContext = null) 
 // Duplicate titles shipped in both v1.2.0 (3 cross-domain pairs) and
 // v1.3.0 (a pair the filename scan missed because the files differed);
 // this makes the recurrence a blocking validation error.
+// An id shared by two roles is not an identifier. Checked across the catalogue
+// rather than per file, the same way duplicate titles are (#180).
+function findDuplicateRoleIds(rolesDir = ROLES_DIR) {
+  const byId = new Map();
+  for (const filePath of listRoleFiles(rolesDir)) {
+    if (REFERENCE_DOC_PATTERN.test(path.basename(filePath))) continue;
+    const { roleId } = parseMeta(fs.readFileSync(filePath, 'utf8'));
+    if (!roleId) continue; // a missing id is already a per-file error
+    const rel = path.relative(path.dirname(rolesDir), filePath).replace(/\\/g, '/');
+    if (!byId.has(roleId)) byId.set(roleId, []);
+    byId.get(roleId).push(rel);
+  }
+  return [...byId.entries()]
+    .filter(([, files]) => files.length > 1)
+    .map(([id, files]) => ({ id, files: files.sort() }));
+}
+
 function findDuplicateTitles(rolesDir = ROLES_DIR) {
   const byTitle = new Map();
   for (const filePath of listRoleFiles(rolesDir)) {
@@ -263,6 +294,7 @@ function main() {
   const withWarnings = results.filter(r => r.warnings.length > 0);
   const skipped      = results.filter(r => r.skipped);
   const duplicates   = findDuplicateTitles();
+  const duplicateIds = findDuplicateRoleIds();
 
   if (credentialContext.errors.length > 0 || credentialContext.warnings.length > 0) {
     console.log(`\n${CREDENTIALS_FILE}`);
@@ -285,14 +317,20 @@ function main() {
     for (const f of d.files) console.log(`  ${f}`);
   }
 
+  for (const d of duplicateIds) {
+    console.log(`\n✖ Duplicate Role ID: "${d.id}"`);
+    for (const f of d.files) console.log(`  ${f}`);
+  }
+
   console.log(`\n${'─'.repeat(60)}`);
   console.log(`Checked ${files.length} role files (${skipped.length} reference docs skipped)`);
   console.log(`  ${withErrors.length} file(s) with errors`);
   console.log(`  ${withWarnings.length} file(s) with warnings`);
   console.log(`  ${duplicates.length} duplicate title(s)`);
+  console.log(`  ${duplicateIds.length} duplicate role ID(s)`);
   console.log('─'.repeat(60));
 
-  if (withErrors.length > 0 || credentialContext.errors.length > 0 || duplicates.length > 0 ||
+  if (withErrors.length > 0 || credentialContext.errors.length > 0 || duplicates.length > 0 || duplicateIds.length > 0 ||
       (STRICT && (withWarnings.length > 0 || credentialContext.warnings.length > 0))) {
     process.exitCode = 1;
   }
@@ -304,4 +342,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { listRoleFiles, validateFile, findDuplicateTitles, REQUIRED_SECTIONS };
+module.exports = { listRoleFiles, validateFile, findDuplicateTitles, findDuplicateRoleIds, REQUIRED_SECTIONS };


### PR DESCRIPTION
Refs #180 — implements the recommendation you approved. Identifiers only; migrating relationships onto them is follow-on work that needs two more decisions first.

## The drift is already there

Every `Reports To` checked against every role title on `main`:

| | |
|---|---|
| Resolve to a catalogue role | **203 of 226** |
| Don't resolve | **23** |

The 23 are three different things, and only one is a defect:

**5 are correct** — `CEO`, `Board of Directors`, `SVP of Technology`. Destinations above the catalogue, which it has no way to express.

**14 are a choice**, not an edge — `Technical Area Lead (TAL) or Product Area Lead (PAL)` (×7) and similar. One field holding an either/or cannot be validated or drawn.

**4 are drift:**

| `Reports To` says | Should almost certainly be | Overlap |
|---|---|---|
| `Infrastructure Onboarding Senior Engineer` | **Enterprise** Infrastructure Onboarding Senior Engineer | 80% |
| `Configuration Management Senior Engineer` | **Application** Configuration Management Senior Engineer | 80% |
| `Modern Workplace Senior Engineer` | Modern Workplace Senior Engineer **(Microsoft 365)** | 67% |
| `GCP Cloud Senior Engineer` | *nothing* — no GCP role exists in the catalogue | — |

Nothing reports these, because a stale name looks exactly like a deliberate reference to something outside the catalogue. That is the failure this issue exists to prevent, already present.

## The decision

**Every role carries a `Role ID`** — lowercase kebab-case, unique, seeded from the title once and then **frozen**.

Deliberately *not* derived at read time. An id computed from the title changes when the title changes, which is precisely the failure it exists to prevent. Renaming a role changes its title and leaves its id alone.

Parenthesised qualifiers are preserved when seeding, so `Modern Workplace Senior Engineer (Microsoft 365)` cannot collide with a plain `Modern Workplace Senior Engineer`. All 227 ids came out unique with no manual intervention.

This mirrors `data/credentials.json`, where a stable id and a mutable display name are already separated — a separation that survived a real vendor rename this session with the id untouched.

Recorded as [ADR-0005](docs/adr/0005-identify-roles-by-a-stable-id-rather-than-by-title.md).

## What enforces it

- `validate-roles.js` — id present, well-formed, and **unique catalogue-wide**, checked the same way duplicate titles already are. An id shared by two roles is not an identifier, so it is an error.
- `scripts/relationship-report.js` — classifies the reporting graph into resolved / external / alternative / drift, so the drift is countable before and after any migration. Reports only; never edits.
- A test guards that **the four drifted references do not become five** — the silent regression this issue is about.

## The four drifted references are deliberately not fixed

They are the live evidence that the problem is real, and they belong with the relationship migration rather than a quiet edit beforehand. The test pins them at four so they cannot grow in the meantime.

## Still open, and deliberately not decided here

Two representation gaps must be settled before relationships can migrate onto ids:

1. How a destination **outside the catalogue** is expressed — a marker like `external:CEO`, a separate field, or a registry of sanctioned external destinations.
2. How a genuine **either/or** is expressed — a list of ids, or one canonical choice with the alternative in prose.

## Verification

- `npm test` — **361/361** pass (was 341); 15 new tests, all written first
- `npm run validate` — 0 errors, **0 duplicate role IDs**, 226 warnings (the #179 provenance gap, unchanged)
- `npm run check-counts` — 226 roles / 34 domains / 7 chapters, README matches
- `markdownlint-cli2 docs/**/*.md` — 0 issues
- Backfill is **idempotent** — a re-run assigns 0
- **0 BOMs lost** across 227 files, verified by byte comparison against `HEAD`; CRLF preserved

## Review note

227 of the 234 changed files are the same one-line insertion. The files worth reading are `validate-roles.js`, the two scripts, and the ADR.
