### PR TITLE
release: 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-08-15
+
+The catalogue now separates durable identity from mutable role names and
+records whether content was substantively reviewed or only changed
+mechanically. Credential recommendations gain stronger evidence tooling and a
+smaller, honest maintenance policy: verified records remain authoritative,
+while legacy prose is explicitly unaudited and migrates only when a role is
+substantively reviewed.
+
+### Added
+
+- **Stable role IDs across all 226 roles (#180).** IDs are frozen independently
+  of display titles, validated for format and uniqueness, and protected by
+  migration and rename regression tests. A relationship report distinguishes
+  valid catalogue destinations, external roles, choices, and actual drift.
+- **Review provenance on every role (#179).** `Content Owner` and
+  `Review Status` distinguish substantive review from mechanical edits;
+  templates, parsing, validation, backfill tooling, and ADR-0004 enforce the
+  distinction without storing personal names.
+- **Credential inventory and evidence tooling (#210, #229).** A reproducible
+  inventory classifies and groups legacy recommendations, while the registry
+  now contains 53 issuer-verified records for reuse by audited roles.
+- **Durable catalogue decisions.** ADR-0003 defines what counts as an
+  individually held credential, ADR-0004 records review provenance, and
+  ADR-0005 defines stable role identity.
+
+### Changed
+
+- **Certification sections use one grouped structure (#227).** All role files
+  use consistent Core, Complementary, and Learning Resources groupings without
+  presenting courses or vague topics as verified credentials.
+- **Credential migration is opportunistic rather than exhaustive (#263).**
+  Legacy recommendations remain visibly unaudited until the affected role is
+  substantively reviewed; the retired catalogue-wide rollout is no longer
+  presented as active committed work.
+- **Repository policy reflects the public project (#263).** README visibility
+  and security-version support now follow current repository and release state.
+
+### Fixed
+
+- **Four drifted reporting lines now resolve to catalogue roles (#180).** The
+  relationship report shows zero unexplained reporting-line drift.
+- **Credential aliases no longer merge distinct levels or absorb real
+  certifications into generic families (#248, #252).** Regression tests prefer
+  safe over-splitting to silent false verification.
+- **Unsupported recommendations were retired or relocated (#229).** Nine dead
+  references were removed, six course-shaped successors moved to Learning
+  Resources, and the SABSA credential name was corrected against issuer
+  evidence.
+
 ## [1.17.1] - 2026-08-11
 
 A maintenance release. Both of the repository's open code-scanning alerts are

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roles-master",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roles-master",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@axe-core/playwright": "4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roles-master",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "Portable role definition library and web viewer for infrastructure and platform engineering teams",
   "private": true,
   "license": "UNLICENSED",


### PR DESCRIPTION
Refs #265. The issue remains open until the tag and GitHub release are published.

## Summary

Bumps package.json and package-lock.json to 1.18.0 and adds the dated 1.18.0 changelog section.

Minor rather than patch: since v1.17.1 the catalogue gained stable role IDs, review provenance, 53 issuer-verified credential records, new inventory and relationship tooling, and stronger validation behavior across 251 changed files.

## Release highlights

- Stable identity and rename-safe IDs for all 226 roles.
- Explicit content owner and mechanical-versus-substantive review status.
- Credential inventory, classification fixes, normalized certification sections, and unsupported-reference cleanup.
- Zero unexplained reporting-line drift.
- Opportunistic credential migration policy replacing the retired exhaustive rollout.

## Verification

- npm test: 369/369
- npm run validate: 0 errors
- npm run check-counts: README matches 226 roles / 34 domains / 7 chapters
- npm run verify-vendor: checksums verified
- markdownlint-cli2 CHANGELOG.md: 0 issues
- package.json / package-lock.json / lock root: 1.18.0
- git diff --check: clean