### PR TITLE
docs: catch up CHANGELOG Unreleased with #268, #272, #277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **The catalogue now has explicit reuse terms (#272).** Software, scripts,
+  tests, workflows, and configuration are licensed under MIT; role
+  definitions, catalogue data, and documentation are licensed under
+  CC BY 4.0. Vendored third-party material keeps its existing upstream
+  terms. `LICENSE` and `LICENSES/` set out the split, and `README.md`
+  documents how to reuse and attribute the catalogue.
+- **A maintainer-controlled waiver for browser-irrelevant pull requests
+  (#277).** The `browser-not-required` label lets a PR that touches no
+  viewer code satisfy the required browser-journeys check without running
+  it, while the check itself stays required for everything else. The
+  policy re-evaluates immediately when the label is added or removed, and
+  tolerates a CRLF checkout of the workflow file.
+
 ### Changed
 
+- **Relationship targets now have an accepted representation (ADR-0006,
+  #268).** Decides how role files will distinguish a catalogue destination,
+  an external party, and a genuine one-of choice from mutable-title drift.
+  Establishes the syntax and authoring guidance; migrating existing role
+  files (#269) and enforcing the model in validation (#270) follow
+  separately.
 - **Security reporting now has a concrete private route (#267).** The security
   policy links directly to GitHub private vulnerability reporting, while
   repository settings enable private reports, secret scanning, push protection,


### PR DESCRIPTION
Closes #280

## Summary

Adds the three merged-but-undocumented PRs to `CHANGELOG.md`'s `[Unreleased]` section:

- #272 — dual licensing (MIT for code, CC BY 4.0 for content)
- #277 — the `browser-not-required` PR waiver mechanism
- #268 — ADR-0006, the accepted relationship-target representation decision

## Verification

- `npx markdownlint-cli2 "CHANGELOG.md"` — 0 issues
- `npm test` — 374 passed
- Manual read-through against each PR's actual body/diff to keep the wording accurate (in particular: ADR-0006 is a decision only, not a migration — #269/#270 still do the actual work)