### PR TITLE
ci: pin LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Pin line endings to LF regardless of a contributor's core.autocrlf setting.
+# Without this, a Windows checkout (autocrlf=true) produces CRLF working-tree
+# files that regex-based content parsers in scripts/ and test/ can silently
+# mis-handle — see #277 for a live incident this already caused.
+* text=auto eol=lf
+
+*.md text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Vendored third-party assets must stay byte-identical to upstream for the
+# checksum verification in scripts/verify-vendor.js — never normalize them.
+vendor/* -text


### PR DESCRIPTION
Closes #281

## Summary

- Add `.gitattributes` pinning LF for source, script, test, workflow, and Markdown files, regardless of a contributor's `core.autocrlf` setting
- Exclude `vendor/` (`-text`) so the upstream checksum verification in `scripts/verify-vendor.js` stays byte-exact

## Why

#277 already broke once because a CRLF checkout (this session's own environment: `core.autocrlf=true`, no `.gitattributes`) fed a raw `\n`-anchored regex in `test/ci-browser-waiver.test.js`. That was patched reactively in one test. This closes the root cause instead of the next symptom.

## Verification

- Forced a fresh checkout of a covered file (`test/doc-links.test.js`) after adding the attributes file — confirmed no CR bytes, versus CR bytes present before
- `npm test` — 374 passed
- `npm run validate` — 0 errors
- `npm run verify-vendor` — checksums verified, unaffected by the `-text` exclusion
- Caught and reverted an unintended side effect during verification: `git add --renormalize .` would have baked this session's local CRLF working-tree copies of `vendor/*` into the index, corrupting their upstream-verified checksums. Not committed — `.gitattributes` alone is sufficient for the acceptance criteria (new checkouts get LF); no renormalize needed since the vendor blobs were already correct.