### PR TITLE
feat: register SABSA Chartered Architect

### DIFF
--- a/data/credentials.json
+++ b/data/credentials.json
@@ -619,6 +619,18 @@
       "owner": "catalogue-maintainers",
       "review_months": 12,
       "notes": "Listed on Broadcom's current VMware certification pages. The page states only the certification title: it did not give a version, year, or exam code, and Broadcom versions VCP credentials by release year (for example VCP-DCV 2024). Confirm the current version at review before citing a specific one."
+    },
+    {
+      "id": "sabsa-chartered-architect",
+      "name": "SABSA Chartered Architect",
+      "issuer": "The SABSA Institute",
+      "type": "certification",
+      "url": "https://sabsa.org/training-schedule/",
+      "status": "active",
+      "verified_on": "2026-08-14",
+      "owner": "catalogue-maintainers",
+      "review_months": 12,
+      "notes": "The SABSA Institute states it \"certifies and accredits the professional Architects who use\" the method, and refers to holders as SABSA Chartered Architects. Certification exams can only be taken after training with an Accredited Education Partner. Courses run at Foundation and Advanced levels, and a practitioner exam is referenced, but no single page found lists the level names definitively - confirm the exact level before citing one. The catalogue writes \"SABSA Chartered Security Architect\"; The SABSA Institute does not use \"Security\" in that phrase."
     }
   ]
 }


### PR DESCRIPTION
Refs #229. Resolves the one candidate that was blocked on **access** rather than judgement.

## The 403 was bot-blocking, not a broken site

`sabsa.org` returns HTTP 403 to every fetch attempt, including a plain root fetch. It loads normally in a browser. This is the second time that distinction has mattered on this issue — `pmi.org` and `scrum.org` behaved the same way — and it is worth treating as the rule rather than the exception: **a blocked fetch is not an unverifiable page.**

## What the issuer says

The SABSA Institute states it *"certifies and accredits the professional Architects who use"* the method, and refers to holders as **SABSA Chartered Architects** — including in its own year-in-review ("SABSA Chartered Architects now in 84 countries worldwide").

Certification exams can only be taken after training with an Accredited Education Partner. Courses run at **Foundation** and **Advanced** levels.

## The catalogue's wording is wrong in a small, specific way

The catalogue writes **`SABSA Chartered Security Architect`** across 8 entries in 6 domains. The SABSA Institute does not use "Security" in that phrase.

So these 8 references are a **naming correction**, not an unknown credential — which moves SABSA off the decision list entirely and leaves six items needing your judgement rather than seven.

## What is deliberately not established

The definitive level names. `SABSA Foundation` and `SABSA Advanced A3` appear as courses, and a "practitioner exam" is referenced in an Institute blog, but no single page found lists the certification scheme. The record says exactly that and asks for the level to be confirmed before one is cited, rather than assembling a plausible-looking name from fragments.

That matters here more than usual: "Foundation / Practitioner / Master" is a well-known shape for this kind of scheme, and it would have been easy to write it down as fact.

## Verification

- `npm run validate` — 0 errors
- `npm test` — 362/362 pass
- Source is the issuer's own site throughout
