### PR TITLE
Make browser waiver cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Least-privilege default: this workflow only checks out code, runs tests,
 # and lints -- it never pushes, comments, or writes releases.

--- a/test/ci-browser-waiver.test.js
+++ b/test/ci-browser-waiver.test.js
@@ -8,6 +8,7 @@ const workflow = readFileSync(
   'utf8',
 );
 
+// Git may materialize the workflow with LF or CRLF depending on the checkout.
 function stepNamed(name) {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = workflow.match(new RegExp(

--- a/test/ci-browser-waiver.test.js
+++ b/test/ci-browser-waiver.test.js
@@ -11,7 +11,7 @@ const workflow = readFileSync(
 function stepNamed(name) {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = workflow.match(new RegExp(
-    `      - name: ${escaped}\\n([\\s\\S]*?)(?=\\n      - |\\n\\n|$)`,
+    `      - name: ${escaped}\\r?\\n([\\s\\S]*?)(?=\\r?\\n      - |\\r?\\n\\r?\\n|$)`,
   ));
 
   assert.ok(match, `missing workflow step: ${name}`);
@@ -22,6 +22,13 @@ test('only a labelled pull request can waive browser tests', () => {
   assert.match(
     workflow,
     /BROWSER_WAIVED: \$\{\{ github\.event_name == 'pull_request' && contains\(github\.event\.pull_request\.labels\.\*\.name, 'browser-not-required'\) \}\}/,
+  );
+});
+
+test('label changes trigger a fresh browser policy evaluation', () => {
+  assert.match(
+    workflow,
+    /pull_request:\r?\n    branches: \[main\]\r?\n    types: \[opened, synchronize, reopened, labeled, unlabeled\]/,
   );
 });
 


### PR DESCRIPTION
Closes #277

## Summary

- make the browser-waiver workflow policy test accept LF and CRLF checkouts
- trigger CI when the waiver label is added or removed so policy is reevaluated immediately

## Verification

- `node --test test/ci-browser-waiver.test.js` (4 passed, 0 failed)
- `npm test` (374 passed, 0 failed)
- `npm run validate` (0 errors; 226 existing warning-bearing role files)
- `npm run check-counts`
- `npm run verify-vendor`
- `npx --yes markdownlint-cli2 "**/*.md" "!node_modules/**"` (290 files, 0 issues)
- `git diff --check`

No local browser engines were installed or run.

