### PR TITLE
fix: retire the credential references no issuer will stand behind

### DIFF
--- a/Roles/cloud_platforms/aws_cloud_engineer.md
+++ b/Roles/cloud_platforms/aws_cloud_engineer.md
@@ -181,7 +181,6 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 - Certified Kubernetes Administrator (CKA)
 - Linux Professional Institute certification
 - AWS Certified Security - Specialty
-- Docker Certified Associate
 
 **Complementary Certifications:**
 
@@ -189,4 +188,5 @@ The AWS Cloud Engineer implements and maintains cloud resources and services in 
 
 **Learning Resources & Communities:**
 
+- Docker Foundations Professional Certificate (LinkedIn Learning) — course, not an individually-held certification
 - AWS Skill Builder (skillbuilder.aws), A Cloud Guru, Pluralsight AWS tracks, Linux Foundation training, and AWS User Group community events

--- a/Roles/data_management/qumulo_storage_product_owner.md
+++ b/Roles/data_management/qumulo_storage_product_owner.md
@@ -205,7 +205,6 @@ The Qumulo Storage Product Owner manages the development and lifecycle of the or
 - Project Management Professional (PMP)
 - ITIL 4 Foundation
 - SAFe Product Owner/Product Manager
-- Certified Agile Service Manager
 - SAFe Product Owner/Product Manager (SAFe POPM), SNIA Certified Storage Professional (overview level), ITIL 4 Foundation, and cloud storage fundamentals
 
 **Learning Resources & Communities:**

--- a/Roles/devops/devops_engineer.md
+++ b/Roles/devops/devops_engineer.md
@@ -183,7 +183,6 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 
 - GitHub Actions / GitHub Advanced Security certifications
 - Microsoft Certified: Azure DevOps Engineer Expert (AZ-400)
-- Docker Certified Associate
 - Certified Kubernetes Application Developer (CKAD)
 - HashiCorp Certified: Terraform Associate
 - GitLab Certified Associate
@@ -196,4 +195,5 @@ The DevOps Engineer implements and maintains CI/CD pipelines and automation tool
 
 **Learning Resources & Communities:**
 
+- Docker Foundations Professional Certificate (LinkedIn Learning) — course, not an individually-held certification
 - GitHub Learning Lab, Microsoft Learn (AZ-400 DevOps path), KodeKloud (hands-on labs for Kubernetes, Terraform, Ansible), TechWorld with Nana (YouTube), Pluralsight DevOps fundamentals tracks.

--- a/Roles/devops/devops_product_owner.md
+++ b/Roles/devops/devops_product_owner.md
@@ -185,7 +185,6 @@ The DevOps Product Owner manages the DevOps platform roadmap and adoption strate
 - AWS Certified DevOps Engineer - Professional
 - Microsoft Certified: DevOps Engineer Expert
 - Project Management Professional (PMP)
-- Certified Agile Service Manager
 - ITIL 4 Foundation
 - DevOps Leadership certification
 

--- a/Roles/devops/devops_senior_engineer.md
+++ b/Roles/devops/devops_senior_engineer.md
@@ -189,7 +189,6 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 - Microsoft Certified: DevOps Engineer Expert
 - Google Professional Cloud DevOps Engineer
 - Certified Kubernetes Administrator (CKA)
-- Docker Certified Associate
 - HashiCorp Certified: Terraform Expert
 - Red Hat Certified Specialist in Ansible Automation
 - GitLab Professional Services Engineer
@@ -200,4 +199,5 @@ The DevOps Senior Engineer leads complex DevOps initiatives and transformations,
 
 **Learning Resources & Communities:**
 
+- Docker Foundations Professional Certificate (LinkedIn Learning) — course, not an individually-held certification
 - Continuous Delivery Foundation resources (cd.foundation), CNCF KubeCon sessions, GitHub Universe talks, Thoughtworks Technology Radar, DevOps Toolkit YouTube channel (Viktor Farcic), Pluralsight DevOps learning paths.

--- a/Roles/directory_services/windows_active_directory_senior_engineer.md
+++ b/Roles/directory_services/windows_active_directory_senior_engineer.md
@@ -172,7 +172,6 @@ The Windows Active Directory Senior Engineer leads all Tier 0 infrastructure ini
 - Microsoft 365 Certified: Identity and Access Administrator Associate
 - Microsoft Certified: Security, Compliance, and Identity Fundamentals
 - CompTIA Security+
