### PR TITLE
fix: repair the four drifted reporting lines

### DIFF
--- a/Roles/c_suite/chief_financial_officer.md
+++ b/Roles/c_suite/chief_financial_officer.md
@@ -6,7 +6,7 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CFO |
-| **Reports To** | CEO |
+| **Reports To** | Chief Executive Officer |
 | **Direct Reports** | None (no subordinate finance roles modelled in this catalog) |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/c_suite/chief_information_officer.md
+++ b/Roles/c_suite/chief_information_officer.md
@@ -6,7 +6,7 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CIO |
-| **Reports To** | CEO |
+| **Reports To** | Chief Executive Officer |
 | **Direct Reports** | Product Area Lead, Technical Area Lead (equivalent title to CTO/SVP of Technology — org uses one) |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/c_suite/chief_technology_officer.md
+++ b/Roles/c_suite/chief_technology_officer.md
@@ -6,7 +6,7 @@
 | **Domain** | C-Suite |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | CTO |
-| **Reports To** | CEO |
+| **Reports To** | Chief Executive Officer |
 | **Direct Reports** | Product Area Lead, Technical Area Lead (equivalent title to CIO/SVP of Technology — org uses one) |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/cloud_platforms/gcp_cloud_engineer.md
+++ b/Roles/cloud_platforms/gcp_cloud_engineer.md
@@ -6,7 +6,7 @@
 | **Domain** | Cloud Platforms |
 | **Chapter:** | Cloud, Platform & Infrastructure |
 | **Role Level** | Engineer |
-| **Reports To** | GCP Cloud Senior Engineer |
+| **Reports To** | Google Cloud Senior Engineer |
 | **Direct Reports** | None |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
+++ b/Roles/infrastructure_onboarding_cross_platform/infrastructure_onboarding_cross_platform_engineer.md
@@ -6,7 +6,7 @@
 | **Domain** | Infrastructure Onboarding |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |
-| **Reports To** | Infrastructure Onboarding Senior Engineer |
+| **Reports To** | Enterprise Infrastructure Onboarding Senior Engineer |
 | **Direct Reports** | None |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/itsm_configuration/application_configuration_management_engineer.md
+++ b/Roles/itsm_configuration/application_configuration_management_engineer.md
@@ -6,7 +6,7 @@
 | **Domain** | ITSM & Configuration |
 | **Chapter:** | Service & Governance |
 | **Role Level** | Engineer |
-| **Reports To** | Configuration Management Senior Engineer |
+| **Reports To** | Application Configuration Management Senior Engineer |
 | **Direct Reports** | None |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/leadership/svp_technology.md
+++ b/Roles/leadership/svp_technology.md
@@ -6,7 +6,7 @@
 | **Domain** | Leadership |
 | **Chapter:** | Leadership (Cross-cutting) |
 | **Role Level** | SVP of Technology |
-| **Reports To** | CEO |
+| **Reports To** | Chief Executive Officer |
 | **Direct Reports** | Product Area Leads, Technical Area Lead (equivalent title to CTO/CIO — org uses one) |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/Roles/modern_workplace/modern_workplace_engineer.md
+++ b/Roles/modern_workplace/modern_workplace_engineer.md
@@ -6,7 +6,7 @@
 | **Domain** | Modern Workplace |
 | **Chapter:** | End User & Workplace |
 | **Role Level** | Engineer |
-| **Reports To** | Modern Workplace Senior Engineer |
+| **Reports To** | Modern Workplace Senior Engineer (Microsoft 365) |
 | **Direct Reports** | None |
 | **Content Owner** | catalogue-maintainers |
 | **Review Status** | mechanical |

