### PR TITLE
docs: add issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Something in the viewer, server, or tooling is broken.
+title: "bug: "
+labels:
+  - bug
+assignees:
+  - JeanKadang
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a security vulnerability, use "Report a security vulnerability"
+        from the template picker instead of this form — see SECURITY.md.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's wrong
+      description: What happened, and what did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps, starting from a clean checkout if possible.
+      placeholder: |
+        1. Run `npm start`
+        2. Open the viewer and search for "..."
+        3. Click "..."
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Error output, screenshots, or logs
+      description: Paste any console output, stack trace, or screenshot. Text pastes as-is, images can be dragged in.
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version (`node -v`), OS, and browser + version if this is a viewer bug.
+      placeholder: "Node 22.x, Windows 11, Chrome 128"
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Relevant file(s) or area
+      description: e.g. viewer-logic.js, server.js, a specific script under scripts/, or a role file path.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/JeanKadang/DOC-ITRoles/security/advisories/new
+    about: >-
+      Do not open a public issue for a vulnerability, exposed secret, or
+      unsafe execution path. Use GitHub's private reporting form instead —
+      see SECURITY.md.
+  - name: Search existing issues first
+    url: https://github.com/JeanKadang/DOC-ITRoles/issues
+    about: Check whether this is already tracked before filing a new one.

--- a/.github/ISSUE_TEMPLATE/content_issue.yml
+++ b/.github/ISSUE_TEMPLATE/content_issue.yml
@@ -1,0 +1,55 @@
+name: Catalogue content issue
+description: A role's responsibilities, relationships, credentials, or KPIs are wrong, outdated, or unsupported.
+title: "content: "
+labels:
+  - backfill
+assignees:
+  - JeanKadang
+body:
+  - type: markdown
+    attributes:
+      value: |
+        See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the evidence standard
+        this catalogue holds itself to. A correction without a source is still
+        useful — it can be filed as unresolved rather than fabricated — but a
+        primary source lets it be fixed immediately instead of queued for review.
+
+  - type: input
+    id: role
+    attributes:
+      label: Role file
+      description: Path under Roles/, e.g. Roles/kubernetes/kubernetes_architect.md
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of problem is this?
+      options:
+        - Responsibility or accountability is wrong or duplicates another role
+        - Credential/certification name, status, or issuer link is wrong
+        - KPI target or cadence is wrong, missing, or unsupported
+        - Reporting line, direct report, or career path is wrong
+        - Technology or standard reference is outdated
+        - Other content problem
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong, and what should it say instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Source
+      description: >-
+        Link the issuer-controlled page, standard, or policy that supports the
+        correction, per the evidence table in CONTRIBUTING.md. If you don't
+        have one, say so — an unresolved value is preferable to a guess.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,43 @@
+name: Enhancement or improvement
+description: A gap, missing capability, or quality improvement — not a bug, not a content correction.
+title: ""
+labels:
+  - enhancement
+assignees:
+  - JeanKadang
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Viewer or server code
+        - Catalogue tooling / scripts / validation
+        - CI, workflows, or repo settings
+        - Documentation
+        - Catalogue structure or taxonomy (new domain, template field, etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or gap
+      description: What's missing or awkward today? Cite the file(s) involved if you know them.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Suggested approach
+      description: Optional — a rough direction is fine.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What changed, and why. -->
+
+Closes #
+
+## Evidence
+
+<!--
+For a catalogue content change: the evidence and any organisation-specific
+assumptions (see CONTRIBUTING.md's evidence table).
+
+For a credential change: registry ID, authoritative issuer URL, and
+verification date.
+-->
+
+## Verification
+
+<!-- Delete lines that don't apply. Paste actual output, not just checkmarks. -->
+
+- [ ] `npm test`
+- [ ] `npm run validate`
+- [ ] `npm run check-counts`
+- [ ] `npm run verify-vendor` (if `vendor/` changed)
+- [ ] `npm run test:browser` (viewer changes only — drives Chromium/Firefox/WebKit, ~2.5 min)
+- [ ] Any focused generator/verifier script this change affects
+
+## Checklist
+
+- [ ] Generated output, documentation links, and `CHANGELOG.md` are consistent with this change
+- [ ] An ADR was added or updated, if this creates or reverses a durable taxonomy decision
+- [ ] No security vulnerability or credential is described here — see [SECURITY.md](../SECURITY.md) if it is


### PR DESCRIPTION
## Summary

- Adds bug/content/enhancement GitHub issue forms and a `config.yml` disabling blank issues, routing security reports to private advisory instead
- Adds a PR template pulled from CONTRIBUTING.md's existing checklist (verification commands, changelog/ADR reminders)

Repo went public recently and now takes external security reports (SECURITY.md); this scaffolding was flagged as missing in the 2026-08-19 repo review.

## Verification

- `npx js-yaml <file>` on each of the 4 new `.yml` forms — all parse
- `npx markdownlint-cli2 .github/PULL_REQUEST_TEMPLATE.md` — 0 issues
- No code paths touched; docs/config only