### PR TITLE
ci: run vendor checksum verification on every push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           node-version: '18'
       - run: npm run validate
       - run: npm run check-counts
+      - run: npm run verify-vendor
 
   markdownlint:
     name: Markdown lint


### PR DESCRIPTION
Closes #279

## Summary

Adds `npm run verify-vendor` as a step in the existing "Role content validation" job. Previously the script existed and passed locally but nothing in CI invoked it, so a tampered or corrupted `vendor/*` file (including `purify.min.js`/`marked.min.js`, which feed the viewer's HTML sanitization) could merge with mismatched checksums unnoticed.

No ruleset change needed: it rides the "Role content validation" job name, which is already in the `BranchProtect` ruleset's required status checks.

## Verification

- Ran the job's full command sequence locally: `npm run validate`, `npm run check-counts`, `npm run verify-vendor` — all pass
- Confirmed "Role content validation" is already a required status check (`gh api repos/{owner}/{repo}/rulesets/<id>`), so this PR needs no ruleset edit