--- a/scripts/relationship-report.js
+++ b/scripts/relationship-report.js
@@ -36,6 +36,31 @@ const EXTERNAL = /\b(CEO|Board of Directors|Board|CTO|CIO|CFO|CISO|SVP|Executive
 // A single field naming two acceptable destinations is a choice, not an edge.
 const ALTERNATIVE = /\bor\b|\//;
 
+// An initialism built from a title's capitalised words: "Chief Executive
+// Officer" -> "CEO". Needed because token overlap is blind to abbreviations —
+// "CEO" and "Chief Executive Officer" share no words — which is how four
+// references to a real catalogue role were first mistaken for destinations
+// above the catalogue.
+function initialism(title) {
+    const words = String(title).split(/\s+/).filter(w => /^[A-Z]/.test(w));
+    return words.length >= 2 ? words.map(w => w[0]).join('').toUpperCase() : null;
+}
+
+// Ambiguous initialisms are dropped rather than guessed: an abbreviation that
+// two roles share identifies neither.
+function initialismIndex(titles) {
+    const byAbbr = new Map();
+    const ambiguous = new Set();
+    for (const title of titles) {
+        const abbr = initialism(title);
+        if (!abbr) continue;
+        if (byAbbr.has(abbr)) ambiguous.add(abbr);
+        else byAbbr.set(abbr, title);
+    }
+    for (const abbr of ambiguous) byAbbr.delete(abbr);
+    return byAbbr;
+}
+
 // Token overlap, used only to suggest what a drifted reference probably meant.
 function similarity(a, b) {
     const A = new Set(a.toLowerCase().split(/\s+/));
@@ -62,6 +87,7 @@ function buildGraph() {
     }
 
     const byTitle = new Map(roles.map(r => [r.title, r]));
+    const byAbbr = initialismIndex(byTitle.keys());
     const resolved = [];
     const external = [];
     const alternatives = [];
@@ -73,6 +99,16 @@ function buildGraph() {
 
         if (byTitle.has(target)) { resolved.push(role); continue; }
         if (ALTERNATIVE.test(target)) { alternatives.push({ role, target }); continue; }
+
+        // Before anything else: an abbreviation of a real role is drift, not an
+        // external destination. This check must precede the EXTERNAL one, since
+        // the titles most often abbreviated -- CEO, CTO, CISO -- are exactly the
+        // ones that look external.
+        if (byAbbr.has(target)) {
+            drift.push({ role, target, suggestion: { title: byAbbr.get(target), score: 1 }, reason: 'abbreviation' });
+            continue;
+        }
+
         if (EXTERNAL.test(target)) { external.push({ role, target }); continue; }
 
         const best = roles
@@ -100,9 +136,9 @@ function report() {
         for (const d of drift) {
             console.log(`  ${d.role.file}`);
             console.log(`     Reports To: "${d.target}"`);
-            console.log(d.suggestion
-                ? `     probably:   "${d.suggestion.title}"  (${Math.round(d.suggestion.score * 100)}% token overlap)`
-                : '     no similar role in the catalogue');
+            if (!d.suggestion) console.log('     no similar role in the catalogue');
+            else if (d.reason === 'abbreviation') console.log(`     resolves:   "${d.suggestion.title}"  (abbreviation of an existing role)`);
+            else console.log(`     probably:   "${d.suggestion.title}"  (${Math.round(d.suggestion.score * 100)}% token overlap — verify before applying)`);
         }
     }
 

--- a/test/relationship-report.test.js
+++ b/test/relationship-report.test.js
@@ -45,6 +45,19 @@ test('no reporting line drifts', () => {
     );
 });
 
+// The first version of this report classified "CEO" as a destination above the
+// catalogue, because it looks like one. It is not: "Chief Executive Officer" is
+// a role in c_suite, and four reporting lines referenced it by initialism. Token
+// overlap cannot catch that — an abbreviation shares no words with the title it
+// stands for — so the report resolves initialisms explicitly.
+test('an initialism of an existing role is not mistaken for an external destination', () => {
+    const { external, drift, resolved } = buildGraph();
+    const all = [...external.map(e => e.target), ...drift.map(d => d.target)];
+    assert.ok(!all.includes('CEO'),
+        '"CEO" is an abbreviation of Chief Executive Officer, a catalogue role, and must resolve');
+    assert.ok(resolved.length > 0);
+});
+
 test('a destination above the catalogue is not counted as drift', () => {
     const { external, drift } = buildGraph();
     assert.ok(external.length > 0, 'expected some external destinations');

--- a/test/relationship-report.test.js
+++ b/test/relationship-report.test.js
@@ -32,13 +32,17 @@ test('the overwhelming majority of reporting lines resolve', () => {
         `only ${resolved.length} of ${roles.length} reporting lines resolve`);
 });
 
-// A guard, not a target. The four known drifted references are recorded in
-// ADR-0005; this fails if that number grows, which is the silent regression
-// the whole issue is about.
-test('drifted reporting lines do not increase beyond the known four', () => {
+// The four references ADR-0005 recorded as drift are fixed, so this is now a
+// ratchet at zero rather than a ceiling at four. A reporting line that resolves
+// to nothing and is not deliberately external is a defect, and this is what
+// makes it loud instead of silent.
+test('no reporting line drifts', () => {
     const { drift } = buildGraph();
-    assert.ok(drift.length <= 4,
-        `drifted reporting lines rose to ${drift.length}:\n${drift.map(d => `  ${d.role.file}: "${d.target}"`).join('\n')}`);
+    assert.deepEqual(
+        drift.map(d => `${d.role.file}: "${d.target}"`),
+        [],
+        'a reporting line resolves to nothing and is not deliberately external',
+    );
 });
 
 test('a destination above the catalogue is not counted as drift', () => {


### PR DESCRIPTION
Refs #180. Fixes **eight** drifted reporting lines — the four recorded in ADR-0005, plus four more the report was hiding.

## The first four: a role that exists under a different title

| Role | Was | Now |
|---|---|---|
| `gcp_cloud_engineer` | `GCP Cloud Senior Engineer` | `Google Cloud Senior Engineer` |
| `infrastructure_onboarding_cross_platform_engineer` | `Infrastructure Onboarding Senior Engineer` | `Enterprise Infrastructure Onboarding Senior Engineer` |
| `application_configuration_management_engineer` | `Configuration Management Senior Engineer` | `Application Configuration Management Senior Engineer` |
| `modern_workplace_engineer` | `Modern Workplace Senior Engineer` | `Modern Workplace Senior Engineer (Microsoft 365)` |

Each target title was confirmed to exist exactly before the edit.

**The GCP one is a caution about the tooling.** The report suggested `AWS Cloud Senior Engineer` at 75% token overlap — wrong. `gcp_cloud_senior_engineer.md` exists, titled `Google Cloud Senior Engineer`; the *files* use `gcp_` while the *titles* use "Google Cloud". Applying that suggestion automatically would have rewired an engineer into a different cloud platform's reporting line — a plausible-looking edge that is simply false.

## The second four: the report was hiding them

`CEO` was classified as a destination above the catalogue, because it looks like one. **It is not** — `Chief Executive Officer` is a role in `c_suite`, and four reporting lines referenced it by initialism: the CFO, CIO, CTO, and SVP of Technology.

Two things combined to hide this. Token overlap is blind to abbreviations — `CEO` and `Chief Executive Officer` share no words — and the `EXTERNAL` heuristic matched the abbreviation first and stopped looking. **The titles most often abbreviated are exactly the ones that look external**, so the heuristic concealed the very cases it should have caught.

Fixed by resolving initialisms explicitly, *before* the external check. Ambiguous abbreviations are dropped rather than guessed: one that two roles share identifies neither.

## Result

```
203 -> 211  reporting lines resolve
  4 ->   0  drift
  5 ->   1  external
```

The one remaining external is `Board of Directors`, which the Chief Executive Officer reports to. No Board role exists, and none should — it is genuinely outside the catalogue, and the only true external destination in it. That also sharpens open decision 1 on this issue: the representation needed is narrower than five references suggested.

The test that capped drift at four is now a **ratchet at zero**, plus a new test that an initialism of an existing role is never mistaken for an external destination.

Output now distinguishes the two kinds of suggestion: an abbreviation match is exact, a token-overlap match says *"verify before applying"*. Not decoration — that heuristic proposed the AWS rewiring above.

## A finding while I was in here, which is not a defect

Checking the reverse direction — does each manager name its reports back? 160 of 211 do not, which looks alarming and is not. `Direct Reports` is **prose by design**:

| | Roles |
|---|---|
| `None` | 171 |
| Every part an exact role title | **1** |
| Descriptive prose | 54 |

A typical value is `AI Governance Engineers (day-to-day technical guidance and mentoring; formal line management sits with…)` — a pluralised role family plus a qualifier about the nature of the relationship. That is *richer* than a list of titles and cannot be reciprocally validated as it stands.

So this is a **third representation decision** for #180, alongside external destinations and either/or: whether `Direct Reports` becomes machine-readable, and if so where the qualifying prose goes. I have deliberately not touched it — converting 54 prose values into title lists would discard real information.

## Verification

- `npm test` — 362/362 pass
- `npm run validate` — 0 errors, 0 duplicate role IDs
- `node scripts/relationship-report.js` — 0 drift, exits 0