-- MCSE: Core Infrastructure (legacy but valuable)
 - Certified Information Systems Security Professional (CISSP)
 - Microsoft 365 Certified: Enterprise Administrator Expert
 - Certified Directory Services Engineer

--- a/Roles/finops/finops_architect.md
+++ b/Roles/finops/finops_architect.md
@@ -193,7 +193,6 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 - Cloud platform financial certifications (AWS, Azure, GCP)
 - IT Financial Management certifications
 - ITIL Financial Management for IT Services
-- Technology Business Management (TBM) certifications
 - Cloud platform architecture certifications
 - Certified Cost Professional (CCP)
 
@@ -203,4 +202,5 @@ See also: [Cloud Cost Optimization Standards](cloud_cost_optimization_standards.
 
 **Learning Resources and Communities:**
 
+- TBM Practitioner course and certification, TBM Council — course, not an individually-held certification
 - FinOps Foundation (finops.org), cloud provider cost management training (AWS, Azure, GCP), Apptio TBM University (tbmuniversity.org), and CloudHealth and Cloudability vendor community resources

--- a/Roles/itsm_configuration/itsm_product_owner.md
+++ b/Roles/itsm_configuration/itsm_product_owner.md
@@ -176,7 +176,6 @@ The ITSM Product Owner owns the product vision, roadmap, and backlog for the org
 **Complementary Certifications:**
 
 - ITIL 4 Foundation
-- Certified Agile Service Manager (CASM)
 
 **Learning Resources and Communities:**
 

--- a/Roles/modern_infrastructure/platform_engineering_engineer.md
+++ b/Roles/modern_infrastructure/platform_engineering_engineer.md
@@ -184,7 +184,6 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 - DevOps certifications
 - Terraform Associate or similar IaC certifications
 - CI/CD platform certifications
-- Docker Certified Associate
 - Programming language certifications
 - Service mesh certifications
 
@@ -194,4 +193,5 @@ The Platform Engineering Engineer implements and maintains internal developer pl
 
 **Learning Resources & Communities:**
 
+- Docker Foundations Professional Certificate (LinkedIn Learning) — course, not an individually-held certification
 - CNCF documentation (cncf.io), Backstage getting started guides (backstage.io/docs), GitHub Actions documentation, HashiCorp Terraform getting started, KubeCon YouTube channel, and kubectl docs (kubectl.docs.kubernetes.io)

--- a/Roles/network/network_product_owner.md
+++ b/Roles/network/network_product_owner.md
@@ -181,7 +181,6 @@ The Network Product Owner manages the development and lifecycle of the organizat
 - ITIL 4 Foundation
 - Cisco Certified Network Associate (CCNA)
 - Project Management Professional (PMP)
-- Certified Agile Service Manager
 - Scaled Agile Framework (SAFe) Agilist
 - AWS Cloud Practitioner or Azure Fundamentals
 

--- a/Roles/server_os_linux/linux_server_architect.md
+++ b/Roles/server_os_linux/linux_server_architect.md
@@ -185,7 +185,6 @@ The Linux Server Architect designs and defines the strategic direction for the o
 - TOGAF Certified Architect
 - CompTIA Linux+
 - Red Hat Certified Engineer (RHCE)
-- Docker Certified Associate
 
 ## Interactions with Other Roles
 
@@ -207,4 +206,5 @@ The Linux Server Architect designs and defines the strategic direction for the o
 
 **Learning Resources and Communities:**
 
+- Docker Foundations Professional Certificate (LinkedIn Learning) — course, not an individually-held certification
 - Red Hat blog (redhat.com/blog), Linux Foundation training (training.linuxfoundation.org), kernel.org documentation, Ansible documentation, and Linux architecture discussion on Hacker News and CNCF community resources

--- a/Roles/server_os_windows/windows_server_architect.md
+++ b/Roles/server_os_windows/windows_server_architect.md
@@ -180,7 +180,6 @@ The Windows Server Architect designs and defines the strategic direction for the
 - Microsoft Certified: Identity and Access Administrator Associate
 - Microsoft 365 Certified: Enterprise Administrator Expert
 - Microsoft Certified: Azure Stack Hub Operator Associate
-- MCSE: Core Infrastructure
 - TOGAF Certified Architect with Windows focus
 - Microsoft Storage Solutions certification
 - Microsoft Active Directory certification

--- a/Roles/server_os_windows/windows_server_product_owner.md
+++ b/Roles/server_os_windows/windows_server_product_owner.md
@@ -201,7 +201,6 @@ The Windows Server Product Owner manages the product backlog and roadmap for all
 - Microsoft Azure Fundamentals (AZ-900)
 - Project Management Professional (PMP)
 - Microsoft 365 Certified: Fundamentals
-- Certified Agile Service Manager
 
 **Complementary Certifications:**
 

--- a/Roles/server_os_windows/windows_server_senior_engineer.md
+++ b/Roles/server_os_windows/windows_server_senior_engineer.md
@@ -195,7 +195,6 @@ The Windows Server Senior Engineer leads complex implementations and optimizatio
 - PowerShell advanced certifications
 - Microsoft Certified: Azure Stack HCI Operator Associate
 - Microsoft Certified: Security, Compliance, and Identity Fundamentals
-- MCSE: Core Infrastructure (legacy)
 - Microsoft Azure certifications related to hybrid scenarios
 - ITIL Foundation certification
 

--- a/Roles/virtualization/hyperv_senior_engineer.md
+++ b/Roles/virtualization/hyperv_senior_engineer.md
@@ -201,7 +201,6 @@ The Hyper-V Senior Engineer leads complex Microsoft virtualization initiatives, 
 - Microsoft Certified: Azure Administrator Associate
 - Microsoft Certified: Azure Virtual Desktop Specialty
 - VMware Certified Professional (for hybrid environments)
-- MCSE: Core Infrastructure (legacy but valuable)
 - Advanced PowerShell certifications
 
 **Complementary Certifications:**

--- a/scripts/retire-unresolved-credentials.js
+++ b/scripts/retire-unresolved-credentials.js
@@ -1,0 +1,168 @@
+'use strict';
+
+// Applies the maintainer's rule for the credential references that no issuer
+// will stand behind (#229):
+//
+//   where the issuer no longer names a credential and offers a clear successor,
+//   rewrite to the successor; where there is no successor, drop the reference
+//   rather than leave a recommendation nobody can act on.
+//
+// ADR-0003 supplies the exception: a successor that is a course belongs under
+// Learning Resources & Communities, not among certifications.
+//
+// Each entry below records the evidence that justifies its action, because the
+// action is a content change and the reasoning should not live only in a commit
+// message.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
+// The catalogue spells this subhead two ways -- 124 roles use "&" and 101 use
+// "and", because #227 only normalised the files it had to restructure. Matching
+// one spelling exactly meant a relocated bullet was removed and its replacement
+// silently dropped in every role using the other.
+const LEARNING_SUBHEAD = '**Learning Resources & Communities:**';
+const LEARNING_SUBHEAD_PATTERN = /^\*\*Learning Resources\s*(?:&|and)\s*Communities:?\*\*$/i;
+
+function findLearningSubhead(lines, from, to) {
+    for (let i = from; i < Math.min(to, lines.length); i++) {
+        if (LEARNING_SUBHEAD_PATTERN.test(lines[i].trim())) return i;
+    }
+    return -1;
+}
+
+const RULES = [
+    {
+        match: /docker certified associate/i,
+        action: 'relocate',
+        replacement: 'Docker Foundations Professional Certificate (LinkedIn Learning) — course, not an individually-held certification',
+        why: 'docker.com/certification returns 404 in fetch and browser; Docker promotes the LinkedIn Learning certificate instead, which is a course under ADR-0003.',
+    },
+    {
+        match: /technology business management \(tbm\) certification|\btbm\b.*certification/i,
+        action: 'relocate',
+        replacement: 'TBM Practitioner course and certification, TBM Council — course, not an individually-held certification',
+        why: 'The TBM Council offers a year-prefixed "2026 TBM Practitioner Course & Certification" and states the programme is mid-relaunch.',
+    },
+    {
+        match: /certified agile service manager/i,
+        action: 'drop',
+        why: "DevOps Institute's current catalogue lists ten certifications and CASM is not among them; no successor is named.",
+    },
+    {
+        match: /\bMCSE\b/,
+        action: 'drop',
+        why: "Microsoft's credential retirement page lists only the last year's retirements and does not mention MCSE; no current Microsoft page describes it.",
+    },
+];
+
+function roleFiles(dir = ROLES_DIR, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) roleFiles(full, out);
+        else if (entry.name.endsWith('.md') && entry.name !== 'README.md') out.push(full);
+    }
+    return out;
+}
+
+// Returns the bounds of the certification section, or null.
+function certificationSection(lines) {
+    const start = lines.findIndex(l => /^## [^\n]*Certification/i.test(l));
+    if (start === -1) return null;
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+        if (/^## /.test(lines[i])) { end = i; break; }
+    }
+    return { start, end };
+}
+
+function applyRules(text) {
+    const lines = text.split('\n');
+    const bounds = certificationSection(lines);
+    if (!bounds) return { text, changes: [] };
+
+    const changes = [];
+    const learningAt = findLearningSubhead(lines, bounds.start, bounds.end);
+
+    // Walk backwards so indices stay valid as lines are removed.
+    for (let i = bounds.end - 1; i > bounds.start; i--) {
+        const line = lines[i];
+        if (!/^\s*[-*]\s+\S/.test(line)) continue;
+        // Anything already under Learning Resources is out of scope.
+        if (learningAt !== -1 && i > learningAt) continue;
+
+        const rule = RULES.find(r => r.match.test(line));
+        if (!rule) continue;
+
+        // A bullet may pack several credentials into one comma-joined list.
+        // Acting on the whole line would take valid recommendations with it --
+        // dropping "Azure Stack HCI Operator Associate, MCSE: Core
+        // Infrastructure, ..." deletes two live Microsoft certifications to
+        // remove one dead one. Those bullets are reported for a human instead.
+        const body = line.replace(/^\s*[-*]\s+/, '').replace(/<!--[\s\S]*?-->/g, '').trim();
+        const packed = body.split(/,\s*(?:and\s+)?|\s+and\s+/).map(s => s.trim()).filter(Boolean);
+        if (packed.length > 1) {
+            changes.push({ action: 'manual', line: line.trim(), why: 'bullet names several credentials; splitting it is a content judgement' });
+            continue;
+        }
+
+        lines.splice(i, 1);
+        changes.push({ action: rule.action, line: line.trim(), why: rule.why });
+
+        if (rule.action === 'relocate') {
+            let at = findLearningSubhead(lines, bounds.start, lines.length);
+
+            // No learning subhead in this role: create one rather than dropping
+            // the replacement. Removing a bullet and silently failing to re-add
+            // it is the one outcome this script must never produce.
+            if (at === -1) {
+                let end = lines.length;
+                for (let j = bounds.start + 1; j < lines.length; j++) {
+                    if (/^## /.test(lines[j])) { end = j; break; }
+                }
+                while (end > bounds.start && !lines[end - 1].trim()) end--;
+                lines.splice(end, 0, '', LEARNING_SUBHEAD, '');
+                at = end + 1;
+            }
+
+            let insert = at + 1;
+            while (insert < lines.length && !/^\s*[-*]\s+\S/.test(lines[insert])) insert++;
+            lines.splice(insert, 0, `- ${rule.replacement}`);
+        }
+    }
+
+    return { text: lines.join('\n'), changes };
+}
+
+function run({ write }) {
+    let touched = 0;
+    const tally = { drop: 0, relocate: 0, manual: 0 };
+
+    for (const file of roleFiles()) {
+        const original = fs.readFileSync(file, 'utf8');
+        const hadBom = original.startsWith('﻿');
+        const hadCrlf = original.includes('\r\n');
+        const body = original.replace(/^﻿/, '').replace(/\r\n/g, '\n');
+
+        const { text: updated, changes } = applyRules(body);
+        if (!changes.length) continue;
+        touched++;
+        for (const c of changes) tally[c.action]++;
+
+        const rel = path.relative(path.dirname(ROLES_DIR), file).split(path.sep).join('/');
+        console.log(`\n${rel}`);
+        for (const c of changes) console.log(`  ${c.action.toUpperCase().padEnd(8)} ${c.line.slice(0, 88)}`);
+
+        if (write) {
+            const out = (hadBom ? '﻿' : '') + (hadCrlf ? updated.replace(/\n/g, '\r\n') : updated);
+            fs.writeFileSync(file, out, 'utf8');
+        }
+    }
+
+    console.log(`\n${write ? 'Updated' : 'Would update'} ${touched} role file(s): ${tally.drop} dropped, ${tally.relocate} relocated to learning resources.`);
+}
+
+if (require.main === module) run({ write: process.argv.includes('--write') });
+
+module.exports = { applyRules, RULES };

--- a/test/retire-unresolved-credentials.test.js
+++ b/test/retire-unresolved-credentials.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { applyRules } = require('../scripts/retire-unresolved-credentials.js');
+
+// #229's rule: rewrite to the successor where one exists, drop where none does.
+// ADR-0003 sends a successor that is a course to Learning Resources instead of
+// the registry.
+//
+// The hazard these tests exist for is silent loss. Removing a bullet is easy;
+// failing to re-add its replacement is invisible in a 15-file diff.
+
+function doc(...body) {
+    return ['# Role', '', '## Recommended Certifications & Learning Paths', '', ...body, '', '## Career Development Path', '', '- Next role', ''].join('\n');
+}
+
+test('a credential with no successor is dropped', () => {
+    const { text, changes } = applyRules(doc('**Core Certifications:**', '', '- MCSE: Core Infrastructure', '- CompTIA Server+'));
+    assert.doesNotMatch(text, /MCSE/);
+    assert.match(text, /CompTIA Server\+/);
+    assert.equal(changes.filter(c => c.action === 'drop').length, 1);
+});
+
+test('a credential whose successor is a course moves to learning resources', () => {
+    const { text } = applyRules(doc(
+        '**Core Certifications:**', '', '- Docker Certified Associate',
+        '', '**Learning Resources & Communities:**', '', '- Existing resource',
+    ));
+    const [certs, learning] = text.split(/\*\*Learning Resources/);
+    assert.doesNotMatch(certs, /Docker/, 'the certification bullet is gone');
+    assert.match(learning, /Docker Foundations Professional Certificate/);
+    assert.match(learning, /Existing resource/);
+});
+
+// 101 roles spell the subhead "and Communities" and 124 use "&". Matching one
+// exactly removed the bullet and dropped its replacement in every role using
+// the other -- caught only by counting insertions against deletions.
+test('the learning subhead is found whichever way it is spelled', () => {
+    for (const subhead of ['**Learning Resources & Communities:**', '**Learning Resources and Communities:**']) {
+        const { text } = applyRules(doc('**Core Certifications:**', '', '- Docker Certified Associate', '', subhead, '', '- Existing resource'));
+        assert.match(text, /Docker Foundations Professional Certificate/, `replacement lost with subhead: ${subhead}`);
+    }
+});
+
+test('a role with no learning subhead gains one rather than losing the replacement', () => {
+    const { text } = applyRules(doc('**Core Certifications:**', '', '- Docker Certified Associate'));
+    assert.match(text, /\*\*Learning Resources & Communities:\*\*/);
+    assert.match(text, /Docker Foundations Professional Certificate/);
+    assert.match(text, /## Career Development Path/, 'the following section survives');
+});
+
+// The catalogue packs several credentials into one comma-joined bullet in 172
+// roles. Acting on the whole line would delete live recommendations to remove a
+// dead one.
+test('a bullet naming several credentials is left for a human', () => {
+    const line = '- Microsoft Certified: Azure Stack HCI Operator Associate, MCSE: Core Infrastructure, Microsoft Certified: Azure Administrator Associate';
+    const { text, changes } = applyRules(doc('**Core Certifications:**', '', line));
+    assert.match(text, /Azure Stack HCI Operator Associate/, 'valid credentials must survive');
+    assert.match(text, /MCSE/, 'the line is untouched, not partially edited');
+    assert.deepEqual(changes.map(c => c.action), ['manual']);
+});
+
+test('every removal is accounted for by a change entry', () => {
+    const before = doc('**Core Certifications:**', '', '- MCSE: Core Infrastructure', '- Certified Agile Service Manager', '- CompTIA Server+');
+    const { text, changes } = applyRules(before);
+    const removed = before.split('\n').filter(l => /^\s*-\s+\S/.test(l)).length
+        - text.split('\n').filter(l => /^\s*-\s+\S/.test(l)).length;
+    assert.equal(removed, changes.filter(c => c.action === 'drop').length);
+});
+
+test('a role with nothing to change is returned untouched', () => {
+    const before = doc('**Core Certifications:**', '', '- CompTIA Server+');
+    const { text, changes } = applyRules(before);
+    assert.equal(text, before);
+    assert.deepEqual(changes, []);
+});


### PR DESCRIPTION
Refs #229. Applies the rule you approved: **rewrite to the successor where the issuer names one, drop where none exists.** ADR-0003 supplies the exception — a successor that is a course belongs under Learning Resources, not the registry.

## What changed

| Credential | Action | Evidence |
|---|---|---|
| Certified Agile Service Manager | **dropped** | DevOps Institute's current catalogue lists ten certifications; CASM is not among them, and no successor is named |
| MCSE: Core Infrastructure | **dropped** | Microsoft's retirement page covers only the last year, and no current Microsoft page describes MCSE at all |
| Docker Certified Associate | **relocated** | `docker.com/certification` 404s in both fetch and browser; successor is a LinkedIn Learning course |
| Technology Business Management | **relocated** | The TBM Council's offering is a year-prefixed course, mid-relaunch |

**9 dropped, 6 relocated, across 17 role files.**

## Two guards, both added because the dry run produced something wrong

I ran this as a report before writing anything, which is the only reason both were caught.

**1. Packed bullets.** 172 roles pack several credentials into one comma-joined bullet. The first run proposed:

```
DROP     - Microsoft Certified: Azure Stack HCI Operator Associate, MCSE: Core Infrastructure, Mi…
RELOCATE - SAFe Product Owner/Product Manager (SAFe POPM), ITIL 4 Foundation, Microsoft Azure Adm…
```

That would have deleted two live Microsoft certifications to remove one dead one, and demoted **SAFe and ITIL 4** into learning resources. Those four bullets are now reported for a human instead of edited.

**2. Silent replacement loss.** The catalogue spells the learning subhead two ways — **124 roles use `&`, 101 use `and`** — because #227 only normalised the files it had to restructure. Matching one spelling exactly removed the bullet and dropped its replacement in every role using the other.

Nothing in the output showed this. It surfaced only from counting insertions against deletions: **6 relocations had produced 4 insertions.** The subhead is now matched either way, and *created* when absent rather than losing content.

Insertions and deletions now reconcile exactly:

```
15 deletions  =  9 drops + 6 relocations
 6 insertions =  6 replacements
```

## Still unresolved: ServiceNow

`ServiceNow Certified System Administrator` (9 entries) and `Certified Implementation Specialist` (6 entries) are **untouched**. `servicenow.com` puts a cookie consent dialog in front of its certification pages, and I don't dismiss consent banners without the maintainer's say-so.

You mentioned you can see the certification list after accepting — if you paste the URL, that resolves the last two of the six and closes out this rule entirely.

## Four bullets left for a human

Listed in the script output; they belong with their domain batches (#230–#245), where the surrounding credentials are being audited anyway:

- `server_os_windows/windows_server_senior_engineer.md` — MCSE packed with two live Azure certifications
- `virtualization/hyperv_product_owner.md` — TBM packed with SAFe and ITIL 4
- `virtualization/nutanix_product_owner.md` — TBM packed with SAFe and ITIL 4
- `modern_infrastructure/platform_engineering_engineer.md` — Docker packed with CKA/CKAD

## Verification

- `npm test` — **369/369** pass (was 362); 7 new tests, including one that pins the exact silent-loss failure
- `npm run validate` — 0 errors, 0 duplicate role IDs
- Inventory: legacy entries 2,166 → **2,151**, the expected drop
- Script reports before it writes; `--write` is opt-in
