### PR TITLE
docs: align policies with current scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A portable role definition repository for infrastructure and platform engineering teams. Covers 34 domains grouped into 7 chapters, and 226 roles — spanning the full hierarchy from Engineer to Senior Engineer, Architect, Lead Architect, Principal Architect, Chapter Lead, Technical Area Lead (TAL), Product Area Lead (PAL), and C-Suite.
 
-Repository: [github.com/JeanKadang/DOC-ITRoles](https://github.com/JeanKadang/DOC-ITRoles) (private). Issues and backlog are tracked on the [Issues tab](https://github.com/JeanKadang/DOC-ITRoles/issues).
+Repository: [github.com/JeanKadang/DOC-ITRoles](https://github.com/JeanKadang/DOC-ITRoles) (public). Issues and committed work are tracked on the [Issues tab](https://github.com/JeanKadang/DOC-ITRoles/issues).
 
 ## Prerequisites
 
@@ -203,7 +203,7 @@ Each role file follows the canonical 14-section structure. See [`docs/role_templ
 | Document | Purpose |
 |---|---|
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Evidence standards, substantive review expectations, and contribution workflow |
-| [`docs/CREDENTIAL_REGISTRY.md`](docs/CREDENTIAL_REGISTRY.md) | Audited credential evidence, ownership, lifecycle, contributor policy, and rollout tracking |
+| [`docs/CREDENTIAL_REGISTRY.md`](docs/CREDENTIAL_REGISTRY.md) | Audited credential evidence, ownership, lifecycle, contributor policy, and migration policy |
 | [`docs/adr/README.md`](docs/adr/README.md) | Durable catalogue and architecture decisions, ADR lifecycle, and index |
 | [`docs/CROSS_DOMAIN_INTERACTIONS.md`](docs/CROSS_DOMAIN_INTERACTIONS.md) | Domain ownership boundaries, key relationships, escalation paths |
 | [`docs/SKILLS_PROGRESSION.md`](docs/SKILLS_PROGRESSION.md) | Engineer → Senior → Architect career ladder per domain |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,11 +3,10 @@
 ## Supported Versions
 
 Security fixes are provided for the current released version of this repository.
-
-| Version | Supported |
-| ------- | --------- |
-| 1.6.x   | Yes       |
-| < 1.6   | No        |
+The supported version is therefore the version marked **Latest** on the
+[GitHub Releases page](https://github.com/JeanKadang/DOC-ITRoles/releases/latest);
+older releases are not maintained. This avoids a hard-coded version table
+becoming stale whenever a new release is published.
 
 ## Reporting a Vulnerability
 

--- a/docs/CREDENTIAL_REGISTRY.md
+++ b/docs/CREDENTIAL_REGISTRY.md
@@ -4,7 +4,10 @@
 
 [`data/credentials.json`](../data/credentials.json) is the authoritative, machine-readable catalogue of credential recommendations that have been audited against an issuer-controlled source. A role recommendation with a valid registry marker is registry-backed and verified as of its recorded `verified_on` date.
 
-Legacy credential text without a marker is not yet audited. It may remain visible while the catalogue is migrated, but it must not be represented as registry-backed or current verified evidence. The current Kubernetes pilot is the first audited domain; remaining domains are tracked in [issue #210](https://github.com/JeanKadang/DOC-ITRoles/issues/210).
+Legacy credential text without a marker is not audited. It may remain visible,
+but it must not be represented as registry-backed or current verified evidence.
+Migration happens opportunistically when a role is substantively reviewed or
+changed; no exhaustive catalogue-wide backfill is scheduled.
 
 ## Registry schema
 
@@ -78,7 +81,11 @@ Migrate the remaining catalogue in bounded domain or role-family batches:
 4. Move learning resources out of certification lists and remove or clarify organisation programmes, ambiguous claims, and unverifiable text.
 5. Add completed roles to `audited_roles` only when every certification bullet is deliberately covered, then run validation.
 
-Legacy prose stays unaudited until that work is complete. The durable tracker for unaudited domains and rollout batches is [issue #210](https://github.com/JeanKadang/DOC-ITRoles/issues/210); do not treat its open scope as verified merely because the text remains in a role file.
+Legacy prose stays unaudited until the affected role receives a substantive
+review. A mechanical edit does not trigger migration and does not establish
+credential evidence. The retired exhaustive rollout remains documented in
+[closed issue #210](https://github.com/JeanKadang/DOC-ITRoles/issues/210), but
+it is not active work and its unfinished scope must not be treated as verified.
 
 Run `node scripts/credential-inventory.js` before and after a batch. It reports the legacy entries that remain, grouped by domain and by alias, so rollout progress is measured rather than asserted. It reports only; it never edits a role file.
 


### PR DESCRIPTION
Closes #263.

## What changed

- Correct the README repository visibility and tracker wording.
- Make SECURITY.md support the current Latest release instead of stale 1.6.x rows.
- Replace the exhaustive credential rollout with explicit opportunistic migration for substantively reviewed roles.

## Verification

- npm test: 369/369
- npm run validate: 0 errors
- markdownlint-cli2: 0 issues in the three changed files
- git diff --check: clean