### PR TITLE
fix: harden repository security controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Security reporting now has a concrete private route (#267).** The security
+  policy links directly to GitHub private vulnerability reporting, while
+  repository settings enable private reports, secret scanning, push protection,
+  and enforced pull-request checks on `main`.
+
+### Fixed
+
+- **Nested credential comments no longer evade retirement classification
+  (#267).** Credential maintenance tools share the comment scanner, which now
+  removes a complete nested comment before deciding whether a bullet contains
+  several recommendations.
+
 ## [1.18.0] - 2026-08-15
 
 The catalogue now separates durable identity from mutable role names and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,13 +10,17 @@ becoming stale whenever a new release is published.
 
 ## Reporting a Vulnerability
 
-Report suspected vulnerabilities privately to the primary maintainer:
+Report suspected vulnerabilities through GitHub's
+[private vulnerability reporting form](https://github.com/JeanKadang/DOC-ITRoles/security/advisories/new).
+Reports are visible only to the repository's security managers while they are
+triaged and coordinated.
 
 - Primary maintainer: Jean Kadang (`@JeanKadang`)
 
-Use an established private contact channel for the maintainer. Do not open a
-public GitHub issue or discussion with exploit details, credentials, private
-repository content, or other sensitive information.
+Do not open a public GitHub issue or discussion with exploit details,
+credentials, private repository content, or other sensitive information. If
+the GitHub form is unavailable, contact the primary maintainer through an
+existing private channel without including secrets in the initial message.
 
 If additional maintainers are invited to the project, this section should be
 updated with the current security contact list.

--- a/scripts/credential-inventory.js
+++ b/scripts/credential-inventory.js
@@ -40,36 +40,29 @@ function normalize(text) {
 const COMMENT_OPEN = '<!--';
 const COMMENT_ENDS = ['-->', '--!>'];
 
-function firstEnd(value) {
-    let at = -1;
-    let length = 0;
-    for (const end of COMMENT_ENDS) {
-        const index = value.indexOf(end);
-        if (index !== -1 && (at === -1 || index < at)) { at = index; length = end.length; }
-    }
-    return { at, length };
-}
-
 function stripComments(value) {
-    let rest = String(value);
     let out = '';
+    const input = String(value);
+    let depth = 0;
 
-    for (;;) {
-        const open = rest.indexOf(COMMENT_OPEN);
-        if (open === -1) { out += rest; break; }
+    for (let i = 0; i < input.length;) {
+        if (input.startsWith(COMMENT_OPEN, i)) {
+            depth++;
+            i += COMMENT_OPEN.length;
+            continue;
+        }
 
-        out += rest.slice(0, open);
-        const after = rest.slice(open + COMMENT_OPEN.length);
-        const end = firstEnd(after);
-        // An unterminated comment swallows the remainder, as a parser would.
-        if (end.at === -1) break;
-        rest = after.slice(end.at + end.length);
+        const end = COMMENT_ENDS.find(token => input.startsWith(token, i));
+        if (end) {
+            if (depth > 0) depth--;
+            i += end.length;
+            continue;
+        }
+
+        if (depth === 0) out += input[i];
+        i++;
     }
-
-    // A nested comment leaves its outer terminator orphaned once the inner one
-    // has been consumed; drop any delimiter that outlived its comment.
-    for (const end of COMMENT_ENDS) out = out.split(end).join('');
-    return out.split(COMMENT_OPEN).join('');
+    return out;
 }
 
 // Returns the body of the certification section, or '' when a role has none.

--- a/scripts/retire-unresolved-credentials.js
+++ b/scripts/retire-unresolved-credentials.js
@@ -16,6 +16,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { stripComments } = require('./credential-inventory');
 
 const ROLES_DIR = path.resolve(__dirname, '..', 'Roles');
 // The catalogue spells this subhead two ways -- 124 roles use "&" and 101 use
@@ -100,7 +101,7 @@ function applyRules(text) {
         // dropping "Azure Stack HCI Operator Associate, MCSE: Core
         // Infrastructure, ..." deletes two live Microsoft certifications to
         // remove one dead one. Those bullets are reported for a human instead.
-        const body = line.replace(/^\s*[-*]\s+/, '').replace(/<!--[\s\S]*?-->/g, '').trim();
+        const body = stripComments(line.replace(/^\s*[-*]\s+/, '')).trim();
         const packed = body.split(/,\s*(?:and\s+)?|\s+and\s+/).map(s => s.trim()).filter(Boolean);
         if (packed.length > 1) {
             changes.push({ action: 'manual', line: line.trim(), why: 'bullet names several credentials; splitting it is a content judgement' });

--- a/test/retire-unresolved-credentials.test.js
+++ b/test/retire-unresolved-credentials.test.js
@@ -60,6 +60,13 @@ test('a bullet naming several credentials is left for a human', () => {
     assert.deepEqual(changes.map(c => c.action), ['manual']);
 });
 
+test('a comma inside a nested comment does not make one credential look packed', () => {
+    const line = '- MCSE: Core Infrastructure <!-- outer <!-- inner -->, trailing -->';
+    const { text, changes } = applyRules(doc('**Core Certifications:**', '', line));
+    assert.doesNotMatch(text, /MCSE/, 'comment metadata must not prevent the retirement rule');
+    assert.deepEqual(changes.map(c => c.action), ['drop']);
+});
+
 test('every removal is accounted for by a change entry', () => {
     const before = doc('**Core Certifications:**', '', '- MCSE: Core Infrastructure', '- Certified Agile Service Manager', '- CompTIA Server+');
     const { text, changes } = applyRules(before);


### PR DESCRIPTION
Refs #267

## What changed

- made the existing ruleset apply to `main` and require pull requests plus the five established CI checks;
- enabled GitHub private vulnerability reporting, secret scanning, and push protection;
- linked `SECURITY.md` directly to the private reporting form;
- replaced the incomplete local comment pattern with the shared scanner;
- made that scanner consume complete nested comments before credential classification; and
- added a regression test that failed before the scanner change.

## Verification

- `node --test test/retire-unresolved-credentials.test.js test/credential-inventory.test.js test/normalise-certification-sections.test.js` — 35/35 pass
- `npm test` — 370/370 pass
- `npm run validate` — 0 errors; 226 intentional content warnings
- `npm run check-counts` — 226 roles, 34 domains, 7 chapters; README matches
- `npm run verify-vendor` — checksums verified
- `npx --yes markdownlint-cli2 CHANGELOG.md SECURITY.md` — 0 issues
- `git diff --check` — clean
- `gh ruleset check main` — 4 active rules, including PR and required-status enforcement
- GitHub API — private reporting, secret scanning, and push protection enabled

The open code-scanning alert will be evaluated against this PR's fresh analysis before the issue is eligible to close.
